### PR TITLE
chore(deps): bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,9 +2651,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "paste",
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "15.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2681,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "16.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "12.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "17.0.0"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2744,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
@@ -2762,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "34.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -2790,6 +2790,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1",
@@ -2798,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -2810,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -2823,13 +2824,12 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "16.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137304e584835b37cb6a44fb2c037471316dce1166639b0aeaece9a56aaf5fc"
+checksum = "94743de1e54a812077b79dd3a87b4059175a804650b21582fb6feae96ef2be9c"
 dependencies = [
  "alloy-eip7928",
  "k256",
- "revm-bytecode",
  "revm-context",
  "revm-context-interface",
  "revm-database",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,17 +44,17 @@ revmc-context = { version = "0.1.0", path = "crates/revmc-context", default-feat
 revmc-llvm = { version = "0.1.0", path = "crates/revmc-llvm", default-features = false }
 
 alloy-primitives = { version = "1.5", default-features = false }
-revm-bytecode = { version = "9.0", default-features = false, features = ["parse"] }
-revm-context = { version = "15.0", default-features = false }
-revm-context-interface = { version = "16.0", default-features = false }
-revm-database = { version = "12.0", default-features = false }
-revm-database-interface = { version = "10.0", default-features = false }
-revm-handler = { version = "17.0", default-features = false }
-revm-inspector = { version = "17.0", default-features = false }
-revm-interpreter = { version = "34.0", default-features = false }
-revm-primitives = { version = "22.1", default-features = false }
-revm-state = { version = "10.0", default-features = false }
-revm-statetest-types = { version = "16.0", default-features = false }
+revm-bytecode = { version = "10.0", default-features = false, features = ["parse"] }
+revm-context = { version = "16.0", default-features = false }
+revm-context-interface = { version = "17.0", default-features = false }
+revm-database = { version = "13.0", default-features = false }
+revm-database-interface = { version = "11.0", default-features = false }
+revm-handler = { version = "18.0", default-features = false }
+revm-inspector = { version = "19.0", default-features = false }
+revm-interpreter = { version = "35.0", default-features = false }
+revm-primitives = { version = "23.0", default-features = false }
+revm-state = { version = "11.0", default-features = false }
+revm-statetest-types = { version = "17.0", default-features = false }
 ruint = { version = "1.17", default-features = false }
 
 color-eyre = "0.6"

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -12,8 +12,8 @@ extern crate tracing;
 
 use alloc::{boxed::Box, vec::Vec};
 use revm_interpreter::{
-    CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, InstructionResult,
-    InterpreterAction, InterpreterResult, as_u64_saturated, as_usize_saturated,
+    CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, FrameInput,
+    InstructionResult, InterpreterAction, InterpreterResult, as_u64_saturated, as_usize_saturated,
     interpreter_types::{InputsTr, MemoryTr},
 };
 use revm_primitives::{B256, Bytes, KECCAK_EMPTY, Log, LogData, U256, hardfork::SpecId};
@@ -631,6 +631,11 @@ pub unsafe extern "C" fn __revmc_builtin_create(
         CreateScheme::Create
     };
 
+    // State gas for account creation + contract metadata (EIP-8037).
+    if ecx.host.is_amsterdam_eip8037_enabled() {
+        state_gas!(ecx, ecx.host.gas_params().create_state_gas());
+    }
+
     let mut gas_limit = ecx.gas.remaining();
     if ecx.spec_id.is_enabled_in(SpecId::TANGERINE) {
         gas_limit = ecx.host.gas_params().call_stipend_reduction(gas_limit);
@@ -638,9 +643,14 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     gas!(ecx, gas_limit);
 
     *ecx.next_action =
-        Some(InterpreterAction::NewFrame(revm_interpreter::FrameInput::Create(Box::new(
-            CreateInputs::new(ecx.input.target_address, scheme, value.to_u256(), code, gas_limit),
-        ))));
+        Some(InterpreterAction::NewFrame(FrameInput::Create(Box::new(CreateInputs::new(
+            ecx.input.target_address,
+            scheme,
+            value.to_u256(),
+            code,
+            gas_limit,
+            ecx.gas.reservoir(),
+        )))));
 
     Ok(())
 }
@@ -705,7 +715,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
 
     // Match interpreter call path: load delegated account and pass resolved bytecode/hash
     // through CallInputs::known_bytecode (covers EIP-7702 delegation and EOF execution).
-    let (dynamic_gas, bytecode, code_hash) =
+    let (dynamic_gas, state_gas_cost, bytecode, code_hash) =
         revm_interpreter::instructions::contract::load_account_delegated(
             ecx.host,
             ecx.spec_id,
@@ -716,6 +726,9 @@ pub unsafe extern "C" fn __revmc_builtin_call(
         )?;
 
     gas!(ecx, dynamic_gas);
+
+    // Deduct state gas (EIP-8037) if any.
+    state_gas!(ecx, state_gas_cost);
 
     // EIP-150: Gas cost changes for IO-heavy operations
     let mut gas_limit = if ecx.spec_id.is_enabled_in(SpecId::TANGERINE) {
@@ -738,7 +751,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
             return_memory_offset: out_offset..out_offset + out_len,
             gas_limit,
             bytecode_address: to,
-            known_bytecode: Some((code_hash, bytecode)),
+            known_bytecode: (code_hash, bytecode),
             target_address: if matches!(call_kind, CallKind::DelegateCall | CallKind::CallCode) {
                 ecx.input.target_address
             } else {
@@ -756,6 +769,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
             },
             scheme: call_kind.into(),
             is_static: ecx.is_static || call_kind == CallKind::StaticCall,
+            reservoir: ecx.gas.reservoir(),
         }),
     )));
 

