### PR TITLE
refactor(builtins): dedup account loading across host instructions

### DIFF
--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -164,13 +164,8 @@ pub unsafe extern "C" fn __revmc_builtin_balance(
     address: &mut EvmWord,
 ) -> BuiltinResult {
     let addr = address.to_address();
-    if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        let account = berlin_load_account!(ecx, addr, false);
-        *address = account.balance.into();
-    } else {
-        let account = ecx.host.load_account_info_skip_cold_load(addr, false, false)?;
-        *address = account.balance.into();
-    }
+    let account = load_account(ecx, addr, false)?;
+    *address = account.balance.into();
     Ok(())
 }
 
@@ -272,13 +267,8 @@ pub unsafe extern "C" fn __revmc_builtin_extcodesize(
     address: &mut EvmWord,
 ) -> BuiltinResult {
     let addr = address.to_address();
-    if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        let account = berlin_load_account!(ecx, addr, true);
-        *address = U256::from(account.code.as_ref().unwrap().len()).into();
-    } else {
-        let account = ecx.host.load_account_info_skip_cold_load(addr, true, false)?;
-        *address = U256::from(account.code.as_ref().unwrap().len()).into();
-    }
+    let account = load_account(ecx, addr, true)?;
+    *address = U256::from(account.code.as_ref().unwrap().len()).into();
     Ok(())
 }
 
@@ -297,13 +287,8 @@ pub unsafe extern "C" fn __revmc_builtin_extcodecopy(
         ensure_memory(ecx, memory_offset_usize, len)?;
     }
 
-    let code = if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        let account = berlin_load_account!(ecx, addr, true);
-        account.code.as_ref().unwrap().original_bytes()
-    } else {
-        let code = ecx.host.load_account_code(addr).ok_or_fatal()?;
-        code.data
-    };
+    let account = load_account(ecx, addr, true)?;
+    let code = account.code.as_ref().unwrap().original_bytes();
 
     let code_offset_usize = core::cmp::min(as_usize_saturated!(code_offset.to_u256()), code.len());
     ecx.memory.set_data(memory_offset_usize, code_offset_usize, len, &code);
@@ -339,11 +324,7 @@ pub unsafe extern "C" fn __revmc_builtin_extcodehash(
     address: &mut EvmWord,
 ) -> BuiltinResult {
     let addr = address.to_address();
-    let account = if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        berlin_load_account!(ecx, addr, false)
-    } else {
-        ecx.host.load_account_info_skip_cold_load(addr, false, false)?
-    };
+    let account = load_account(ecx, addr, false)?;
     let code_hash = if account.is_empty { revm_primitives::B256::ZERO } else { account.code_hash };
     *address = EvmWord::from_be_bytes(code_hash);
     Ok(())

--- a/crates/revmc-builtins/src/macros.rs
+++ b/crates/revmc-builtins/src/macros.rs
@@ -18,25 +18,6 @@ macro_rules! gas {
     };
 }
 
-/// Mirrors revm's `berlin_load_account!` macro.
-/// Loads account info with the cold-load-skip optimization: if remaining gas
-/// is less than the cold cost, skip the DB load and return OOG immediately.
-/// Charges `cold_account_additional_cost` if cold. The base `warm_storage_read_cost`
-/// is deducted upfront by the JIT as static gas.
-#[collapse_debuginfo(yes)]
-macro_rules! berlin_load_account {
-    ($ecx:expr, $address:expr, $load_code:expr) => {{
-        let cold_load_gas = $ecx.host.gas_params().cold_account_additional_cost();
-        let skip_cold_load = $ecx.gas.remaining() < cold_load_gas;
-        let account =
-            $ecx.host.load_account_info_skip_cold_load($address, $load_code, skip_cold_load)?;
-        if account.is_cold {
-            gas!($ecx, cold_load_gas);
-        }
-        account
-    }};
-}
-
 #[collapse_debuginfo(yes)]
 macro_rules! ensure_non_staticcall {
     ($ecx:expr) => {

--- a/crates/revmc-builtins/src/utils.rs
+++ b/crates/revmc-builtins/src/utils.rs
@@ -1,5 +1,7 @@
 use core::num::NonZero;
+use revm_context_interface::journaled_state::AccountInfoLoad;
 use revm_interpreter::{InstructionResult, as_usize_saturated, host::LoadError};
+use revm_primitives::Address;
 use revmc_context::{EvmContext, EvmWord};
 
 pub type BuiltinResult = Result<(), BuiltinError>;
@@ -35,6 +37,23 @@ impl<T> OkOrFatal<T> for Option<T> {
     fn ok_or_fatal(self) -> Result<T, BuiltinError> {
         self.ok_or(InstructionResult::FatalExternalError.into())
     }
+}
+
+/// Loads an account, handling cold load gas accounting.
+///
+/// Pre-Berlin, `cold_account_additional_cost` is 0, so the cold load logic is a no-op.
+pub(crate) fn load_account<'a>(
+    ecx: &'a mut EvmContext<'_>,
+    address: Address,
+    load_code: bool,
+) -> Result<AccountInfoLoad<'a>, BuiltinError> {
+    let cold_load_gas = ecx.host.gas_params().cold_account_additional_cost();
+    let skip_cold_load = ecx.gas.remaining() < cold_load_gas;
+    let account = ecx.host.load_account_info_skip_cold_load(address, load_code, skip_cold_load)?;
+    if account.is_cold {
+        gas!(ecx, cold_load_gas);
+    }
+    Ok(account)
 }
 
 /// Splits the stack pointer into `N` elements by casting it to an array.


### PR DESCRIPTION
Replace the duplicated `if berlin { berlin_load_account!() } else { load_account_info_skip_cold_load() }` pattern in balance, extcodesize, extcodehash, and extcodecopy with a single `load_account` function.

Pre-Berlin, `cold_account_additional_cost` is 0, so the cold load gas logic is a no-op and the function works correctly for all spec versions.

Remove the `berlin_load_account!` macro entirely.

Mirrors https://github.com/bluealloy/revm/pull/3562.