### PR TITLE
feat(dse): make POP DSE-able

### DIFF
--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -472,7 +472,7 @@ bb2:           ; stack_in=0 max_growth=7
   PUSH1 0x42   ; ic=14 pc=24 noop
   PUSH2 0xffff ; ic=15 pc=26 noop
   CALL         ; ic=16 pc=29 suspends
-  POP          ; ic=17 pc=30 gas=2 stack_in=1 max_growth=0
+  POP          ; ic=17 pc=30 gas=2 stack_in=1 max_growth=0 noop
   STOP         ; ic=18 pc=31
 
 "#]]

--- a/crates/revmc/src/bytecode/passes/dead_store_elim.rs
+++ b/crates/revmc/src/bytecode/passes/dead_store_elim.rs
@@ -183,6 +183,8 @@ fn can_skip_when_dead(opcode: u8) -> bool {
             | op::SWAP1..=op::SWAP16
             | op::SWAPN
             | op::EXCHANGE
+            // POP.
+            | op::POP
             // Constants / push.
             | op::PUSH0..=op::PUSH32
             | op::PC
@@ -353,6 +355,8 @@ fn all_outputs_dead(
             let tos = h_before - 1;
             !live[tos - n as usize] && !live[tos - m as usize]
         }
+        // POP: dead when its input is already dead.
+        (op::POP, _) => !live[h_before - 1],
         // Infeasible immediates — conservatively not dead.
         (op::DUPN | op::SWAPN | op::EXCHANGE, _) => false,
         // Generic: all output positions must be dead.
@@ -691,7 +695,7 @@ mod tests {
         ",
         );
         //       PUSH0, CDL_A, PUSH_20, CDL_B, PUSH_40, CDL_C, SWAP2, POP, SWAP1, POP
-        for (i, alive) in [false, false, false, true, false, false, false, true, true, true]
+        for (i, alive) in [false, false, false, true, false, false, false, false, true, false]
             .into_iter()
             .enumerate()
         {

--- a/crates/revmc/src/bytecode/passes/dead_store_elim.rs
+++ b/crates/revmc/src/bytecode/passes/dead_store_elim.rs
@@ -425,6 +425,10 @@ mod tests {
             bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
             "PUSH should be skipped (dead store)"
         );
+        assert!(
+            bytecode.inst(Inst::from_usize(1)).flags.contains(InstFlags::NOOP),
+            "POP should be skipped (input dead)"
+        );
     }
 
     #[test]
@@ -438,7 +442,7 @@ mod tests {
             STOP
         ",
         );
-        for (i, name) in [(0, "PUSH 3"), (1, "PUSH 4"), (2, "ADD")] {
+        for (i, name) in [(0, "PUSH 3"), (1, "PUSH 4"), (2, "ADD"), (3, "POP")] {
             assert!(
                 bytecode.inst(Inst::from_usize(i)).flags.contains(InstFlags::NOOP),
                 "{name} should be skipped"
@@ -1034,6 +1038,133 @@ mod tests {
         assert!(
             bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
             "PUSH 0 should be skipped (const input)"
+        );
+    }
+
+    // --- POP DSE tests ---
+
+    #[test]
+    fn pop_dead_at_diverging_exit() {
+        // POP's input is dead because STOP diverges.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0
+            PUSH1 0x69      ; inst 1
+            POP             ; inst 2: input dead (exit diverges)
+            POP             ; inst 3: input dead
+            STOP            ; inst 4
+        ",
+        );
+        for (i, name) in [(0, "PUSH 0x42"), (1, "PUSH 0x69"), (2, "POP"), (3, "POP")] {
+            assert!(
+                bytecode.inst(Inst::from_usize(i)).flags.contains(InstFlags::NOOP),
+                "{name} at {i} should be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn pop_live_input_not_eliminated() {
+        // POP's input is live because it was produced by CALLDATALOAD and the
+        // position feeds a later MSTORE (via the stack layout). POP cannot be
+        // eliminated here because the value it discards is needed.
+        let bytecode = analyze_asm(
+            "
+            PUSH0           ; inst 0
+            CALLDATALOAD    ; inst 1: dynamic value
+            DUP1            ; inst 2: copy
+            POP             ; inst 3: pops the copy (dead)
+            PUSH0           ; inst 4
+            MSTORE          ; inst 5: stores the original
+            STOP            ; inst 6
+        ",
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(2)).flags.contains(InstFlags::NOOP),
+            "DUP1 should be skipped (copy is dead)"
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(3)).flags.contains(InstFlags::NOOP),
+            "POP should be skipped (input is dead copy)"
+        );
+        assert!(
+            !bytecode.inst(Inst::from_usize(1)).flags.contains(InstFlags::NOOP),
+            "CALLDATALOAD should NOT be skipped (feeds MSTORE)"
+        );
+    }
+
+    #[test]
+    fn pop_after_suspend() {
+        // Regression test for stale stack_len bug: CALL suspends and creates a
+        // section boundary. POP immediately after CALL is NOOP'd because its
+        // input (the CALL success flag) feeds only a dead POP+STOP sequence.
+        // The codegen must still update the stack_len alloca for the section head
+        // reload to see the correct height.
+        let bytecode = analyze_code_spec(
+            vec![
+                op::PUSH1,
+                0x00, // ret length
+                op::PUSH1,
+                0x00, // ret offset
+                op::PUSH1,
+                0x00, // args length
+                op::PUSH1,
+                0x00, // args offset
+                op::PUSH1,
+                0x00, // value
+                op::PUSH1,
+                0x69,     // address
+                op::GAS,  // gas
+                op::CALL, // inst 7: suspends, pushes success flag
+                op::POP,  // inst 8: pops success flag
+                op::STOP, // inst 9
+            ],
+            SpecId::CANCUN,
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(8)).flags.contains(InstFlags::NOOP),
+            "POP after CALL should be NOOP'd (success flag is dead)"
+        );
+    }
+
+    #[test]
+    fn pop_after_suspend_with_dup() {
+        // CALL → POP → DUP6: the POP (NOOP'd) decrements the stack. DUP6 must
+        // see the correct height after the POP, otherwise it reads the wrong slot.
+        // This is the pattern from precompsEIP2929Cancun.json that exposed the bug.
+        let bytecode = analyze_code_spec(
+            vec![
+                op::PUSH1,
+                0x00, // ret length
+                op::PUSH1,
+                0x00, // ret offset
+                op::PUSH1,
+                0x00, // args length
+                op::PUSH1,
+                0x00, // args offset
+                op::PUSH1,
+                0x00, // value
+                op::PUSH1,
+                0x69,     // address
+                op::GAS,  // gas
+                op::CALL, // suspends, pushes success
+                op::POP,  // pops success (NOOP'd)
+                op::PUSH1,
+                0x42,       // push marker
+                op::PUSH0,  //
+                op::MSTORE, // store marker to memory
+                op::STOP,
+            ],
+            SpecId::CANCUN,
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(8)).flags.contains(InstFlags::NOOP),
+            "POP after CALL should be NOOP'd"
+        );
+        // MSTORE after POP must NOT be eliminated.
+        assert!(
+            !bytecode.inst(Inst::from_usize(11)).flags.contains(InstFlags::NOOP),
+            "MSTORE should NOT be skipped"
         );
     }
 }

