### PR TITLE
feat: update to LLVM 18

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  LLVM_VERSION: "17" # Must be just the major version
+  LLVM_VERSION: "18" # Must be just the major version
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install LLVM
         run: sudo .github/scripts/install_llvm_ubuntu.sh ${{ env.LLVM_VERSION }}
+      - name: llvm-config
+        run: llvm-config --version --bindir --libdir
       - name: Install Valgrind
         run: sudo apt update && sudo apt install valgrind
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  LLVM_VERSION: "17" # Must be just the major version
+  LLVM_VERSION: "18" # Must be just the major version
   ALL_BACKENDS: "llvm,cranelift"
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,8 +1286,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b597a7b2cdf279aeef6d7149071e35e4bc87c2cf05a5b7f2d731300bffe587ea"
+source = "git+https://github.com/TheDan64/inkwell#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1300,8 +1299,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa4d8d74483041a882adaa9a29f633253a66dde85055f0495c121620ac484b2"
+source = "git+https://github.com/TheDan64/inkwell#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1456,9 +1454,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "llvm-sys"
-version = "170.1.0"
+version = "180.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8b6d5671d471fec5010c24daa7c031e172bfaab1c48497ef6185c75eed88a5"
+checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
 dependencies = [
  "anyhow",
  "cc",

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ This repository hosts two backend implementations:
 ### LLVM backend
 
 - Linux or macOS, Windows is not supported
-- LLVM 17
+- LLVM 18
   - On Debian-based Linux distros: see [apt.llvm.org](https://apt.llvm.org/)
   - On Arch-based Linux distros: `pacman -S llvm`
-  - On macOS: `brew install llvm@17`
+  - On macOS: `brew install llvm@18`
   - The following environment variables may be required:
     ```bash
     prefix=$(llvm-config --prefix)
     # or
-    #prefix=$(llvm-config-17 --prefix)
+    #prefix=$(llvm-config-18 --prefix)
     # on macOS:
-    #prefix=$(brew --prefix llvm@17)
-    export LLVM_SYS_170_PREFIX=$prefix
+    #prefix=$(brew --prefix llvm@18)
+    export LLVM_SYS_180_PREFIX=$prefix
     ```
 
 ## Usage

--- a/crates/revmc-llvm/Cargo.toml
+++ b/crates/revmc-llvm/Cargo.toml
@@ -19,10 +19,12 @@ workspace = true
 [dependencies]
 revmc-backend.workspace = true
 
-inkwell = { version = "0.4", features = ["llvm17-0"] }
+inkwell = { version = "0.4", git = "https://github.com/TheDan64/inkwell", features = [
+    "llvm18-0",
+] }
 rustc-hash.workspace = true
 tracing.workspace = true
 
 [features]
-prefer-static = ["inkwell/llvm17-0-prefer-static"]
-prefer-dynamic = ["inkwell/llvm17-0-prefer-dynamic"]
+prefer-static = ["inkwell/llvm18-0-prefer-static"]
+prefer-dynamic = ["inkwell/llvm18-0-prefer-dynamic"]

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -146,7 +146,7 @@ impl<'ctx> EvmLlvmBackend<'ctx> {
         let ty_i64 = cx.i64_type();
         let ty_i256 = cx.custom_width_int_type(256);
         let ty_isize = cx.ptr_sized_int_type(&machine.get_target_data(), None);
-        let ty_ptr = ty_i8.ptr_type(AddressSpace::default());
+        let ty_ptr = cx.ptr_type(AddressSpace::default());
         Ok(Self {
             cx,
             _dh: dh::DiagnosticHandlerGuard::new(cx),


### PR DESCRIPTION
Benchmark results: <https://github.com/paradigmxyz/revm-jit/actions/runs/9331684622/job/25686643194?pr=28>
~~Blocked on inkwell release.~~ Pushing anyway since most package managers have updated to llvm 18.