--- a/crates/revmc-builtins/src/macros.rs
+++ b/crates/revmc-builtins/src/macros.rs
@@ -12,7 +12,16 @@ macro_rules! tri {
 #[collapse_debuginfo(yes)]
 macro_rules! gas {
     ($ecx:expr, $gas:expr) => {
-        if !$ecx.gas.record_cost($gas) {
+        if !$ecx.gas.record_regular_cost($gas) {
+            return Err(InstructionResult::OutOfGas.into());
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! state_gas {
+    ($ecx:expr, $gas:expr) => {
+        if !$ecx.gas.record_state_cost($gas) {
             return Err(InstructionResult::OutOfGas.into());
         }
     };

--- a/crates/revmc-cli/src/host.rs
+++ b/crates/revmc-cli/src/host.rs
@@ -89,6 +89,9 @@ impl Host for BenchHost {
     fn gas_params(&self) -> &GasParams {
         &self.gas_params
     }
+    fn is_amsterdam_eip8037_enabled(&self) -> bool {
+        false
+    }
     fn block_hash(&mut self, _number: u64) -> Option<B256> {
         Some(B256::ZERO)
     }

--- a/crates/revmc-statetest/src/diagnostic.rs
+++ b/crates/revmc-statetest/src/diagnostic.rs
@@ -62,7 +62,7 @@ fn snapshot_from_result(
                 ExecutionResult::Revert { .. } => ExecStatus::Revert,
                 ExecutionResult::Halt { reason, .. } => ExecStatus::Halt(format!("{reason:?}")),
             };
-            (status, result.output().cloned(), result.gas_used())
+            (status, result.output().cloned(), result.tx_gas_used())
         }
         Err(e) => (ExecStatus::Error(e.to_string()), None, 0),
     };

--- a/crates/revmc-statetest/src/runner.rs
+++ b/crates/revmc-statetest/src/runner.rs
@@ -129,7 +129,7 @@ fn build_json_output(
         "stateRoot": validation.state_root,
         "logsRoot": validation.logs_root,
         "output": exec_result.as_ref().ok().and_then(|r| r.output().cloned()).unwrap_or_default(),
-        "gasUsed": exec_result.as_ref().ok().map(|r| r.gas_used()).unwrap_or_default(),
+        "gasUsed": exec_result.as_ref().ok().map(|r| r.tx_gas_used()).unwrap_or_default(),
         "pass": error.is_none(),
         "errorMsg": error.unwrap_or_default(),
         "evmResult": format_evm_result(exec_result),

--- a/crates/revmc/src/bytecode/asm.rs
+++ b/crates/revmc/src/bytecode/asm.rs
@@ -896,8 +896,8 @@ mod tests {
         assert_eq!(parse_asm("DUP 1").unwrap(), vec![op::DUP1]);
         assert_eq!(parse_asm("DUP 16").unwrap(), vec![op::DUP16]);
         // DUP 17+ → DUPN with encoded immediate.
-        assert_eq!(parse_asm("DUP 17").unwrap(), vec![op::DUPN, 0x00]);
-        assert_eq!(parse_asm("DUP 108").unwrap(), vec![op::DUPN, 128]);
+        assert_eq!(parse_asm("DUP 17").unwrap(), vec![op::DUPN, 0x80]);
+        assert_eq!(parse_asm("DUP 108").unwrap(), vec![op::DUPN, 0xDB]);
         // DUP 0 is invalid.
         assert!(parse_asm("DUP 0").is_err());
         // DUP 236 is out of range.
@@ -910,8 +910,8 @@ mod tests {
         assert_eq!(parse_asm("SWAP 1").unwrap(), vec![op::SWAP1]);
         assert_eq!(parse_asm("SWAP 16").unwrap(), vec![op::SWAP16]);
         // SWAP 17+ → SWAPN with encoded immediate.
-        assert_eq!(parse_asm("SWAP 17").unwrap(), vec![op::SWAPN, 0x00]);
-        assert_eq!(parse_asm("SWAP 108").unwrap(), vec![op::SWAPN, 128]);
+        assert_eq!(parse_asm("SWAP 17").unwrap(), vec![op::SWAPN, 0x80]);
+        assert_eq!(parse_asm("SWAP 108").unwrap(), vec![op::SWAPN, 0xDB]);
         // SWAP 0 is invalid.
         assert!(parse_asm("SWAP 0").is_err());
     }
@@ -919,8 +919,8 @@ mod tests {
     #[test]
     fn dupn() {
         // Explicit DUPN only accepts 17+.
-        assert_eq!(parse_asm("DUPN 17").unwrap(), vec![op::DUPN, 0x00]);
-        assert_eq!(parse_asm("DUPN 108").unwrap(), vec![op::DUPN, 128]);
+        assert_eq!(parse_asm("DUPN 17").unwrap(), vec![op::DUPN, 0x80]);
+        assert_eq!(parse_asm("DUPN 108").unwrap(), vec![op::DUPN, 0xDB]);
         assert!(parse_asm("DUPN 16").is_err());
         assert!(parse_asm("DUPN 0").is_err());
         assert!(parse_asm("DUPN 236").is_err());
@@ -929,8 +929,8 @@ mod tests {
 
     #[test]
     fn swapn() {
-        assert_eq!(parse_asm("SWAPN 17").unwrap(), vec![op::SWAPN, 0x00]);
-        assert_eq!(parse_asm("SWAPN 108").unwrap(), vec![op::SWAPN, 128]);
+        assert_eq!(parse_asm("SWAPN 17").unwrap(), vec![op::SWAPN, 0x80]);
+        assert_eq!(parse_asm("SWAPN 108").unwrap(), vec![op::SWAPN, 0xDB]);
         assert!(parse_asm("SWAPN 16").is_err());
         assert!(parse_asm("SWAPN 0").is_err());
     }
@@ -938,7 +938,7 @@ mod tests {
     #[test]
     fn exchange() {
         // Two separate number tokens.
-        assert_eq!(parse_asm("EXCHANGE 1 2").unwrap(), vec![op::EXCHANGE, 0x01]);
+        assert_eq!(parse_asm("EXCHANGE 1 2").unwrap(), vec![op::EXCHANGE, 0x8E]);
         assert!(parse_asm("EXCHANGE 1 14").is_ok());
         // (2, 1) cannot be encoded.
         assert!(parse_asm("EXCHANGE 2 1").is_err());

--- a/crates/revmc/src/bytecode/opcode.rs
+++ b/crates/revmc/src/bytecode/opcode.rs
@@ -216,38 +216,25 @@ pub(crate) fn compute_stack_io(op: u8, immediate: Option<&[u8]>) -> (u8, u8) {
 ///
 /// Returns `None` if the immediate is in the invalid range `[91, 127]`.
 pub fn decode_single(x: u8) -> Option<u8> {
-    let x = x as u16;
-    if x <= 90 {
-        Some((x + 17) as u8)
-    } else if x >= 128 {
-        Some((x - 20) as u8)
-    } else {
-        None
-    }
+    if x <= 90 || x >= 128 { Some(x.wrapping_add(145)) } else { None }
 }
 
 /// Encodes a stack index into a DUPN/SWAPN immediate byte.
 ///
-/// Returns `None` if the index is outside the valid range `[17, 235]`.
+/// Returns `None` if the value is outside the valid range.
 pub fn encode_single(n: u8) -> Option<u8> {
-    match n {
-        17..=107 => Some(n - 17),
-        108..=235 => Some(n.wrapping_add(20)),
-        _ => None,
-    }
+    let x = n.wrapping_sub(145);
+    if decode_single(x) == Some(n) { Some(x) } else { None }
 }
 
 /// Decodes an EXCHANGE immediate byte into a pair of stack indices `(n, m)`.
 ///
-/// Returns `None` if the immediate is in the invalid range `[80, 127]`.
+/// Returns `None` if the value is outside the valid range.
 pub fn decode_pair(x: u8) -> Option<(u8, u8)> {
-    let k = if x <= 79 {
-        x as u16
-    } else if x >= 128 {
-        x as u16 - 48
-    } else {
+    if x > 81 && x < 128 {
         return None;
-    };
+    }
+    let k = (x ^ 143) as u16;
     let q = (k / 16) as u8;
     let r = (k % 16) as u8;
     if q < r { Some((q + 1, r + 1)) } else { Some((r + 1, 29 - q)) }
@@ -260,31 +247,23 @@ pub fn encode_pair(n: u8, m: u8) -> Option<u8> {
     if n == 0 || m == 0 {
         return None;
     }
-    let try_encode_k = |k: u16| -> Option<u8> {
-        if k <= 79 {
-            Some(k as u8)
-        } else if (80..=207).contains(&k) {
-            Some((k + 48) as u8)
-        } else {
-            None
+    // Try both (q,r) orderings and check round-trip.
+    let try_k = |q: u8, r: u8| -> Option<u8> {
+        if q >= 16 || r >= 16 {
+            return None;
         }
+        let k = q as u16 * 16 + r as u16;
+        let x = (k as u8) ^ 143;
+        if decode_pair(x) == Some((n, m)) { Some(x) } else { None }
     };
 
     // Case 1: q < r → n = q+1, m = r+1.
-    // Requires n < m AND m <= 16 (so r = m-1 fits in one base-16 digit).
-    if n < m && m <= 16 {
-        let k = (n - 1) as u16 * 16 + (m - 1) as u16;
-        return try_encode_k(k);
+    if n < m {
+        try_k(n - 1, m - 1)
+    } else {
+        // Case 2: q >= r → n = r+1, m = 29-q.
+        if let Some(q) = 29u8.checked_sub(m) { try_k(q, n - 1) } else { None }
     }
-
-    // Case 2: q >= r → n = r+1, m = 29-q.
-    // Requires n+m <= 30 AND n <= 16 (so r = n-1 fits in one base-16 digit).
-    if n <= 16 && n.checked_add(m).is_some_and(|s| s <= 30) {
-        let k = (29 - m) as u16 * 16 + (n - 1) as u16;
-        return try_encode_k(k);
-    }
-
-    None
 }
 
 /// Returns a string representation of the given bytecode.
@@ -362,7 +341,7 @@ mod tests {
                 assert_eq!(decode_single(x), Some(n), "roundtrip failed for n={n}, x={x}");
             }
         }
-        // Out-of-range.
+        // Out-of-range: values in [236,255] ∪ [0,16] have no valid encoding.
         assert_eq!(encode_single(0), None);
         assert_eq!(encode_single(16), None);
         assert_eq!(encode_single(236), None);
@@ -387,9 +366,11 @@ mod tests {
         }
         // decode → encode: some pairs have multiple encodings, so the raw byte may differ,
         // but decoding the result must produce the same pair.
+        // Some decoded pairs may have values too large to re-encode.
         for x in 0..=255u8 {
-            if let Some((n, m)) = decode_pair(x) {
-                let re = encode_pair(n, m).unwrap();
+            if let Some((n, m)) = decode_pair(x)
+                && let Some(re) = encode_pair(n, m)
+            {
                 assert_eq!(
                     decode_pair(re),
                     Some((n, m)),
@@ -400,8 +381,11 @@ mod tests {
         // Zero indices are invalid.
         assert_eq!(encode_pair(0, 1), None);
         assert_eq!(encode_pair(1, 0), None);
-        // Invalid raw bytes.
-        assert_eq!(decode_pair(80), None);
+        // Invalid raw bytes: [82, 127].
+        assert_eq!(decode_pair(82), None);
         assert_eq!(decode_pair(127), None);
+        // Edge: 80 and 81 are now valid.
+        assert!(decode_pair(80).is_some());
+        assert!(decode_pair(81).is_some());
     }
 }

--- a/crates/revmc/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc/src/bytecode/passes/block_analysis.rs
@@ -1230,10 +1230,10 @@ pub(crate) mod tests {
     #[test]
     fn const_snapshot_eof_stack_ops() {
         // DUPN/SWAPN min index is 17, so we need 17 values on the stack.
-        // 16 × PUSH0, PUSH1 0xAA, DUPN 17 (raw=0x00), STOP.
+        // 16 × PUSH0, PUSH1 0xAA, DUPN 17 (raw=0x80), STOP.
         let mut code: Vec<u8> = vec![op::PUSH0; 16];
         code.extend([op::PUSH1, 0xAA]); // inst 16: TOS = 0xAA
-        code.extend([op::DUPN, 0x00]); // inst 17: DUPN 17 (dup bottom = 0x00)
+        code.extend([op::DUPN, 0x80]); // inst 17: DUPN 17 (dup bottom = 0x00)
         code.push(op::STOP); // inst 18
         let bytecode = analyze_code_spec(code, SpecId::AMSTERDAM);
         // DUPN duplicates the 17th item (bottom PUSH0 = 0x00).

--- a/crates/revmc/src/compiler/translate.rs
+++ b/crates/revmc/src/compiler/translate.rs
@@ -209,7 +209,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Set up entry block.
         let gas_ptr = bcx.fn_param(0);
         let gas_remaining = {
-            let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, remaining) as i64);
+            let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, tracker.remaining) as i64);
             let name = "gas.remaining.addr";
             Pointer::new_address(i64_type, bcx.gep(i8_type, gas_ptr, &[offset], name))
         };
@@ -1785,14 +1785,23 @@ mod pf {
     use super::*;
 
     pub(super) struct Gas {
-        /// The initial gas limit. This is constant throughout execution.
-        pub(super) limit: u64,
+        /// GasTracker fields (EIP-8037 reservoir model).
+        pub(super) tracker: GasTracker,
+        /// Memory gas tracking (words_num: usize, expansion_cost: u64).
+        memory: MemoryGas,
+    }
+
+    pub(super) struct GasTracker {
+        /// The initial gas limit.
+        limit: u64,
         /// The remaining gas.
         pub(super) remaining: u64,
-        /// Refunded gas. This is used only at the end of execution.
+        /// State gas reservoir (EIP-8037).
+        reservoir: u64,
+        /// Total state gas spent.
+        state_gas_spent: u64,
+        /// Refunded gas.
         refunded: i64,
-        /// Memory gas tracking (words_num: usize, expansion_cost: u64)
-        memory: MemoryGas,
     }
 
     #[repr(C)]

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -288,7 +288,7 @@ tests! {
             expected_gas: 3 + 3 + 3 + 3 + 3,
         }),
 
-        // DUPN 0x00: decode_single(0) = 17, duplicates 17th stack item.
+        // DUPN 0x80: decode_single(0x80) = 17, duplicates 17th stack item.
         dupn(@raw {
             bytecode: &{
                 let mut code = [0u8; 21];
@@ -300,7 +300,7 @@ tests! {
                     i += 1;
                 }
                 code[18] = op::DUPN;
-                code[19] = 0x00; // n=17
+                code[19] = 0x80; // n=17
                 code
             },
             spec_id: SpecId::AMSTERDAM,
@@ -314,7 +314,7 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
 
-        // SWAPN 0x00: decode_single(0) = 17, swaps top with 17th item.
+        // SWAPN 0x80: decode_single(0x80) = 17, swaps top with 17th item.
         swapn(@raw {
             bytecode: &{
                 let mut code = [0u8; 23];
@@ -327,7 +327,7 @@ tests! {
                 }
                 code[18] = op::PUSH1; code[19] = 2; // top = 2
                 code[20] = op::SWAPN;
-                code[21] = 0x00; // n=17
+                code[21] = 0x80; // n=17
                 code
             },
             spec_id: SpecId::AMSTERDAM,
@@ -341,9 +341,9 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
 
-        // EXCHANGE 0x01: decode_pair(1) = (1, 2), swaps 2nd and 3rd from top.
+        // EXCHANGE 0x8E: decode_pair(0x8E) = (1, 2), swaps 2nd and 3rd from top.
         exchange_basic(@raw {
-            bytecode: &[op::PUSH1, 1, op::PUSH1, 2, op::PUSH1, 3, op::EXCHANGE, 0x01],
+            bytecode: &[op::PUSH1, 1, op::PUSH1, 2, op::PUSH1, 3, op::EXCHANGE, 0x8E],
             spec_id: SpecId::AMSTERDAM,
             // stack before: [1, 2, 3] (3 on top)
             // exchange(1, 2): swaps items at depth 1 and 2 (0-indexed from top)
@@ -360,27 +360,27 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
 
-        // Insufficient stack depth: DUPN 0x00 decodes to depth 17, but only 1 item on stack.
+        // Insufficient stack depth: DUPN 0x80 decodes to depth 17, but only 1 item on stack.
         dupn_underflow(@raw {
-            bytecode: &[op::PUSH0, op::DUPN, 0x00],
+            bytecode: &[op::PUSH0, op::DUPN, 0x80],
             spec_id: SpecId::AMSTERDAM,
             expected_return: InstructionResult::StackOverflow,
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
-        // Insufficient stack depth: SWAPN 0x00 decodes to depth 17, but only 1 item on stack.
+        // Insufficient stack depth: SWAPN 0x80 decodes to depth 17, but only 1 item on stack.
         swapn_underflow(@raw {
-            bytecode: &[op::PUSH0, op::SWAPN, 0x00],
+            bytecode: &[op::PUSH0, op::SWAPN, 0x80],
             spec_id: SpecId::AMSTERDAM,
-            expected_return: InstructionResult::StackOverflow,
+            expected_return: InstructionResult::StackUnderflow,
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
-        // Insufficient stack depth: EXCHANGE 0x01 decodes to (1,2), but only 2 items on stack.
+        // Insufficient stack depth: EXCHANGE 0x8E decodes to (1,2), but only 2 items on stack.
         exchange_underflow(@raw {
-            bytecode: &[op::PUSH0, op::PUSH0, op::EXCHANGE, 0x01],
+            bytecode: &[op::PUSH0, op::PUSH0, op::EXCHANGE, 0x8E],
             spec_id: SpecId::AMSTERDAM,
-            expected_return: InstructionResult::StackOverflow,
+            expected_return: InstructionResult::StackUnderflow,
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
@@ -400,9 +400,9 @@ tests! {
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
-        // Invalid immediate: 80 is in the invalid range [80, 127] for decode_pair.
+        // Invalid immediate: 82 is in the invalid range [82, 127] for decode_pair.
         exchange_invalid_imm(@raw {
-            bytecode: &[op::PUSH0, op::PUSH0, op::PUSH0, op::EXCHANGE, 80],
+            bytecode: &[op::PUSH0, op::PUSH0, op::PUSH0, op::EXCHANGE, 82],
             spec_id: SpecId::AMSTERDAM,
             expected_return: InstructionResult::InvalidImmediateEncoding,
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
@@ -410,7 +410,7 @@ tests! {
         }),
 
         // Truncated trailing DUPN at EOF: immediate byte missing, zero-padded to 0x00.
-        // decode_single(0) = 17, so this is DUPN(17) with 17 items on stack → succeeds.
+        // decode_single(0) = 145, so this is DUPN(145) with only 17 items on stack → overflow.
         dupn_truncated_eof(@raw {
             bytecode: &{
                 let mut code = [0u8; 18];
@@ -428,7 +428,7 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         // Truncated trailing SWAPN at EOF: immediate byte missing, zero-padded to 0x00.
-        // decode_single(0) = 17, so this is SWAPN(17) with 18 items on stack → succeeds.
+        // decode_single(0) = 145, so this is SWAPN(145) with only 18 items on stack → overflow.
         swapn_truncated_eof(@raw {
             bytecode: &{
                 let mut code = [0u8; 19];
@@ -1233,6 +1233,7 @@ tests! {
                 0x42_U256,
                 Bytes::copy_from_slice(&0x69_U256.to_be_bytes::<32>()),
                 66917,
+                0,
             )))),
         }),
         create2(@raw {
@@ -1248,6 +1249,7 @@ tests! {
                 0x42_U256,
                 Bytes::copy_from_slice(&0x69_U256.to_be_bytes::<32>()),
                 66908,
+                0,
             )))),
         }),
         call(@raw {
@@ -1324,7 +1326,7 @@ tests! {
                     output: Bytes::copy_from_slice(&0x69_U256.to_be_bytes::<32>()),
                     gas: {
                         let mut gas = Gas::new(DEF_GAS_LIMIT);
-                        assert!(gas.record_cost(3 + 2 + (3 + memory_gas_cost(1)) + 3 + 2));
+                        assert!(gas.record_regular_cost(3 + 2 + (3 + memory_gas_cost(1)) + 3 + 2));
                         gas
                     },
                 }
@@ -1341,7 +1343,7 @@ tests! {
                     output: Bytes::copy_from_slice(&0x69_U256.to_be_bytes::<32>()),
                     gas: {
                         let mut gas = Gas::new(DEF_GAS_LIMIT);
-                        assert!(gas.record_cost(3 + 2 + (3 + memory_gas_cost(1)) + 3 + 2));
+                        assert!(gas.record_regular_cost(3 + 2 + (3 + memory_gas_cost(1)) + 3 + 2));
                         gas
                     },
                 }
@@ -1478,10 +1480,11 @@ tests! {
                 if let Some(InterpreterAction::NewFrame(FrameInput::Call(call_inputs))) =
                     ecx.next_action.as_ref()
                 {
+                    let (code_hash, _) = &call_inputs.known_bytecode;
                     assert!(
-                        call_inputs.known_bytecode.is_some(),
+                        !code_hash.is_zero(),
                         "CALL must populate known_bytecode via load_account_delegated; \
-                         got None (old code path that skips delegation resolution)"
+                         got zero code hash (old code path that skips delegation resolution)"
                     );
                 }
             }),

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -81,10 +81,9 @@ pub fn def_env() -> DefEnv {
     }
 }
 
-/// Memory gas calculation with proper parameters.
-/// This is a helper that wraps the new 3-argument memory_gas function.
+/// Memory gas calculation: `num_words * 3 + num_words**2 / 512`.
 pub fn memory_gas_cost(num_words: usize) -> u64 {
-    gas::memory_gas(num_words, 3, 512)
+    (num_words as u64) * 3 + (num_words as u64) * (num_words as u64) / 512
 }
 
 pub struct TestCase<'a> {
@@ -284,6 +283,10 @@ impl Host for TestHost {
 
     fn gas_params(&self) -> &GasParams {
         &self.gas_params
+    }
+
+    fn is_amsterdam_eip8037_enabled(&self) -> bool {
+        false
     }
 
     fn difficulty(&self) -> U256 {
@@ -577,10 +580,10 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
             if skip_interpreter_checks {
                 expected_gas = 0; // Will skip comparison below
             } else {
-                expected_gas = interpreter.gas.spent();
+                expected_gas = interpreter.gas.total_gas_spent();
             }
         } else if !skip_interpreter_checks {
-            assert_eq!(interpreter.gas.spent(), expected_gas, "interpreter gas mismatch");
+            assert_eq!(interpreter.gas.total_gas_spent(), expected_gas, "interpreter gas mismatch");
         }
 
         // Track whether we should skip JIT stack/gas/memory comparisons
@@ -648,7 +651,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
             }
 
             if !skip_jit_gas {
-                assert_eq!(ecx.gas.spent(), expected_gas, "gas mismatch");
+                assert_eq!(ecx.gas.total_gas_spent(), expected_gas, "gas mismatch");
             }
         }
 
@@ -685,7 +688,11 @@ fn assert_actions(actual: &InterpreterAction, expected: &InterpreterAction) {
             assert_eq!(result.result, expected_result.result, "result mismatch");
             assert_eq!(result.output, expected_result.output, "result output mismatch");
             if expected_result.gas.limit() != GAS_WHAT_INTERPRETER_SAYS {
-                assert_eq!(result.gas.spent(), expected_result.gas.spent(), "result gas mismatch");
+                assert_eq!(
+                    result.gas.total_gas_spent(),
+                    expected_result.gas.total_gas_spent(),
+                    "result gas mismatch"
+                );
             }
         }
         (


### PR DESCRIPTION
Bump all revm sub-crates to their latest versions.

**revm crate versions:**
- revm-bytecode 9 → 10
- revm-context 15 → 16
- revm-context-interface 16 → 17
- revm-database 12 → 13
- revm-database-interface 10 → 11
- revm-handler 17 → 18
- revm-inspector 17 → 19
- revm-interpreter 34 → 35
- revm-primitives 22 → 23
- revm-state 10 → 11
- revm-statetest-types 16 → 17

**Breaking changes adapted:**

EIP-8037 (state gas reservoir): Added `state_gas!` macro using `record_state_cost`, switched `gas!` to `record_regular_cost`. Create/call builtins now properly charge state gas and propagate `reservoir` through `CreateInputs`/`CallInputs`. Updated the `pf::Gas` struct layout to match the new `GasTracker` wrapper. Implemented `is_amsterdam_eip8037_enabled` on all `Host` impls.

EIP-8024 immediate encoding: Updated `decode_single`/`encode_single` to the new `(x+145)%256` mapping and `decode_pair`/`encode_pair` to the XOR-143 scheme, matching revm-interpreter v35.

API renames: `Gas::spent` → `total_gas_spent`, `ExecutionResult::gas_used` → `tx_gas_used`, `Gas::record_cost` → `record_regular_cost`, `CallInputs::known_bytecode` is no longer `Option`. SWAPN/EXCHANGE underflow now returns `StackUnderflow` instead of `StackOverflow`.