### PR TITLE
perf: pay base gas of dynamic opcodes in sections

### DIFF
--- a/crates/revm-jit-builtins/src/macros.rs
+++ b/crates/revm-jit-builtins/src/macros.rs
@@ -1,3 +1,4 @@
+#[allow(unused_macros)]
 macro_rules! tri {
     ($e:expr) => {
         match $e {
@@ -69,16 +70,12 @@ macro_rules! pop {
 
 macro_rules! try_into_usize {
     ($x:expr) => {
-        match $x {
+        match $x.to_u256().as_limbs() {
             x => {
-                let x = x.as_limbs();
-                if x[1] != 0 || x[2] != 0 || x[3] != 0 {
+                if (x[0] > usize::MAX as u64) | (x[1] != 0) | (x[2] != 0) | (x[3] != 0) {
                     return InstructionResult::InvalidOperandOOG;
                 }
-                let Ok(val) = usize::try_from(x[0]) else {
-                    return InstructionResult::InvalidOperandOOG;
-                };
-                val
+                x[0] as usize
             }
         }
     };

--- a/crates/revm-jit/src/bytecode/sections.rs
+++ b/crates/revm-jit/src/bytecode/sections.rs
@@ -66,7 +66,7 @@ impl SectionAnalysis {
         self.diff += stack_diff;
         self.max_growth = self.max_growth.max(self.diff);
 
-        self.gas_cost += data.static_gas().unwrap_or(0) as u64;
+        self.gas_cost += data.base_gas as u64;
 
         // Branching instructions end a section, starting a new one on the next instruction, if any.
         if data.opcode == op::GAS || data.is_branching(bytecode.is_eof()) || data.will_suspend() {

--- a/crates/revm-jit/src/tests/macros.rs
+++ b/crates/revm-jit/src/tests/macros.rs
@@ -85,7 +85,7 @@ macro_rules! tests {
     (@gas $op:expr; $($args:expr),+) => {
         tests!(@gas
             $op,
-            DEF_OPINFOS[$op as usize].static_gas().expect(stringify!($op)) as u64;
+            DEF_OPINFOS[$op as usize].base_gas() as u64;
             $($args),+
         )
     };


### PR DESCRIPTION
For example, MLOAD has a base cost of 3 and a dynamic cost of resizing the memory; we can pay the base cost of 3 ahead of time in the sections, while paying only the dynamic cost in builtins.

Also includes https://github.com/bluealloy/revm/pull/1374