--- a/crates/revmc/src/compiler/translate.rs
+++ b/crates/revmc/src/compiler/translate.rs
@@ -567,11 +567,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Pay static gas for the current section.
         self.gas_cost_imm(data.gas_section.gas_cost as u64);
 
-        // NOOPs that aren't section heads need no codegen beyond gas.
+        // NOOPs with zero stack diff that aren't section heads need no codegen beyond gas.
         let (inp, out) = data.stack_io();
         let diff = effective_stack_diff(inp, out, data);
-        if data.flags.contains(InstFlags::NOOP) && !data.is_stack_section_head() {
-            self.section_len_offset += diff;
+        if data.flags.contains(InstFlags::NOOP) && diff == 0 && !data.is_stack_section_head() {
             goto_return!("noop");
         }
 
@@ -636,14 +635,19 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }
         }
 
-        // NOOP section head: still needs bounds check above, but skip the rest.
-        if data.flags.contains(InstFlags::NOOP) {
-            self.section_len_offset += diff;
-            goto_return!("noop");
-        }
+        // Store updated stack length. This must happen before the NOOP check so that
+        // NOOPs with nonzero diff (e.g. POP) keep the alloca up-to-date for the next
+        // section head.
         if diff != 0 || self.section_len_offset != 0 {
             let len_changed = self.bcx.iadd_imm(self.len_before, diff as i64);
             self.stack_len.store(&mut self.bcx, len_changed);
+        }
+
+        // NOOP: section heads still needed the bounds check and stack_len store above,
+        // but can skip the opcode logic.
+        if data.flags.contains(InstFlags::NOOP) {
+            self.section_len_offset += diff;
+            goto_return!("noop");
         }
 
         // If the output is a known constant and the opcode has no dynamic gas or side effects,
