### PR TITLE
fix(inkwell): use from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,8 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.4.0"
-source = "git+https://github.com/TheDan64/inkwell#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fb405537710d51f6bdbc8471365ddd4cd6d3a3c3ad6e0c8291691031ba94b2"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1323,8 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "inkwell_internals"
-version = "0.9.0"
-source = "git+https://github.com/TheDan64/inkwell#5c9f7fcbb0a667f7391b94beb65f1a670ad13221"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/revmc-llvm/Cargo.toml
+++ b/crates/revmc-llvm/Cargo.toml
@@ -19,9 +19,7 @@ workspace = true
 [dependencies]
 revmc-backend.workspace = true
 
-inkwell = { version = "0.4", git = "https://github.com/TheDan64/inkwell", features = [
-    "llvm18-0",
-] }
+inkwell = { version = "0.5", features = [ "llvm18-0" ] }
 rustc-hash.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
For some reason cargo fails to find inkwell 4 as a dep with this particular feature. I saw they've done some new release but I am not sure why this feature is not available in v4 anymore. Anyways, I suggest using it from crates.io and using v5.

All tests passed.