### PR TITLE
chore(scripts): rewrite shell scripts as Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ clif
 /tests/GeneralStateTests
 /tests/BlockchainTests
 /test-fixtures
+/scripts/__pycache__

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ RUST_LOG=debug cargo r -- run usdc_proxy --display |& rg 'jump|JUMP'
 To get a summary across all benchmarks:
 
 ```bash
-./scripts/jump-resolution.sh                  # all benchmarks
-./scripts/jump-resolution.sh usdc_proxy weth  # specific benchmarks
+./scripts/jump-resolution.py                  # all benchmarks
+./scripts/jump-resolution.py usdc_proxy weth  # specific benchmarks
 ```
 
 Use `cargo r -- run --list` to see available benchmark names.
@@ -73,9 +73,9 @@ Use `cargo r -- run --list` to see available benchmark names.
 To compare LLVM IR and assembly line counts against another revision:
 
 ```bash
-./scripts/codegen-lines.sh /tmp/dump --diff main                # all benchmarks vs main
-./scripts/codegen-lines.sh /tmp/dump --diff main usdc_proxy     # specific benchmarks
-./scripts/codegen-lines.sh /tmp/dump                            # line counts only (no diff)
+./scripts/codegen-lines.py /tmp/dump --diff main                # all benchmarks vs main
+./scripts/codegen-lines.py /tmp/dump --diff main usdc_proxy     # specific benchmarks
+./scripts/codegen-lines.py /tmp/dump                            # line counts only (no diff)
 ```
 
 ## Important

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -344,6 +344,8 @@ impl<'a> Bytecode<'a> {
             "constant folding gas budget",
         );
 
+        self.log_const_input_stats();
+
         Ok(())
     }
 