@@ -1578,7 +1582,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
     /// Adds a comment to the current instruction.
     fn add_comment(&mut self, comment: &str) {
-        if comment.is_empty() {
+        if comment.is_empty() || !self.config.comments {
             return;
         }
         self.bcx.add_comment_to_current_inst(comment);

--- a/crates/revmc/src/tests/resume_at_call.rs
+++ b/crates/revmc/src/tests/resume_at_call.rs
@@ -23,6 +23,7 @@ use revm_primitives::{Bytes, U256};
 matrix_tests!(call_then_push = |compiler| run_call_then_push(compiler));
 matrix_tests!(call_then_return = |compiler| run_call_then_return(compiler));
 matrix_tests!(call_returndatasize = |compiler| run_call_returndatasize(compiler));
+matrix_tests!(call_pop_dse_dup = |compiler| run_call_pop_dse_dup(compiler));
 
 /// Contract: PUSH args → CALL → PUSH1 0x42 → STOP
 ///
@@ -253,6 +254,89 @@ fn run_call_returndatasize<B: Backend>(compiler: &mut EvmCompiler<B>) {
                 value,
                 U256::from(7),
                 "RETURNDATASIZE should be 7 after CALL with 7-byte return data"
+            );
+        }
+        other => panic!("expected Return after resume, got {other:?}"),
+    }
+}
+
+/// Regression test for stale `stack_len` after NOOP'd POP at a section boundary.
+///
+/// Contract: PUSH 0xAA → CALL args → CALL → POP → DUP1 → MSTORE → RETURN
+///
+/// DSE marks POP as NOOP (the success flag is dead). POP has a nonzero stack
+/// diff (-1), so the codegen must still store the updated `stack_len` to the
+/// alloca. Without the fix, the section head after CALL would reload a stale
+/// length, causing DUP1 to read the wrong slot.
+fn run_call_pop_dse_dup<B: Backend>(compiler: &mut EvmCompiler<B>) {
+    #[rustfmt::skip]
+    let bytecode: &[u8] = &[
+        op::PUSH1, 0xAA, // marker value
+        // CALL arguments
+        op::PUSH1, 0,    // ret length
+        op::PUSH1, 0,    // ret offset
+        op::PUSH1, 0,    // args length
+        op::PUSH1, 0,    // args offset
+        op::PUSH1, 0,    // value
+        op::PUSH1, 0x69, // address
+        op::GAS,         // gas
+        op::CALL,        // suspends; pushes success flag
+        // -- resume (new section) --
+        op::POP,         // discard success flag (NOOP'd by DSE)
+        // Stack: [0xAA]
+        op::DUP1,        // [0xAA, 0xAA]
+        op::PUSH0,       // [0xAA, 0xAA, 0]
+        op::MSTORE,      // mem[0] = 0xAA
+        op::POP,         // discard remaining 0xAA
+        op::PUSH1, 32,   // return size
+        op::PUSH0,       // return offset
+        op::RETURN,
+    ];
+
+    unsafe { compiler.clear() }.unwrap();
+    compiler.inspect_stack(true);
+    let f = unsafe { compiler.jit("pop_dse_dup", bytecode, DEF_SPEC) }.unwrap();
+
+    let mut host = TestHost::new();
+    let input = InputsImpl {
+        target_address: DEF_ADDR,
+        bytecode_address: None,
+        caller_address: DEF_CALLER,
+        input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
+        call_value: DEF_VALUE,
+    };
+    let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
+    let ext_bytecode = ExtBytecode::new(bytecode_obj);
+    let mut interpreter =
+        Interpreter::new(SharedMemory::new(), ext_bytecode, input, false, DEF_SPEC, DEF_GAS_LIMIT);
+
+    // First call: suspends at CALL.
+    let action = unsafe { f.call_with_interpreter(&mut interpreter, &mut host) };
+    let return_memory_offset = match &action {
+        InterpreterAction::NewFrame(FrameInput::Call(call_inputs)) => {
+            Some(call_inputs.return_memory_offset.clone())
+        }
+        other => panic!("expected NewFrame(Call), got {other:?}"),
+    };
+
+    let call_result = InterpreterResult {
+        result: InstructionResult::Stop,
+        output: Bytes::new(),
+        gas: Gas::new(0),
+    };
+    insert_call_outcome_test(&mut interpreter, call_result, return_memory_offset);
+
+    // Second call: resume → POP (noop) → DUP1 → MSTORE → RETURN.
+    let action = unsafe { f.call_with_interpreter(&mut interpreter, &mut host) };
+    match &action {
+        InterpreterAction::Return(result) => {
+            assert_eq!(result.result, InstructionResult::Return);
+            assert_eq!(result.output.len(), 32);
+            let value = U256::from_be_slice(&result.output);
+            assert_eq!(
+                value,
+                U256::from(0xAA),
+                "DUP1 should read 0xAA (the value below the POP'd success flag)"
             );
         }
         other => panic!("expected Return after resume, got {other:?}"),


### PR DESCRIPTION

Add POP to the set of instructions that can be eliminated by DSE when their input is dead. When a POP consumes a value that no other instruction reads, both the POP and its producer can be marked NOOP.

Also fixes a latent bug in translate where NOOP instructions with nonzero stack diff did not store the updated `stack_len` to the alloca. A following section head would reload the stale pre-NOOP value. This was previously unreachable since all existing NOOPs either had `diff == 0` (SWAP, EXCHANGE) or were always followed by a non-NOOP that flushed the correct value before the next section boundary. POP NOOPs (`diff = -1`) can appear right before a JUMPDEST, exposing the bug. Fixed by moving the `stack_len` store before the NOOP early-return.

DSE eliminated instructions across benchmarks:

```
Benchmark            Before → After
fibonacci               3 →    6  (+3)
fibonacci-calldata      7 →   10  (+3)
factorial               8 →   10  (+2)
counter                47 →   48  (+1)
snailtracer          1375 → 1505  (+130)
weth                  483 →  589  (+106)
hash_10k               28 →   31  (+3)
erc20_transfer        438 →  504  (+66)
push0_proxy             9 →    9
usdc_proxy            239 →  302  (+63)
fiat_token           2776 → 3228  (+452)
uniswap_v2_pair      1382 → 1674  (+292)
univ2_router         2512 → 3277  (+765)
seaport              2847 → 3454  (+607)
airdrop              1000 → 1157  (+157)
bswap64               110 →  111  (+1)
bswap64_opt            65 →   65
eip4788                21 →   21
eip2935                18 →   18
curve_stableswap      691 →  861  (+170)
```
