### PR TITLE
perf: infer when to use local stack

### DIFF
--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -545,11 +545,17 @@ impl<'a> Bytecode<'a> {
         );
     }
 
+    /// Returns the EOF container, if any.
+    #[inline]
+    pub fn eof(&self) -> Option<&Eof> {
+        self.eof.as_deref()
+    }
+
     /// Returns the `Eof` container, panicking if it is not set.
     #[track_caller]
     #[inline]
     pub(crate) fn expect_eof(&self) -> &Eof {
-        self.eof.as_deref().expect("EOF container not set")
+        self.eof().expect("EOF container not set")
     }
 
     /// Returns the name for a basic block.

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -4,8 +4,7 @@ use crate::{Backend, Builder, Bytecode, EvmCompilerFn, EvmContext, EvmStack, Res
 use revm_interpreter::{Contract, Gas};
 use revm_primitives::{Bytes, Env, Eof, SpecId, EOF_MAGIC_BYTES};
 use revmc_backend::{
-    eyre::{ensure, eyre},
-    Attribute, FunctionAttributeLocation, Linkage, OptimizationLevel,
+    eyre::ensure, Attribute, FunctionAttributeLocation, Linkage, OptimizationLevel,
 };
 use revmc_builtins::Builtins;
 use revmc_context::RawEvmCompilerFn;
@@ -165,7 +164,7 @@ impl<B: Backend> EvmCompiler<B> {
         self.config.validate_eof = yes;
     }
 
-    /// Sets whether to allocate the stack locally.
+    /// Forces the stack to be allocated inside of the function, instead of passed as an argument.
     ///
     /// If this is set to `true`, the stack pointer argument will be ignored and the stack will be
     /// allocated in the function.
@@ -359,12 +358,7 @@ impl<B: Backend> EvmCompiler<B> {
         if !self.config.validate_eof {
             return Ok(());
         }
-        revm_interpreter::analysis::validate_eof_inner(eof, None).map_err(|e| match e {
-            revm_interpreter::analysis::EofError::Decode(e) => e.into(),
-            revm_interpreter::analysis::EofError::Validation(e) => {
-                eyre!("validation error: {e:?}")
-            }
-        })
+        revm_interpreter::analysis::validate_eof_inner(eof, None).map_err(Into::into)
     }
 
     #[instrument(name = "translate", level = "debug", skip_all)]

--- a/tests/codegen/address_mask.evm
+++ b/tests/codegen/address_mask.evm
@@ -2,8 +2,12 @@ ADDRESS
 PUSH20 0xffffffffffffffffffffffffffffffffffffffff
 AND
 
+PUSH0 MSTORE
+PUSH1 0x20 PUSH0 RETURN
+
 ; CHECK: load i160
-; CHECK: [[ADDR:%.*]] = zext i160 {{.*}} to i256
+; CHECK: zext i160 {{.*}} to i256
 ; CHECK-NOT: and
-; CHECK: store i256 [[ADDR]]
+; CHECK: call {{.*}}mstore
+; CHECK: call {{.*}}return
 ; CHECK: ret i8

--- a/tests/codegen/non_zero.evm
+++ b/tests/codegen/non_zero.evm
@@ -2,8 +2,12 @@ CALLVALUE
 ISZERO
 ISZERO
 
+PUSH0 MSTORE
+PUSH1 0x20 PUSH0 RETURN
+
 ; CHECK: [[VALUE:%.*value.*]] = load i256
 ; CHECK-NEXT: [[NON_ZERO:%.*]] = icmp ne i256 [[VALUE]], 0
 ; CHECK-NEXT: [[EXTENDED:%.*]] = zext i1 [[NON_ZERO]] to i256
-; CHECK-NEXT: store i256 [[EXTENDED]]
-; CHECK-NEXT: br label %return
+; CHECK: call {{.*}}mstore
+; CHECK: call {{.*}}return
+; CHECK: ret i8


### PR DESCRIPTION
Allocate stack locally when possible