### PR TITLE
chore: mark JIT as unsafe

### DIFF
--- a/crates/revmc-cli/benches/bench.rs
+++ b/crates/revmc-cli/benches/bench.rs
@@ -83,7 +83,7 @@ fn run_bench(c: &mut Criterion, bench: &Bench) {
         (name, compiler.translate(None, bytecode, SPEC_ID).expect(name))
     });
     for &(name, fn_id) in &jit_ids {
-        let jit = compiler.jit_function(fn_id).expect(name);
+        let jit = unsafe { compiler.jit_function(fn_id) }.expect(name);
         g.bench_function(&format!("revmc/{name}"), |b| b.iter(|| call_jit(jit)));
     }
 

--- a/crates/revmc-cli/src/main.rs
+++ b/crates/revmc-cli/src/main.rs
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
             return Err(eyre!("--load with no argument requires --aot"));
         }
     } else {
-        compiler.jit_function(f_id)?
+        unsafe { compiler.jit_function(f_id)? }
     };
 
     let mut run = |f: revmc::EvmCompilerFn| {

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -234,18 +234,28 @@ impl<B: Backend> EvmCompiler<B> {
     /// (JIT) Compiles the given EVM bytecode into a JIT function.
     ///
     /// See [`translate`](Self::translate) for more information.
-    pub fn jit(
+    ///
+    /// # Safety
+    ///
+    /// The returned function pointer is owned by the module, and must not be called after the
+    /// module is cleared or the function is freed.
+    pub unsafe fn jit(
         &mut self,
         name: Option<&str>,
         bytecode: &[u8],
         spec_id: SpecId,
     ) -> Result<EvmCompilerFn> {
         let id = self.translate(name, bytecode, spec_id)?;
-        self.jit_function(id)
+        unsafe { self.jit_function(id) }
     }
 
     /// (JIT) Finalizes the module and JITs the given function.
-    pub fn jit_function(&mut self, id: B::FuncId) -> Result<EvmCompilerFn> {
+    ///
+    /// # Safety
+    ///
+    /// The returned function pointer is owned by the module, and must not be called after the
+    /// module is cleared or the function is freed.
+    pub unsafe fn jit_function(&mut self, id: B::FuncId) -> Result<EvmCompilerFn> {
         ensure!(self.is_jit(), "cannot JIT functions during AOT compilation");
         self.finalize()?;
         let addr = self.backend.jit_function(id)?;

--- a/crates/revmc/src/tests/fibonacci.rs
+++ b/crates/revmc/src/tests/fibonacci.rs
@@ -19,7 +19,7 @@ fn run_fibonacci_test<B: Backend>(compiler: &mut EvmCompiler<B>, input: u16, dyn
 
     unsafe { compiler.clear() }.unwrap();
     compiler.inspect_stack_length(true);
-    let f = compiler.jit(None, &code, DEF_SPEC).unwrap();
+    let f = unsafe { compiler.jit(None, &code, DEF_SPEC) }.unwrap();
 
     with_evm_context(&code, |ecx, stack, stack_len| {
         if dynamic {

--- a/crates/revmc/src/tests/meta.rs
+++ b/crates/revmc/src/tests/meta.rs
@@ -13,8 +13,8 @@ fn translate_then_compile<B: Backend>(compiler: &mut EvmCompiler<B>) {
     let gas_id = compiler.translate(name, bytecode, spec_id).unwrap();
     compiler.gas_metering(true);
     let no_gas_id = compiler.translate(name, bytecode, spec_id).unwrap();
-    let gas_fn = compiler.jit_function(gas_id).unwrap();
-    let no_gas_fn = compiler.jit_function(no_gas_id).unwrap();
+    let gas_fn = unsafe { compiler.jit_function(gas_id) }.unwrap();
+    let no_gas_fn = unsafe { compiler.jit_function(no_gas_id) }.unwrap();
     with_evm_context(bytecode, |ecx, stack, stack_len| {
         let r = unsafe { gas_fn.call(Some(stack), Some(stack_len), ecx) };
         assert_eq!(r, InstructionResult::Stop);

--- a/crates/revmc/src/tests/resume.rs
+++ b/crates/revmc/src/tests/resume.rs
@@ -23,7 +23,7 @@ fn run_resume_tests<B: Backend>(compiler: &mut EvmCompiler<B>) {
         // 3
     ][..];
 
-    let f = compiler.jit(None, code, DEF_SPEC).unwrap();
+    let f = unsafe { compiler.jit(None, code, DEF_SPEC) }.unwrap();
 
     with_evm_context(code, |ecx, stack, stack_len| {
         assert_eq!(ecx.resume_at, 0);

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -304,7 +304,7 @@ pub fn set_test_dump<B: Backend>(compiler: &mut EvmCompiler<B>, module_path: &st
 pub fn run_test_case<B: Backend>(test_case: &TestCase<'_>, compiler: &mut EvmCompiler<B>) {
     let TestCase { bytecode, spec_id, .. } = *test_case;
     compiler.inspect_stack_length(true);
-    let f = compiler.jit(None, bytecode, spec_id).unwrap();
+    let f = unsafe { compiler.jit(None, bytecode, spec_id) }.unwrap();
     run_compiled_test_case(test_case, f);
 }
 

--- a/examples/compiler/src/main.rs
+++ b/examples/compiler/src/main.rs
@@ -35,8 +35,7 @@ fn main() -> eyre::Result<()> {
     let context = revmc::llvm::inkwell::context::Context::create();
     let backend = EvmLlvmBackend::new(&context, false, OptimizationLevel::Aggressive)?;
     let mut compiler = EvmCompiler::new(backend);
-    let f = compiler
-        .jit(Some("test"), &bytecode, SpecId::CANCUN)
+    let f = unsafe { compiler.jit(Some("test"), &bytecode, SpecId::CANCUN) }
         .wrap_err("Failed to JIT-compile code")?;
 
     // Set up runtime context and run the function.


### PR DESCRIPTION
Calling a JIT'd function after clearing the module or dropping the compiler is undefined behavior.