### PR TITLE
fix: propagate leader marks for dead reachable JUMPDESTs in rebuild_cfg

### DIFF
--- a/crates/revmc/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc/src/bytecode/passes/block_analysis.rs
@@ -503,11 +503,16 @@ impl Bytecode<'_> {
         is_leader.set(0, true);
 
         for (i, inst) in self.insts.raw.iter().enumerate() {
-            if inst.is_dead_code() {
-                continue;
-            }
+            // Reachable JUMPDESTs must be leaders even when dead (e.g. deduped).
+            // Without this, `pending_leader` in the block-building loop below never
+            // fires for a dead JUMPDEST, and the preceding live block absorbs the
+            // next alive instruction — potentially a diverging terminator that
+            // poisons DSE.
             if inst.is_reachable_jumpdest(self.has_dynamic_jumps) {
                 is_leader.set(i, true);
+            }
+            if inst.is_dead_code() {
+                continue;
             }
             if (inst.is_branching() || inst.is_diverging()) && i + 1 < n {
                 is_leader.set(i + 1, true);

--- a/crates/revmc/src/tests/dedup_jumpdest_leader.rs
+++ b/crates/revmc/src/tests/dedup_jumpdest_leader.rs
@@ -1,0 +1,127 @@
+//! Regression test: dedup of a reachable JUMPDEST block must preserve leader marks.
+//!
+//! Same class of bug as `dedup_leader_propagation.rs`, but triggered by a deduped
+//! reachable JUMPDEST block rather than a JUMPI fall-through.
+//!
+//! When `rebuild_cfg` skips dead instructions before checking `is_reachable_jumpdest`,
+//! a deduped JUMPDEST block never gets its leader mark set. `pending_leader` never fires
+//! and the preceding live block absorbs the next alive instruction past the dead region.
+//! If that instruction is a diverging terminator (INVALID), DSE treats all exit stack
+//! positions as dead and incorrectly NOOPs live PUSHes.
+//!
+//! The key difference from `dedup_leader_propagation.rs`: that test's deduped block is
+//! preceded by JUMPI, whose `is_branching()` already sets `is_leader[i+1]` on the first
+//! dead instruction. Here, the deduped block is preceded by a non-branching instruction
+//! (PUSH1), so the leader mark must come from `is_reachable_jumpdest` — which the buggy
+//! code skips for dead instructions.
+//!
+//! Real-world trigger: tx 0x3a0ab5...31856 (block 5330710).
+//!
+//! `inspect_stack` must be **off** so DSE's diverging-terminator optimisation is active.
+
+use super::{DEF_SPEC, with_evm_context};
+use crate::{Backend, EvmCompiler};
+use revm_bytecode::opcode as op;
+use revm_interpreter::{InstructionResult, InterpreterAction, InterpreterResult};
+
+/// Bytecode layout:
+/// ```text
+/// 00: JUMPDEST          ; entry
+/// 01: PUSH1 0x00        ; dummy value (replaced at alt_entry)
+/// 03: CALLDATASIZE      ; ≠ 0 → taken
+/// 04: PUSH1 0x0e        ; → alt_entry
+/// 06: JUMPI             ; taken
+/// 07: PUSH1 0x14        ; → dup_ret (makes it reachable)
+/// 09: JUMP
+///
+/// 0a: JUMPDEST          ; canonical_ret
+/// 0b: PUSH1 0x19        ; → dest
+/// 0d: JUMP
+///
+/// 0e: JUMPDEST          ; alt_entry
+/// 0f: DUP1              ; dup entry's 0x00 (raises max_growth so DSE bitvec fits)
+/// 10: POP               ; drop dup
+/// 11: POP               ; drop entry's 0x00
+/// 12: PUSH1 0x2a        ; ← live value DSE must NOT kill
+///
+/// 14: JUMPDEST          ; dup_ret (identical to canonical_ret → deduped)
+/// 15: PUSH1 0x19        ; → dest
+/// 17: JUMP
+///
+/// 18: INVALID           ; alive after dead dup_ret
+///
+/// 19: JUMPDEST          ; dest: uses 0x2a
+/// 1a: PUSH1 0x00
+/// 1c: MSTORE            ; mem[0] = 0x2a
+/// 1d: PUSH1 0x20
+/// 1f: PUSH1 0x00
+/// 21: RETURN            ; return 32 bytes
+/// ```
+const BYTECODE: &[u8] = &[
+    // 0x00: entry
+    op::JUMPDEST,
+    op::PUSH1,
+    0x00,
+    op::CALLDATASIZE,
+    op::PUSH1,
+    0x0e, // → alt_entry
+    op::JUMPI,
+    // 0x07: not-taken → dup_ret (makes it reachable for analysis)
+    op::PUSH1,
+    0x14, // → dup_ret
+    op::JUMP,
+    // 0x0a: canonical_ret
+    op::JUMPDEST,
+    op::PUSH1,
+    0x19, // → dest
+    op::JUMP,
+    // 0x0e: alt_entry
+    op::JUMPDEST,
+    op::DUP1,
+    op::POP,
+    op::POP,
+    op::PUSH1,
+    0x2a, // ← DSE must NOT kill
+    // 0x14: dup_ret (byte-identical to canonical_ret → deduped)
+    op::JUMPDEST,
+    op::PUSH1,
+    0x19, // → dest
+    op::JUMP,
+    // 0x18: alive after dead dup_ret
+    op::INVALID,
+    // 0x19: dest
+    op::JUMPDEST,
+    op::PUSH1,
+    0x00,
+    op::MSTORE,
+    op::PUSH1,
+    0x20,
+    op::PUSH1,
+    0x00,
+    op::RETURN,
+];
+
+fn run_dedup_jumpdest_leader_test<B: Backend>(compiler: &mut EvmCompiler<B>) {
+    unsafe { compiler.clear() }.unwrap();
+    // inspect_stack must be OFF so that DSE's diverging-terminator logic is active.
+    compiler.inspect_stack(false);
+    let f = unsafe { compiler.jit("dedup_jumpdest_leader", BYTECODE, DEF_SPEC) }.unwrap();
+
+    with_evm_context(BYTECODE, DEF_SPEC, |ecx, _stack, _stack_len| {
+        let r = unsafe { f.call(None, None, ecx) };
+        assert_eq!(r, InstructionResult::Return, "JIT must return Return, got {r:?}");
+
+        let action = ecx.next_action.as_ref().expect("expected Return action");
+        let InterpreterAction::Return(InterpreterResult { output, .. }) = action else {
+            panic!("expected Return action, got {action:?}");
+        };
+        assert_eq!(output.len(), 32, "expected 32-byte return data");
+        assert_eq!(
+            output[31], 0x2a,
+            "PUSH1 0x2a was incorrectly killed by DSE; return_data[31] = {:#04x}, expected 0x2a",
+            output[31]
+        );
+    });
+}
+
+matrix_tests!(dedup_jumpdest_leader = run_dedup_jumpdest_leader_test);

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -49,6 +49,7 @@ mod macros;
 
 mod meta;
 
+mod dedup_jumpdest_leader;
 mod dedup_leader_propagation;
 mod disabled_section_poison;
 mod div_zero_opaque;


### PR DESCRIPTION
When dedup marks a JUMPDEST block as dead code, `rebuild_cfg` must still recognize it as a block leader so that `pending_leader` propagates the boundary to the next alive instruction. Previously, the leader identification loop skipped dead instructions entirely, meaning a deduped reachable JUMPDEST never got its leader mark set. This caused the preceding live block to absorb alive instructions past the dead region (e.g. STOP), and if that instruction was a diverging terminator, DSE would incorrectly NOOP live stack values.

Same class of bug as #292 (JUMPI fall-through leader propagation), but triggered by deduped JUMPDEST blocks rather than JUMPI fall-throughs.

Fix: move the `is_reachable_jumpdest` check before the `is_dead_code` skip in the leader identification loop.

Trigger: tx `0x3a0ab5bfd0ed187ffdf255d2942b7828b257c0b2149c72d81ddda8cae9831856` (block 5330710), ERC-20 `distribute` function returning `false` instead of `true` due to `PUSH1 0x01` being NOOPed.