### PR TITLE
feat(bytecode): add ANSI syntax highlighting to IR display

### DIFF
--- a/crates/revmc-cli/src/cmd/run.rs
+++ b/crates/revmc-cli/src/cmd/run.rs
@@ -184,7 +184,7 @@ impl RunArgs {
 
         let bytecode = compiler.parse(bytecode_slice.into(), spec_id)?;
         if self.display || self.parse_only {
-            println!("{name}()\n{bytecode}");
+            println!("{name}()\n{bytecode:#}");
         }
         if let Some(fmt) = self.dot {
             let dump_dir = compiler.dump_dir().expect("dump_dir should be set when --dot is used");

--- a/crates/revmc/src/bytecode/asm.rs
+++ b/crates/revmc/src/bytecode/asm.rs
@@ -43,13 +43,22 @@ pub fn parse_asm(s: &str) -> Result<Vec<u8>> {
 
 /// A token produced by the tokenizer.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum Token<'a> {
+pub(super) struct Token<'a> {
+    /// The source text slice this token was produced from.
+    pub src: &'a str,
+    /// The kind of token.
+    pub kind: TokenKind,
+}
+
+/// The kind of a [`Token`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TokenKind {
     /// An identifier (opcode name, macro name, etc.).
-    Ident(&'a str),
+    Ident,
     /// A label definition (`name:`).
-    Label(&'a str),
+    Label,
     /// A label reference (`%name`).
-    LabelRef(&'a str),
+    LabelRef,
     /// A numeric literal.
     Number(U256),
     /// A comma.
@@ -59,19 +68,25 @@ enum Token<'a> {
     /// Closing parenthesis.
     RParen,
     /// A macro parameter reference (`$name`).
-    ParamRef(&'a str),
+    ParamRef,
+    /// Whitespace.
+    Whitespace,
+    /// Comment text including the leading `;`.
+    Comment,
     /// Unrecognized input.
-    Unknown(&'a str),
+    Unknown,
 }
 
 /// Character-by-character tokenizer over source text.
-struct Tokenizer<'a> {
+///
+/// Always emits all tokens including whitespace and comments.
+pub(super) struct Tokenizer<'a> {
     src: &'a str,
     pos: usize,
 }
 
 impl<'a> Tokenizer<'a> {
-    fn new(src: &'a str) -> Self {
+    pub(super) fn new(src: &'a str) -> Self {
         Self { src, pos: 0 }
     }
 
@@ -85,20 +100,6 @@ impl<'a> Tokenizer<'a> {
 
     fn advance(&mut self, n: usize) {
         self.pos += n;
-    }
-
-    fn skip_whitespace(&mut self) {
-        let rest = self.remaining();
-        let trimmed = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
-        self.advance(rest.len() - trimmed.len());
-    }
-
-    fn skip_line(&mut self) {
-        if let Some(nl) = self.remaining().find('\n') {
-            self.advance(nl + 1);
-        } else {
-            self.pos = self.src.len();
-        }
     }
 
     /// Read a contiguous word of alphanumeric/underscore characters.
@@ -118,11 +119,11 @@ impl<'a> Tokenizer<'a> {
         } else {
             rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len())
         };
-        let s = &rest[..end];
+        let src = &rest[..end];
         self.advance(end);
-        match s.parse::<U256>() {
-            Ok(n) => Token::Number(n),
-            Err(_) => Token::Unknown(s),
+        match src.parse::<U256>() {
+            Ok(n) => Token { src, kind: TokenKind::Number(n) },
+            Err(_) => Token { src, kind: TokenKind::Unknown },
         }
     }
 }
@@ -131,78 +132,97 @@ impl<'a> Iterator for Tokenizer<'a> {
     type Item = Token<'a>;
 
     fn next(&mut self) -> Option<Token<'a>> {
-        loop {
-            self.skip_whitespace();
-            let c = self.peek_char()?;
+        // Emit whitespace as a token.
+        let rest = self.remaining();
+        let trimmed = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+        let ws_len = rest.len() - trimmed.len();
+        if ws_len > 0 {
+            let src = &self.src[self.pos..self.pos + ws_len];
+            self.advance(ws_len);
+            return Some(Token { src, kind: TokenKind::Whitespace });
+        }
 
-            match c {
-                ';' => self.skip_line(),
+        let c = self.peek_char()?;
 
-                '%' => {
-                    let start = self.pos;
-                    self.advance(1);
-                    let name = self.read_word();
-                    return Some(if name.is_empty() {
-                        Token::Unknown(&self.src[start..self.pos])
-                    } else {
-                        Token::LabelRef(name)
-                    });
+        match c {
+            ';' => {
+                let start = self.pos;
+                if let Some(nl) = self.remaining().find('\n') {
+                    self.advance(nl);
+                } else {
+                    self.pos = self.src.len();
                 }
+                Some(Token { src: &self.src[start..self.pos], kind: TokenKind::Comment })
+            }
 
-                '$' => {
-                    let start = self.pos;
-                    self.advance(1);
-                    let name = self.read_word();
-                    return Some(if name.is_empty() {
-                        Token::Unknown(&self.src[start..self.pos])
-                    } else {
-                        Token::ParamRef(name)
-                    });
-                }
+            '%' => {
+                let start = self.pos;
+                self.advance(1);
+                let name = self.read_word();
+                Some(if name.is_empty() {
+                    Token { src: &self.src[start..self.pos], kind: TokenKind::Unknown }
+                } else {
+                    Token { src: name, kind: TokenKind::LabelRef }
+                })
+            }
 
-                ',' => {
-                    self.advance(1);
-                    return Some(Token::Comma);
-                }
-                '(' => {
-                    self.advance(1);
-                    return Some(Token::LParen);
-                }
-                ')' => {
-                    self.advance(1);
-                    return Some(Token::RParen);
-                }
+            '$' => {
+                let start = self.pos;
+                self.advance(1);
+                let name = self.read_word();
+                Some(if name.is_empty() {
+                    Token { src: &self.src[start..self.pos], kind: TokenKind::Unknown }
+                } else {
+                    Token { src: name, kind: TokenKind::ParamRef }
+                })
+            }
 
-                '0'..='9' => return Some(self.read_number()),
+            ',' => {
+                let src = &self.src[self.pos..self.pos + 1];
+                self.advance(1);
+                Some(Token { src, kind: TokenKind::Comma })
+            }
+            '(' => {
+                let src = &self.src[self.pos..self.pos + 1];
+                self.advance(1);
+                Some(Token { src, kind: TokenKind::LParen })
+            }
+            ')' => {
+                let src = &self.src[self.pos..self.pos + 1];
+                self.advance(1);
+                Some(Token { src, kind: TokenKind::RParen })
+            }
 
-                _ if c.is_ascii_alphabetic() || c == '_' => {
-                    let word = self.read_word();
-                    if self.peek_char() == Some(':') {
-                        self.advance(1);
-                        return Some(Token::Label(word));
+            '0'..='9' => Some(self.read_number()),
+
+            _ if c.is_ascii_alphabetic() || c == '_' => {
+                let word = self.read_word();
+                if self.peek_char() == Some(':') {
+                    self.advance(1);
+                    Some(Token { src: word, kind: TokenKind::Label })
+                } else {
+                    Some(Token { src: word, kind: TokenKind::Ident })
+                }
+            }
+
+            ':' => {
+                self.advance(1);
+                Some(Token { src: "", kind: TokenKind::Label })
+            }
+
+            _ => {
+                let start = self.pos;
+                // Consume consecutive unrecognized characters.
+                while let Some(c) = self.peek_char() {
+                    if c.is_ascii_whitespace()
+                        || c.is_ascii_alphanumeric()
+                        || matches!(c, '_' | ';' | '%' | '$' | ',' | '(' | ')' | ':')
+                    {
+                        break;
                     }
-                    return Some(Token::Ident(word));
+                    self.advance(c.len_utf8());
                 }
-
-                ':' => {
-                    self.advance(1);
-                    return Some(Token::Label(""));
-                }
-
-                _ => {
-                    let start = self.pos;
-                    // Consume consecutive unrecognized characters.
-                    while let Some(c) = self.peek_char() {
-                        if c.is_ascii_whitespace()
-                            || c.is_ascii_alphanumeric()
-                            || matches!(c, '_' | ';' | '%' | '$' | ',' | '(' | ')' | ':')
-                        {
-                            break;
-                        }
-                        self.advance(c.len_utf8());
-                    }
-                    return Some(Token::Unknown(&self.src[start..self.pos]));
-                }
+                Some(Token { src: &self.src[start..self.pos], kind: TokenKind::Unknown })
             }
         }
     }
@@ -229,12 +249,12 @@ fn builtin_macros() -> HashMap<&'static str, MacroDef<'static>> {
             is_fn: false,
             params: vec![],
             body: vec![
-                Token::Ident("PUSH0"),
-                Token::Ident("MSTORE"),
-                Token::Ident("PUSH1"),
-                Token::Number(U256::from(0x20)),
-                Token::Ident("PUSH0"),
-                Token::Ident("RETURN"),
+                Token { src: "PUSH0", kind: TokenKind::Ident },
+                Token { src: "MSTORE", kind: TokenKind::Ident },
+                Token { src: "PUSH1", kind: TokenKind::Ident },
+                Token { src: "0x20", kind: TokenKind::Number(U256::from(0x20)) },
+                Token { src: "PUSH0", kind: TokenKind::Ident },
+                Token { src: "RETURN", kind: TokenKind::Ident },
             ],
         },
     );
@@ -262,11 +282,14 @@ fn preprocess(s: &str) -> Result<Vec<Token<'_>>> {
         }
     }
 
-    // Tokenize non-directive lines (borrowing from `s`).
+    // Tokenize non-directive lines (borrowing from `s`), skipping whitespace and comments.
     let mut raw = Vec::new();
     for &(start, end) in &rest_start {
         let line = &s[start..end];
-        raw.extend(Tokenizer::new(line));
+        raw.extend(
+            Tokenizer::new(line)
+                .filter(|t| !matches!(t.kind, TokenKind::Whitespace | TokenKind::Comment)),
+        );
     }
 
     if macros.is_empty() {
@@ -278,28 +301,31 @@ fn preprocess(s: &str) -> Result<Vec<Token<'_>>> {
 
 /// Parse a `#define` directive body (everything after `#define`) into the macro table.
 fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>) -> Result<()> {
-    let mut tok = Tokenizer::new(after);
+    let mut tok = Tokenizer::new(after)
+        .filter(|t| !matches!(t.kind, TokenKind::Whitespace | TokenKind::Comment))
+        .peekable();
 
     let name = match tok.next() {
-        Some(Token::Ident(name)) => name,
+        Some(Token { src, kind: TokenKind::Ident }) => src,
         Some(other) => eyre::bail!("expected macro name after #define, got {other:?}"),
         None => eyre::bail!("expected macro name after #define"),
     };
 
     // Function-like macro: NAME(a, b).
     // Only if '(' immediately follows the name (no whitespace), matching C preprocessor semantics.
-    let is_fn = tok.peek_char() == Some('(');
+    let is_fn = after.as_bytes().get(name.as_ptr() as usize - after.as_ptr() as usize + name.len())
+        == Some(&b'(');
 
     let all_tokens: Vec<Token<'a>> = tok.collect();
     let mut i = 0;
 
     let mut params = Vec::new();
-    if is_fn && matches!(all_tokens.get(i), Some(Token::LParen)) {
+    if is_fn && matches!(all_tokens.get(i), Some(Token { kind: TokenKind::LParen, .. })) {
         i += 1; // consume '('
-        if !matches!(all_tokens.get(i), Some(Token::RParen)) {
+        if !matches!(all_tokens.get(i), Some(Token { kind: TokenKind::RParen, .. })) {
             loop {
                 match all_tokens.get(i) {
-                    Some(Token::Ident(p)) => {
+                    Some(Token { src: p, kind: TokenKind::Ident }) => {
                         params.push(*p);
                         i += 1;
                     }
@@ -308,11 +334,11 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
                     }
                 }
                 match all_tokens.get(i) {
-                    Some(Token::RParen) => {
+                    Some(Token { kind: TokenKind::RParen, .. }) => {
                         i += 1;
                         break;
                     }
-                    Some(Token::Comma) => i += 1,
+                    Some(Token { kind: TokenKind::Comma, .. }) => i += 1,
                     other => eyre::bail!(
                         "expected ',' or ')' in #define {name} parameter list, got {other:?}"
                     ),
@@ -337,21 +363,25 @@ fn expand_macros<'a>(
     let mut iter = tokens.into_iter().peekable();
 
     while let Some(tok) = iter.next() {
-        let Token::Ident(name) = &tok else {
+        let TokenKind::Ident = &tok.kind else {
             out.push(tok);
             continue;
         };
-        let Some(mac) = macros.get(name) else {
+        let Some(mac) = macros.get(tok.src) else {
             out.push(tok);
             continue;
         };
+        let name = tok.src;
 
         if !mac.is_fn {
             // Object-like macro: simple body substitution.
             out.extend(mac.body.iter().cloned());
         } else {
             // Function-like macro: consume `(arg1, arg2, ...)`.
-            eyre::ensure!(iter.next() == Some(Token::LParen), "macro {name:?} expects arguments");
+            eyre::ensure!(
+                matches!(iter.next(), Some(Token { kind: TokenKind::LParen, .. })),
+                "macro {name:?} expects arguments",
+            );
 
             // Parse arguments, handling nested parens.
             let mut args: Vec<Vec<Token<'a>>> = vec![vec![]];
@@ -360,19 +390,19 @@ fn expand_macros<'a>(
                 let t = iter
                     .next()
                     .ok_or_else(|| eyre::eyre!("unclosed '(' in macro invocation {name:?}"))?;
-                match &t {
-                    Token::LParen => {
+                match &t.kind {
+                    TokenKind::LParen => {
                         depth += 1;
                         args.last_mut().unwrap().push(t);
                     }
-                    Token::RParen => {
+                    TokenKind::RParen => {
                         depth -= 1;
                         if depth == 0 {
                             break;
                         }
                         args.last_mut().unwrap().push(t);
                     }
-                    Token::Comma if depth == 1 => args.push(vec![]),
+                    TokenKind::Comma if depth == 1 => args.push(vec![]),
                     _ => args.last_mut().unwrap().push(t),
                 }
             }
@@ -394,8 +424,8 @@ fn expand_macros<'a>(
 
             // Substitute $param refs in the body.
             for body_tok in &mac.body {
-                if let Token::ParamRef(pname) = body_tok
-                    && let Some(idx) = mac.params.iter().position(|p| p == pname)
+                if let TokenKind::ParamRef = body_tok.kind
+                    && let Some(idx) = mac.params.iter().position(|p| *p == body_tok.src)
                 {
                     out.extend(args[idx].iter().cloned());
                 } else {
@@ -449,14 +479,16 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
     let mut items = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
-        match &tokens[i] {
-            Token::Label(name) => {
+        match &tokens[i].kind {
+            TokenKind::Label => {
+                let name = tokens[i].src;
                 eyre::ensure!(!name.is_empty(), "empty label name");
                 items.push(Item::Label(name));
                 i += 1;
             }
-            Token::Ident(word) => {
-                if *word == "PUSH" {
+            TokenKind::Ident => {
+                let word = tokens[i].src;
+                if word == "PUSH" {
                     i += 1;
                     let imm = expect_imm(tokens, &mut i, "PUSH")?;
                     items.push(Item::Inst(Inst {
@@ -464,8 +496,8 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
                         imm: Some(imm),
                         push_kind: PushKind::Auto,
                     }));
-                } else if *word == "DUP" || *word == "SWAP" {
-                    let is_swap = *word == "SWAP";
+                } else if word == "DUP" || word == "SWAP" {
+                    let is_swap = word == "SWAP";
                     i += 1;
                     let n = expect_number_u8(tokens, &mut i, word)?;
                     eyre::ensure!(n >= 1, "{word} index must be >= 1, got {n}");
@@ -524,7 +556,10 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
                                 push_kind: PushKind::Fixed(imm_len),
                             }));
                         } else {
-                            if matches!(tokens.get(i), Some(Token::Number(_))) {
+                            if matches!(
+                                tokens.get(i),
+                                Some(Token { kind: TokenKind::Number(_), .. })
+                            ) {
                                 eyre::bail!("unexpected immediate for opcode {opc}");
                             }
                             items.push(Item::Inst(Inst {
@@ -536,8 +571,8 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
                     }
                 }
             }
-            Token::Unknown(s) => eyre::bail!("unexpected token: {s:?}"),
-            other => eyre::bail!("unexpected token: {other:?}"),
+            TokenKind::Unknown => eyre::bail!("unexpected token: {:?}", tokens[i].src),
+            _ => eyre::bail!("unexpected token: {:?}", tokens[i]),
         }
     }
     Ok(items)
@@ -551,8 +586,8 @@ fn expect_number_u8(
 ) -> Result<u8> {
     let tok = tokens.get(*i).ok_or_else(|| eyre::eyre!("missing immediate for opcode {ctx}"))?;
     *i += 1;
-    match tok {
-        Token::Number(n) => {
+    match &tok.kind {
+        TokenKind::Number(n) => {
             let v: u64 =
                 n.try_into().map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))?;
             u8::try_from(v).map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))
@@ -569,10 +604,10 @@ fn expect_imm<'a>(
 ) -> Result<Imm<'a>> {
     let tok = tokens.get(*i).ok_or_else(|| eyre::eyre!("missing immediate for opcode {ctx}"))?;
     *i += 1;
-    match tok {
-        Token::Number(n) => Ok(Imm::Number(*n)),
-        Token::LabelRef(name) => Ok(Imm::Label(name)),
-        other => eyre::bail!("expected immediate for {ctx}, got {other:?}"),
+    match &tok.kind {
+        TokenKind::Number(n) => Ok(Imm::Number(*n)),
+        TokenKind::LabelRef => Ok(Imm::Label(tok.src)),
+        _ => eyre::bail!("expected immediate for {ctx}, got {tok:?}"),
     }
 }
 

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -1,8 +1,13 @@
-use super::{Bytecode, Inst, InstData, InstFlags, bitvec_as_bytes, passes::block_analysis::Block};
+use super::{
+    Bytecode, Inst, InstData, InstFlags,
+    asm::{TokenKind, Tokenizer},
+    bitvec_as_bytes,
+    passes::block_analysis::Block,
+};
 use oxc_index::{IndexVec, index_vec};
 use revm_bytecode::opcode as op;
 use revm_primitives::hex;
-use std::{borrow::Cow, fmt, fmt::Write};
+use std::{borrow::Cow, fmt, fmt::Write, io::IsTerminal};
 
 impl Bytecode<'_> {
     /// Resolves a jump target instruction to its CFG block index.
@@ -77,26 +82,27 @@ impl Bytecode<'_> {
                 let opcode = data.to_op_in(self);
                 write!(text, "{opcode}").unwrap();
                 if data.flags.contains(InstFlags::INVALID_JUMP) {
-                    text.push_str(" INVALID");
+                    text.push_str(" %invalid");
                 } else if data.flags.contains(InstFlags::MULTI_JUMP) {
                     if let Some(targets) = self.multi_jump_targets(inst) {
-                        text.push(' ');
                         for (i, &t) in targets.iter().enumerate() {
                             if i > 0 {
-                                text.push_str(", ");
+                                text.push(',');
                             }
                             match self.target_block(t) {
-                                Some(b) => write!(text, " {b}").unwrap(),
-                                None => write!(text, " inst {t}").unwrap(),
+                                Some(b) => write!(text, " %{b}").unwrap(),
+                                None => write!(text, " %inst{t}").unwrap(),
                             }
                         }
                     }
                 } else if data.is_static_jump() {
                     let target = Inst::from_usize(data.data as usize);
                     match self.target_block(target) {
-                        Some(b) => write!(text, " {b}").unwrap(),
-                        None => write!(text, " inst {target}").unwrap(),
+                        Some(b) => write!(text, " %{b}").unwrap(),
+                        None => write!(text, " %inst{target}").unwrap(),
                     }
+                } else if data.is_jump() {
+                    text.push_str(" %dynamic");
                 }
 
                 // Comment with ic, pc, and flags/behavior.
@@ -147,13 +153,10 @@ impl Bytecode<'_> {
         *self.inst_lines.borrow_mut() = inst_lines;
         lines
     }
-}
 
-impl fmt::Display for Bytecode<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /// Formats the bytecode IR as plain text.
+    fn display_plain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let lines = self.collect_lines();
-
-        // Find max text width and write with aligned comments.
         let max_text_width = lines.iter().map(|(t, _)| t.len()).max().unwrap_or(0);
         let comment_col = max_text_width.clamp(4, 20);
         for (text, comment) in &lines {
@@ -165,8 +168,101 @@ impl fmt::Display for Bytecode<'_> {
                 writeln!(f, "{text:<comment_col$} ; {comment}")?;
             }
         }
-
         Ok(())
+    }
+
+    /// Formats the bytecode IR with ANSI syntax highlighting.
+    ///
+    /// Builds the plain-text output first, then runs it through the asm
+    /// tokenizer and emits colored spans.
+    fn display_colored(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let plain = format!("{}", std::fmt::from_fn(|f| self.display_plain(f)));
+        colorize(f, &plain)
+    }
+}
+
+impl fmt::Display for Bytecode<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() && std::io::stdout().is_terminal() {
+            self.display_colored(f)
+        } else {
+            self.display_plain(f)
+        }
+    }
+}
+
+// ———————————————————————————————————————————————————————————————————————
+// Colorizer (uses asm::Tokenizer)
+// ———————————————————————————————————————————————————————————————————————
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const CYAN: &str = "\x1b[36m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RED: &str = "\x1b[31m";
+const BLUE: &str = "\x1b[34m";
+const WHITE: &str = "\x1b[37m";
+
+/// Writes ANSI-colored output by tokenizing `plain` with the asm tokenizer.
+fn colorize(f: &mut fmt::Formatter<'_>, plain: &str) -> fmt::Result {
+    for token in Tokenizer::new(plain) {
+        let s = token.src;
+        match token.kind {
+            TokenKind::Whitespace => write!(f, "{s}")?,
+            TokenKind::Label => write!(f, "{BOLD}{CYAN}{s}:{RESET}")?,
+            TokenKind::Comment => write!(f, "{DIM}{s}{RESET}")?,
+            TokenKind::Number(_) => write!(f, "{YELLOW}{s}{RESET}")?,
+            TokenKind::LabelRef if s == "dynamic" => write!(f, "{RED}%{s}{RESET}")?,
+            TokenKind::LabelRef => write!(f, "{CYAN}%{s}{RESET}")?,
+            TokenKind::Ident => {
+                let color = opcode_color(s);
+                write!(f, "{BOLD}{color}{s}{RESET}")?;
+            }
+            TokenKind::Comma => write!(f, ",")?,
+            TokenKind::Unknown => write!(f, "{s}")?,
+            TokenKind::LParen | TokenKind::RParen | TokenKind::ParamRef => {}
+        }
+    }
+    Ok(())
+}
+
+/// Returns the ANSI color for an opcode name based on its byte-value category.
+fn opcode_color(name: &str) -> &'static str {
+    use revm_bytecode::opcode::OpCode;
+    let byte = match OpCode::parse(name) {
+        Some(op) => op.get(),
+        // Bare "PUSH" without a number suffix.
+        None if name == "PUSH" => op::PUSH32,
+        None => return WHITE,
+    };
+    opcode_color_by_byte(byte)
+}
+
+fn opcode_color_by_byte(byte: u8) -> &'static str {
+    use op::*;
+    match byte {
+        // Terminating.
+        STOP | RETURN | REVERT | INVALID | SELFDESTRUCT => RED,
+        // Side effects: jumps, calls, creates, log.
+        JUMP
+        | JUMPI
+        | JUMPDEST
+        | CREATE
+        | CALL
+        | CALLCODE
+        | DELEGATECALL
+        | CREATE2
+        | STATICCALL
+        | LOG0..=LOG4 => GREEN,
+        // Arithmetic, comparison, bitwise, keccak.
+        ADD..=SIGNEXTEND | LT..=CLZ | KECCAK256 => WHITE,
+        // I/O: environment, memory, storage.
+        ADDRESS..=SLOTNUM | MLOAD..=MCOPY => BLUE,
+        // Stack: POP, PUSH, DUP, SWAP, EOF stack ops.
+        POP | PUSH0..=SWAP16 | DUPN | SWAPN | EXCHANGE => YELLOW,
+        _ => WHITE,
     }
 }
 
@@ -452,7 +548,7 @@ mod tests {
 
 bb0:           ; stack_in=0 max_growth=1
   PUSH1 0x03   ; ic= 0 pc= 0 gas=11 noop
-  JUMP bb1     ; ic= 1 pc= 2
+  JUMP %bb1    ; ic= 1 pc= 2
 
 bb1:           ; stack_in=0 max_growth=2
   JUMPDEST     ; ic= 2 pc= 3 gas=7 reachable
@@ -461,7 +557,7 @@ bb1:           ; stack_in=0 max_growth=2
   SSTORE       ; ic= 5 pc= 8
   PUSH1 0x01   ; ic= 6 pc= 9 gas=16 noop
   PUSH1 0x03   ; ic= 7 pc=11 noop
-  JUMPI bb1    ; ic= 8 pc=13
+  JUMPI %bb1   ; ic= 8 pc=13
 
 bb2:           ; stack_in=0 max_growth=7
   PUSH1 0x00   ; ic= 9 pc=14 gas=121
@@ -477,6 +573,34 @@ bb2:           ; stack_in=0 max_growth=7
 
 "#]]
         );
+    }
+
+    #[test]
+    fn display_roundtrip() {
+        let bytecode = test_bytecode();
+        let displayed = format!("{bytecode}");
+
+        // Strip the resolved jump-target refs (e.g. ` %bb1`) from JUMP/JUMPI
+        // lines — these are display metadata, not asm operands.
+        let stripped: String = displayed
+            .lines()
+            .map(|line| {
+                let (before_comment, comment) = line.split_once(';').unwrap_or((line, ""));
+                let cleaned = before_comment
+                    .replace(" %bb", " ; %bb")
+                    .replace(" %dynamic", " ; %dynamic")
+                    .replace(" %invalid", " ; %invalid");
+                if comment.is_empty() {
+                    format!("{cleaned}\n")
+                } else {
+                    format!("{cleaned};{comment}\n")
+                }
+            })
+            .collect();
+
+        println!("{stripped}");
+        let reparsed = crate::parse_asm(&stripped).unwrap();
+        assert_eq!(reparsed, bytecode.code.as_ref(), "display output did not roundtrip");
     }
 
     #[test]


### PR DESCRIPTION
Add terminal syntax highlighting when displaying bytecode IR on a TTY. The colored output is triggered by the alternate Display format (`{:#}`).

Refactor `Token` from an enum with data in each variant into a struct with `src`/`kind` fields. The tokenizer now always emits whitespace and comment tokens; callers that don't need them filter them out. This removes the `preserve` flag and `NumberRaw` variant.

Coloring: opcodes by category (arithmetic=green, memory=yellow, control=red, etc.), labels in cyan, numbers in yellow, comments dimmed, dynamic jump refs in red.

<img width="548" height="938" alt="image" src="https://github.com/user-attachments/assets/eda7beab-ae6a-4a17-8ff7-74ada4286e5d" />