@@ -515,6 +517,97 @@ impl<'a> Bytecode<'a> {
     pub(crate) fn const_output(&self, inst: Inst) -> Option<U256> {
         let idx = self.snapshots.outputs[inst]?.as_const()?;
         Some(*self.u256_interner.borrow().get(idx))
+    }
+
+    /// Logs per-opcode constant-input statistics at trace level.
+    fn log_const_input_stats(&self) {
+        use revm_bytecode::opcode::OpCode;
+        use std::fmt::Write;
+
+        if !tracing::enabled!(tracing::Level::TRACE) {
+            return;
+        }
+
+        // per_input[depth] = [total, const_count, fits_usize_count].
+        struct Entry {
+            inputs: usize,
+            outputs: usize,
+            total: u32,
+            all_const: u32,
+            const_output: u32,
+            per_input: Vec<[u32; 3]>,
+        }
+        let mut stats: Vec<Option<Entry>> = (0..256).map(|_| None).collect();
+        for (inst, data) in self.iter_insts() {
+            let (inputs, outputs) = data.stack_io();
+            if inputs == 0
+                || matches!(data.opcode, op::DUP1..=op::DUP16 | op::SWAP1..=op::SWAP16 | op::DUPN | op::SWAPN)
+            {
+                continue;
+            }
+            let entry = stats[data.opcode as usize].get_or_insert_with(|| Entry {
+                inputs: inputs as usize,
+                outputs: outputs as usize,
+                total: 0,
+                all_const: 0,
+                const_output: 0,
+                per_input: vec![[0u32; 3]; inputs as usize],
+            });
+            entry.total += 1;
+            let mut all = true;
+            for depth in 0..inputs as usize {
+                entry.per_input[depth][0] += 1;
+                if let Some(val) = self.const_operand(inst, depth) {
+                    entry.per_input[depth][1] += 1;
+                    if val <= U256::from(usize::MAX) {
+                        entry.per_input[depth][2] += 1;
+                    }
+                } else {
+                    all = false;
+                }
+            }
+            if all {
+                entry.all_const += 1;
+            }
+            if self.const_output(inst).is_some() {
+                entry.const_output += 1;
+            }
+        }
+
+        let mut buf = String::from("const input stats:");
+        for (opcode, entry) in stats.iter().enumerate() {
+            let Some(entry) = entry else { continue };
+            if entry.total == 0 {
+                continue;
+            }
+            let name = OpCode::new(opcode as u8)
+                .map_or_else(|| format!("0x{opcode:02x}"), |o| o.as_str().to_string());
+            let all_pct = entry.all_const as f64 / entry.total as f64 * 100.0;
+            let _ = write!(
+                buf,
+                "\n  {name:<16} 0x{opcode:02x}, {total} occ, {inputs} inputs, all_const={ac}/{total} ({all_pct:.0}%)",
+                opcode = opcode,
+                total = entry.total,
+                inputs = entry.inputs,
+                ac = entry.all_const,
+            );
+            if entry.outputs > 0 {
+                let co = entry.const_output;
+                let co_pct = co as f64 / entry.total as f64 * 100.0;
+                let _ = write!(buf, ", const_output={co}/{t} ({co_pct:.0}%)", t = entry.total);
+            }
+            for (i, [t, c, usize_c]) in entry.per_input.iter().enumerate() {
+                if *t > 0 {
+                    let pct = *c as f64 / *t as f64 * 100.0;
+                    let usize_pct = *usize_c as f64 / *t as f64 * 100.0;
+                    let _ = write!(
+                        buf,
+                        "\n    [{i}]: const={c}/{t} ({pct:.0}%), fits_usize={usize_c}/{t} ({usize_pct:.0}%)",
+                    );
+                }
+            }
+        }
+        trace!("{buf}");
     }
 
     /// Returns the name for a basic block.

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -344,7 +344,7 @@ impl<'a> Bytecode<'a> {
             "constant folding gas budget",
         );
 
-        if !tracing::enabled!(tracing::Level::TRACE) {
+        if tracing::enabled!(tracing::Level::TRACE) {
             self.log_const_input_stats();
         }
 

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -3,7 +3,7 @@
 use crate::FxHashMap;
 use bitvec::vec::BitVec;
 use oxc_index::IndexVec;
-use revm_bytecode::opcode as op;
+use revm_bytecode::{opcode as op, opcode::OpCode};
 use revm_primitives::{U256, hardfork::SpecId};
 use revmc_backend::Result;
 use smallvec::SmallVec;
@@ -344,7 +344,9 @@ impl<'a> Bytecode<'a> {
             "constant folding gas budget",
         );
 
-        self.log_const_input_stats();
+        if !tracing::enabled!(tracing::Level::TRACE) {
+            self.log_const_input_stats();
+        }
 
         Ok(())
     }
@@ -520,13 +522,9 @@ impl<'a> Bytecode<'a> {
     }
 
     /// Logs per-opcode constant-input statistics at trace level.
+    #[inline(never)]
     fn log_const_input_stats(&self) {
-        use revm_bytecode::opcode::OpCode;
         use std::fmt::Write;
-
-        if !tracing::enabled!(tracing::Level::TRACE) {
-            return;
-        }
 
         // per_input[depth] = [total, const_count, fits_usize_count].
         struct Entry {
@@ -537,7 +535,7 @@ impl<'a> Bytecode<'a> {
             const_output: u32,
             per_input: Vec<[u32; 3]>,
         }
-        let mut stats: Vec<Option<Entry>> = (0..256).map(|_| None).collect();
+        let mut stats = [const { None }; 256];
         for (inst, data) in self.iter_insts() {
             let (inputs, outputs) = data.stack_io();
             if inputs == 0

--- a/scripts/codegen-lines.py
+++ b/scripts/codegen-lines.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["tqdm>=4.67.3"]
+# ///
+"""Reports line counts of generated LLVM IR and assembly for all benchmarks."""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from tqdm import tqdm
+
+from utils import get_benches, repo_root, run_cargo
+
+
+def collect(benches: list[str], dump_dir: str, root: str):
+    subprocess.run(
+        ["cargo", "build", "--quiet"],
+        capture_output=True,
+        cwd=root,
+    )
+    for bench in tqdm(benches, desc="Collecting", unit="bench", file=sys.stderr):
+        bench_dir = os.path.join(dump_dir, bench)
+        if os.path.isdir(bench_dir):
+            shutil.rmtree(bench_dir)
+        run_cargo(["r", "--", "run", bench, "-o", dump_dir], root)
+
+
+def line_count(path: str) -> int:
+    try:
+        with open(path) as f:
+            return sum(1 for _ in f)
+    except FileNotFoundError:
+        return 0
+
+
+def fmt_diff(base: int, current: int) -> str:
+    d = current - base
+    return "    =" if d == 0 else f"{d:+5d}"
+
+
+def fmt_pct(base: int, current: int) -> str:
+    if base == 0:
+        return "    -"
+    return f"{(current - base) / base * 100:+.1f}%"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Report line counts of generated LLVM IR and assembly."
+    )
+    parser.add_argument("dump_dir", help="Directory to dump generated files into")
+    parser.add_argument("--diff", metavar="REV", help="Compare against a git revision")
+    parser.add_argument("benches", nargs="*", help="Specific benchmarks to run")
+    args = parser.parse_args()
+
+    root = repo_root()
+    benches = args.benches or get_benches(root)
+
+    # Collect current results.
+    collect(benches, args.dump_dir, root)
+
+    if args.diff:
+        base_dump = args.dump_dir + ".base"
+        base_worktree = tempfile.mkdtemp()
+        try:
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", "--quiet", base_worktree, args.diff],
+                capture_output=True,
+                cwd=root,
+            )
+            collect(benches, base_dump, base_worktree)
+            print(f"Base dump saved to: {base_dump}", file=sys.stderr)
+
+            print(
+                f"{'':22s} {'unopt.ll':>18s} {'opt.ll':>18s} {'opt.s':>18s}"
+            )
+            print(
+                f"{'benchmark':22s} {args.diff:>8s} {'diff':>9s} "
+                f"{args.diff:>8s} {'diff':>9s} {args.diff:>8s} {'diff':>9s}"
+            )
+            print("-" * 76)
+
+            t_bu = t_bo = t_ba = t_mu = t_mo = t_ma = 0
+            for bench in benches:
+                bu = line_count(os.path.join(args.dump_dir, bench, "unopt.ll"))
+                bo = line_count(os.path.join(args.dump_dir, bench, "opt.ll"))
+                ba = line_count(os.path.join(args.dump_dir, bench, "opt.s"))
+                mu = line_count(os.path.join(base_dump, bench, "unopt.ll"))
+                mo = line_count(os.path.join(base_dump, bench, "opt.ll"))
+                ma = line_count(os.path.join(base_dump, bench, "opt.s"))
+
+                print(
+                    f"{bench:22s} {mu:6d} {fmt_diff(mu, bu):>5s} {fmt_pct(mu, bu):>5s}  "
+                    f"{mo:6d} {fmt_diff(mo, bo):>5s} {fmt_pct(mo, bo):>5s}  "
+                    f"{ma:6d} {fmt_diff(ma, ba):>5s} {fmt_pct(ma, ba):>5s}"
+                )
+
+                t_bu += bu
+                t_bo += bo
+                t_ba += ba
+                t_mu += mu
+                t_mo += mo
+                t_ma += ma
+
+            print("-" * 76)
+            print(
+                f"{'TOTAL':22s} {t_mu:6d} {fmt_diff(t_mu, t_bu):>5s} {fmt_pct(t_mu, t_bu):>5s}  "
+                f"{t_mo:6d} {fmt_diff(t_mo, t_bo):>5s} {fmt_pct(t_mo, t_bo):>5s}  "
+                f"{t_ma:6d} {fmt_diff(t_ma, t_ba):>5s} {fmt_pct(t_ma, t_ba):>5s}"
+            )
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", base_worktree],
+                capture_output=True,
+                cwd=root,
+            )
+            if os.path.isdir(base_worktree):
+                shutil.rmtree(base_worktree)
+    else:
+        print(f"{'benchmark':22s} {'unopt':>7s} {'opt.ll':>7s} {'opt.s':>7s}")
+        print("-" * 46)
+
+        t_u = t_o = t_a = 0
+        for bench in benches:
+            u = line_count(os.path.join(args.dump_dir, bench, "unopt.ll"))
+            o = line_count(os.path.join(args.dump_dir, bench, "opt.ll"))
+            a = line_count(os.path.join(args.dump_dir, bench, "opt.s"))
+            print(f"{bench:22s} {u:7d} {o:7d} {a:7d}")
+            t_u += u
+            t_o += o
+            t_a += a
+
+        print("-" * 46)
+        print(f"{'TOTAL':22s} {t_u:7d} {t_o:7d} {t_a:7d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/const-input-stats.py
+++ b/scripts/const-input-stats.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["tqdm>=4.67.3"]
+# ///
+"""Aggregate per-opcode constant-input statistics across all benchmarks.
+
+Runs each benchmark with RUST_LOG=revmc::bytecode=trace and --parse-only,
+parses the trace output, and prints aggregated stats.
+"""
+
+import re
+import subprocess
+import sys
+
+from tqdm import tqdm
+
+from utils import strip_ansi
+
+
+def parse_trace(output: str):
+    """Parse const input stats from combined output.
+
+    Returns dict: opcode_name -> {opbyte, inputs, total, all_const, const_output, per_input}.
+    """
+    stats = {}
+    current = None
+    in_block = False
+
+    for raw_line in output.splitlines():
+        line = strip_ansi(raw_line)
+
+        if "const input stats:" in line:
+            in_block = True
+            continue
+        if not in_block:
+            continue
+
+        # Opcode header, e.g.:
+        # "  ADD              0x01, 86 occ, 2 inputs, all_const=39/86 (45%), const_output=39/86 (45%)"
+        m = re.match(
+            r"\s{2}(\S+)\s+(0x[0-9a-f]{2}), (\d+) occ, (\d+) inputs, all_const=(\d+)/(\d+)"
+            r"(?:.*?const_output=(\d+)/(\d+))?",
+            line,
+        )
+        if m:
+            name = m.group(1)
+            opbyte = int(m.group(2), 16)
+            total = int(m.group(3))
+            inputs = int(m.group(4))
+            all_const = int(m.group(5))
+            const_output = int(m.group(7)) if m.group(7) else 0
+            current = name
+            stats[name] = {
+                "opbyte": opbyte,
+                "inputs": inputs,
+                "total": total,
+                "all_const": all_const,
+                "const_output": const_output,
+                "per_input": [],
+            }
+            continue
+
+        # Per-input line: "    [0]: const=70/86 (81%), fits_usize=70/86 (81%)"
+        m = re.match(
+            r"\s{4}\[(\d+)\]: const=(\d+)/(\d+) \(\d+%\), fits_usize=(\d+)/(\d+)",
+            line,
+        )
+        if m and current:
+            c = int(m.group(2))
+            t = int(m.group(3))
+            u = int(m.group(4))
+            stats[current]["per_input"].append([t, c, u])
+            continue
+
+        # Any other non-empty, non-indented line ends the block.
+        if line.strip() and not line.startswith("  "):
+            in_block = False
+            current = None
+
+    return stats
+
+
+def merge(aggregate, stats):
+    """Merge per-benchmark stats into aggregate."""
+    for name, s in stats.items():
+        if name not in aggregate:
+            aggregate[name] = {
+                "opbyte": s["opbyte"],
+                "inputs": s["inputs"],
+                "total": 0,
+                "all_const": 0,
+                "const_output": 0,
+                "per_input": [[0, 0, 0] for _ in range(s["inputs"])],
+            }
+        agg = aggregate[name]
+        agg["total"] += s["total"]
+        agg["all_const"] += s["all_const"]
+        agg["const_output"] += s.get("const_output", 0)
+        for i, [t, c, u] in enumerate(s["per_input"]):
+            agg["per_input"][i][0] += t
+            agg["per_input"][i][1] += c
+            agg["per_input"][i][2] += u
+
+
+def pct(a, b):
+    return f"{a / b * 100:.0f}%" if b else "0%"
+
+
+def print_stats(stats, title):
+    print(f"\n=== {title} ===")
+    for name in sorted(stats, key=lambda n: stats[n].get("opbyte", 0)):
+        s = stats[name]
+        t = s["total"]
+        if t == 0:
+            continue
+        ac = s["all_const"]
+        co = s.get("const_output", 0)
+        line = (
+            f"  {name:<16} {t} occ, {s['inputs']} inputs, "
+            f"all_const={ac}/{t} ({pct(ac, t)})"
+        )
+        if co:
+            line += f", const_output={co}/{t} ({pct(co, t)})"
+        print(line)
+        for i, [total, const, usize] in enumerate(s["per_input"]):
+            if total > 0:
+                print(
+                    f"    [{i}]: const={const}/{total} ({pct(const, total)}), "
+                    f"fits_usize={usize}/{total} ({pct(usize, total)})"
+                )
+
+
+def main():
+    benches = sys.argv[1:] if len(sys.argv) > 1 else None
+
+    root = subprocess.os.path.dirname(subprocess.os.path.dirname(__file__)) or "."
+
+    # Get bench list.
+    r = subprocess.run(
+        ["cargo", "r", "--", "run", "--list"],
+        capture_output=True, text=True, cwd=root,
+    )
+    all_benches = [x.strip() for x in r.stdout.splitlines() if x.strip()]
+    if benches:
+        all_benches = [b for b in all_benches if b in benches]
+
+    aggregate = {}
+    env = {
+        **subprocess.os.environ,
+        "RUST_LOG": "revmc::bytecode=trace",
+        "NO_COLOR": "1",
+    }
+
+    for bench in tqdm(all_benches, desc="Analyzing", unit="bench", file=sys.stderr):
+        r = subprocess.run(
+            ["cargo", "r", "--", "run", bench, "--parse-only"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env, cwd=root,
+        )
+        stats = parse_trace(r.stdout)
+        if stats:
+            merge(aggregate, stats)
+            print_stats(stats, bench)
+
+    print_stats(aggregate, f"AGGREGATE ({len(all_benches)} benchmarks)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/jump-resolution.py
+++ b/scripts/jump-resolution.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["tqdm>=4.67.3"]
+# ///
+"""Reports dynamic jump resolution stats for all benchmarks."""
+
+import re
+import sys
+
+from tqdm import tqdm
+
+from utils import cargo_env, get_benches, repo_root, run_cargo, strip_ansi
+
+
+def last_match(pattern: str, text: str) -> int:
+    """Return the last regex capture, or 0 if none."""
+    matches = re.findall(pattern, text)
+    return int(matches[-1]) if matches else 0
+
+
+def count_matches(pattern: str, text: str) -> int:
+    return len(re.findall(pattern, text))
+
+
+def analyze(bench: str, root: str, env: dict[str, str]) -> dict[str, int]:
+    output = strip_ansi(
+        run_cargo(["r", "--", "run", bench, "--parse-only"], root, env)
+    )
+
+    local_res = last_match(r"local_jumps.*newly_resolved=(\d+)", output)
+    non_adj = count_matches(r"resolved non-adjacent jump", output)
+    pcr_res = count_matches(r"resolved via PCR hint", output)
+    fixpt_res = last_match(r"ba:.*newly_resolved=(\d+)", output)
+
+    ba_unres_matches = re.findall(
+        r"analyze:ba: .*unresolved dynamic jumps remain n=(\d+)", output
+    )
+    ba_ran = "analyze:ba:" in output
+
+    if ba_unres_matches:
+        unresolved = int(ba_unres_matches[-1])
+    elif ba_ran:
+        unresolved = 0
+    else:
+        unresolved = last_match(
+            r"local_jumps:.*unresolved dynamic jumps remain n=(\d+)", output
+        )
+
+    total = local_res + fixpt_res + unresolved
+
+    return {
+        "local": local_res,
+        "non_adj": non_adj,
+        "pcr": pcr_res,
+        "fixpt": fixpt_res,
+        "unresolved": unresolved,
+        "total": total,
+    }
+
+
+def main():
+    root = repo_root()
+    all_benches = get_benches(root)
+
+    if len(sys.argv) > 1:
+        selected = set(sys.argv[1:])
+        all_benches = [b for b in all_benches if b in selected]
+
+    env = cargo_env(rust_log="revmc::bytecode=trace")
+
+    header = f"{'BENCHMARK':<25} {'LOCAL':>6} {'NONADJ':>6} {'PCR':>6} {'FIXPT':>6} {'UNRES':>6} {'TOTAL':>10}"
+    sep = f"{'---------':<25} {'-----':>6} {'------':>6} {'---':>6} {'-----':>6} {'-----':>6} {'-----':>10}"
+    print(header)
+    print(sep)
+
+    for bench in tqdm(all_benches, desc="Analyzing", unit="bench", file=sys.stderr):
+        s = analyze(bench, root, env)
+        print(
+            f"{bench:<25} {s['local']:>6d} {s['non_adj']:>6d} {s['pcr']:>6d} "
+            f"{s['fixpt']:>6d} {s['unresolved']:>6d} {s['total']:>10d}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for revmc analysis scripts."""
+
+import os
+import re
+import subprocess
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s)
+
+
+def repo_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def cargo_env(rust_log: str | None = None) -> dict[str, str]:
+    env = {**os.environ, "NO_COLOR": "1"}
+    if rust_log:
+        env["RUST_LOG"] = rust_log
+    return env
+
+
+def get_benches(root: str) -> list[str]:
+    r = subprocess.run(
+        ["cargo", "r", "--", "run", "--list"],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    return [line.strip() for line in r.stdout.splitlines() if line.strip()]
+
+
+def run_cargo(
+    args: list[str], root: str, env: dict[str, str] | None = None
+) -> str:
+    r = subprocess.run(
+        ["cargo", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        cwd=root,
+    )
+    return r.stdout


### PR DESCRIPTION
Rewrite `jump-resolution.sh` and `codegen-lines.sh` as Python scripts using PEP 723 inline script metadata for dependency management (`tqdm`). Extract shared utilities into `utils.py`. All scripts use `#!/usr/bin/env -S uv run` shebangs and work directly from the repo root.

Also adds per-opcode constant-input statistics logging at trace level in the bytecode analysis pass, used by `const-input-stats.py`.

Shell originals are kept around.