### PR TITLE
chore(deps): bump alloy + revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,30 +45,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "alloy-eips"
-version = "0.2.1"
+name = "alloy-eip2930"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9431c99a3b3fe606ede4b3d4043bdfbcb780c45b8d8d226c3804e2b75cfbe68"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "c-kzg",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "k256",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499ee14d296a133d142efd215eb36bf96124829fe91cf8f5d4e5ccdd381eae00"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "c-kzg",
+ "derive_more 1.0.0",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+checksum = "a767e59c86900dd7c3ce3ecef04f3ace5ac9631ee150beb8b7d22f7fa3bbb2d7"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 0.99.18",
  "hex-literal",
  "itoa",
  "k256",
@@ -915,6 +938,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.72",
 ]
 
@@ -2047,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "13.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2f635bbbf4002b1b5c0219f841ec1a317723883ed7662c0d138617539a6087"
+checksum = "1f719e28cc6fdd086f8bc481429e587740d20ad89729cec3f5f5dd7b655474df"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -2060,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "9.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ad04c7d87dc3421a5ccca76e56dbd0b29a358c03bb41fe9e80976e9d3f397d"
+checksum = "959ecbc36802de6126852479844737f20194cf8e6718e0c30697d306a2cca916"
 dependencies = [
  "paste",
  "phf",
@@ -2072,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526a4ba5ec400e7bbe71affbc10fe2e67c1cd1fb782bab988873d09a102e271"
+checksum = "6e25f604cb9db593ca3013be8c00f310d6790ccb1b7d8fbbdd4660ec8888043a"
 dependencies = [
  "aurora-engine-modexp",
  "cfg-if",
@@ -2088,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "8.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4093d98a26601f0a793871c5bc7928410592f76b1f03fc89fde77180c554643c"
+checksum = "0ccb981ede47ccf87c68cebf1ba30cdbb7ec935233ea305f3dfff4c1e10ae541"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ revmc-context = { version = "0.1.0", path = "crates/revmc-context", default-feat
 revmc-cranelift = { version = "0.1.0", path = "crates/revmc-cranelift", default-features = false }
 revmc-llvm = { version = "0.1.0", path = "crates/revmc-llvm", default-features = false }
 
-alloy-primitives = { version = "0.7.0", default-features = false }
-revm = { version = "13.0.0", default-features = false }
-revm-primitives = { version = "8.0.0", default-features = false }
-revm-interpreter = { version = "9.0.0", default-features = false }
-ruint = { version = "1.12.1", default-features = false }
+alloy-primitives = { version = "0.8", default-features = false }
+revm = { version = "14.0", default-features = false }
+revm-primitives = { version = "9.0", default-features = false }
+revm-interpreter = { version = "10.0", default-features = false }
+ruint = { version = "1.12", default-features = false }
 
 color-eyre = "0.6"
 eyre = "0.6"

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -208,11 +208,7 @@ pub unsafe extern "C" fn __revmc_builtin_extcodesize(
     let (code, state) = try_host!(ecx.host.code(address.to_address())).into_components();
     *address = code.len().into();
     let gas = if spec_id.is_enabled_in(SpecId::BERLIN) {
-        if state.is_cold {
-            gas::COLD_ACCOUNT_ACCESS_COST
-        } else {
-            gas::WARM_STORAGE_READ_COST
-        }
+        gas::warm_cold_cost_with_delegation(state)
     } else if spec_id.is_enabled_in(SpecId::TANGERINE) {
         700
     } else {
@@ -272,11 +268,7 @@ pub unsafe extern "C" fn __revmc_builtin_extcodehash(
     let (hash, state) = try_host!(ecx.host.code_hash(address.to_address())).into_components();
     *address = EvmWord::from_be_bytes(hash.0);
     let gas = if spec_id.is_enabled_in(SpecId::BERLIN) {
-        if state.is_cold {
-            gas::COLD_ACCOUNT_ACCESS_COST
-        } else {
-            gas::WARM_STORAGE_READ_COST
-        }
+        gas::warm_cold_cost_with_delegation(state)
     } else if spec_id.is_enabled_in(SpecId::ISTANBUL) {
         700
     } else {

--- a/crates/revmc-cli/benches/iai.rs
+++ b/crates/revmc-cli/benches/iai.rs
@@ -62,8 +62,8 @@ fn setup_group(group: &mut BinaryBenchmarkGroup, is_ct: bool) {
         ("bswap64", true),
         ("usdc_proxy", false),
         ("weth", false),
-        ("snailtracer", false),
-        ("snailtracer-eof", false),
+        // ("snailtracer", false),
+        // ("snailtracer-eof", false),
     ];
     for (bench, small) in benches {
         if !is_ct && !small {

--- a/crates/revmc-cli/benches/iai.rs
+++ b/crates/revmc-cli/benches/iai.rs
@@ -55,16 +55,15 @@ fn setup_group(group: &mut BinaryBenchmarkGroup, is_ct: bool) {
         run
     };
     let benches = [
-        // ("fibonacci", true),
-        // ("counter", true),
-        // ("hash_10k", true),
-        // ("bswap64", true),
-        // ("usdc_proxy", false),
-        // ("weth", false),
+        ("fibonacci", true),
+        ("counter", true),
         ("hash_10k", true),
         ("hash_10k-eof", true),
-        ("snailtracer", true),
-        ("snailtracer-eof", true),
+        ("bswap64", true),
+        ("usdc_proxy", false),
+        ("weth", false),
+        ("snailtracer", false),
+        ("snailtracer-eof", false),
     ];
     for (bench, small) in benches {
         if !is_ct && !small {

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -817,25 +817,36 @@ mod tests {
             fn env_mut(&mut self) -> &mut Env {
                 self.0
             }
-            fn load_account(
+            fn load_account_delegated(
                 &mut self,
                 address: Address,
-            ) -> Option<revm_interpreter::LoadAccountResult> {
+            ) -> Option<revm_interpreter::AccountLoad> {
                 unimplemented!()
             }
             fn block_hash(&mut self, number: u64) -> Option<revm_primitives::B256> {
                 unimplemented!()
             }
-            fn balance(&mut self, address: Address) -> Option<(U256, bool)> {
+            fn balance(&mut self, address: Address) -> Option<revm_interpreter::StateLoad<U256>> {
                 unimplemented!()
             }
-            fn code(&mut self, address: Address) -> Option<(revm_primitives::Bytes, bool)> {
+            fn code(
+                &mut self,
+                address: Address,
+            ) -> Option<revm_interpreter::Eip7702CodeLoad<Bytes>> {
                 unimplemented!()
             }
-            fn code_hash(&mut self, address: Address) -> Option<(revm_primitives::B256, bool)> {
+            fn code_hash(
+                &mut self,
+                address: Address,
+            ) -> Option<revm_interpreter::Eip7702CodeLoad<revm_primitives::FixedBytes<32>>>
+            {
                 unimplemented!()
             }
-            fn sload(&mut self, address: Address, index: U256) -> Option<(U256, bool)> {
+            fn sload(
+                &mut self,
+                address: Address,
+                index: U256,
+            ) -> Option<revm_interpreter::StateLoad<U256>> {
                 unimplemented!()
             }
             fn sstore(
@@ -843,7 +854,7 @@ mod tests {
                 address: Address,
                 index: U256,
                 value: U256,
-            ) -> Option<revm_interpreter::SStoreResult> {
+            ) -> Option<revm_interpreter::StateLoad<revm_interpreter::SStoreResult>> {
                 unimplemented!()
             }
             fn tload(&mut self, address: Address, index: U256) -> U256 {
@@ -859,7 +870,8 @@ mod tests {
                 &mut self,
                 address: Address,
                 target: Address,
-            ) -> Option<revm_interpreter::SelfDestructResult> {
+            ) -> Option<revm_interpreter::StateLoad<revm_interpreter::SelfDestructResult>>
+            {
                 unimplemented!()
             }
         }

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -264,14 +264,12 @@ impl Host for TestHost {
 
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>> {
         let code = self.code_map.get(&address).map(|b| b.original_bytes()).unwrap_or_default();
-        let state_load = StateLoad::new(code, false);
-        Some(Eip7702CodeLoad::new(state_load, false))
+        Some(Eip7702CodeLoad::new_not_delegated(code, false))
     }
 
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>> {
         let code_hash = self.code_map.get(&address).map(|b| b.hash_slow()).unwrap_or(KECCAK_EMPTY);
-        let state_load = StateLoad::new(code_hash, false);
-        Some(Eip7702CodeLoad::new(state_load, false))
+        Some(Eip7702CodeLoad::new_not_delegated(code_hash, false))
     }
 
     fn sload(&mut self, address: Address, index: U256) -> Option<StateLoad<U256>> {

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -1,6 +1,6 @@
 use super::*;
-use interpreter::LoadAccountResult;
-use revm_interpreter::{opcode as op, Contract, DummyHost, Host};
+use interpreter::{AccountLoad, Eip7702CodeLoad, SStoreResult, StateLoad};
+use revm_interpreter::{opcode as op, Contract, DummyHost, Host, SelfDestructResult};
 use revm_primitives::{
     spec_to_generic, BlobExcessGasAndPrice, BlockEnv, CfgEnv, Env, HashMap, TxEnv, EOF_MAGIC_BYTES,
 };
@@ -250,30 +250,31 @@ impl Host for TestHost {
         self.host.env_mut()
     }
 
-    fn load_account(&mut self, address: Address) -> Option<LoadAccountResult> {
-        self.host.load_account(address)
+    fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad> {
+        self.host.load_account_delegated(address)
     }
 
     fn block_hash(&mut self, number: u64) -> Option<B256> {
         Some(U256::from(number).into())
     }
 
-    fn balance(&mut self, address: Address) -> Option<(U256, bool)> {
-        Some((U256::from(*address.last().unwrap()), false))
+    fn balance(&mut self, address: Address) -> Option<StateLoad<U256>> {
+        Some(StateLoad::new(U256::from(*address.last().unwrap()), false))
     }
 
-    fn code(&mut self, address: Address) -> Option<(Bytes, bool)> {
-        self.code_map
-            .get(&address)
-            .map(|b| (b.original_bytes(), false))
-            .or_else(|| Some((Bytes::new(), false)))
+    fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>> {
+        let code = self.code_map.get(&address).map(|b| b.original_bytes()).unwrap_or(Bytes::new());
+        let state_load = StateLoad::new(code, false);
+        Some(Eip7702CodeLoad::new(state_load, false))
     }
 
-    fn code_hash(&mut self, address: Address) -> Option<(B256, bool)> {
-        self.code_map.get(&address).map(|b| (b.hash_slow(), false)).or(Some((KECCAK_EMPTY, false)))
+    fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>> {
+        let code_hash = self.code_map.get(&address).map(|b| b.hash_slow()).unwrap_or(KECCAK_EMPTY);
+        let state_load = StateLoad::new(code_hash, false);
+        Some(Eip7702CodeLoad::new(state_load, false))
     }
 
-    fn sload(&mut self, address: Address, index: U256) -> Option<(U256, bool)> {
+    fn sload(&mut self, address: Address, index: U256) -> Option<StateLoad<U256>> {
         self.host.sload(address, index)
     }
 
@@ -282,7 +283,7 @@ impl Host for TestHost {
         address: Address,
         index: U256,
         value: U256,
-    ) -> Option<interpreter::SStoreResult> {
+    ) -> Option<StateLoad<SStoreResult>> {
         self.host.sstore(address, index, value)
     }
 
@@ -302,14 +303,17 @@ impl Host for TestHost {
         &mut self,
         address: Address,
         target: Address,
-    ) -> Option<interpreter::SelfDestructResult> {
+    ) -> Option<StateLoad<SelfDestructResult>> {
         self.selfdestructs.push((address, target));
-        Some(interpreter::SelfDestructResult {
-            had_value: false,
-            target_exists: true,
-            is_cold: false,
-            previously_destroyed: false,
-        })
+
+        Some(StateLoad::new(
+            SelfDestructResult {
+                had_value: false,
+                target_exists: true,
+                previously_destroyed: false,
+            },
+            false,
+        ))
     }
 }
 

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -263,7 +263,7 @@ impl Host for TestHost {
     }
 
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>> {
-        let code = self.code_map.get(&address).map(|b| b.original_bytes()).unwrap_or(Bytes::new());
+        let code = self.code_map.get(&address).map(|b| b.original_bytes()).unwrap_or_default();
         let state_load = StateLoad::new(code, false);
         Some(Eip7702CodeLoad::new(state_load, false))
     }


### PR DESCRIPTION
Updated revm and alloy as most of the rust ethereum crates already migrated to alloy 0.3.

Removed minor versions of deps in Cargo.toml.

Please let me know if I should change anything.

All tests passed.