### PR TITLE
refactor: simplify RawEvmCompilerFn signature

### DIFF
--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -100,6 +100,7 @@ const _: () = {
     assert!(core::mem::size_of::<EvmContext<'_>>() == 96);
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
+    assert!(offset_of!(EvmContext<'_>, gas) == 16);
     assert!(offset_of!(EvmContext<'_>, spec_id) == 65);
     assert!(offset_of!(EvmContext<'_>, resume_at) == 72);
 };
@@ -164,11 +165,9 @@ macro_rules! extern_revmc {
             $(
                 $(#[$attr])*
                 $vis fn $name(
-                    gas: *mut $crate::private::revm_interpreter::Gas,
+                    ecx: *mut $crate::EvmContext<'_>,
                     stack: *mut $crate::EvmStack,
                     stack_len: *mut usize,
-                    input: *const $crate::private::revm_interpreter::InputsImpl,
-                    ecx: *mut $crate::EvmContext<'_>,
                 ) -> $crate::private::revm_interpreter::InstructionResult;
             )+
         }
@@ -181,11 +180,9 @@ macro_rules! extern_revmc {
 /// information.
 // When changing the signature, also update the corresponding declarations in `fn translate`.
 pub type RawEvmCompilerFn = unsafe extern "C" fn(
-    gas: *mut Gas,
+    ecx: *mut EvmContext<'_>,
     stack: *mut EvmStack,
     stack_len: *mut usize,
-    input: *const InputsImpl,
-    ecx: *mut EvmContext<'_>,
 ) -> InstructionResult;
 
 /// An EVM bytecode function.
@@ -288,7 +285,7 @@ impl EvmCompilerFn {
         stack_len: Option<&mut usize>,
         ecx: &mut EvmContext<'_>,
     ) -> InstructionResult {
-        (self.0)(ecx.gas, option_as_mut_ptr(stack), option_as_mut_ptr(stack_len), ecx.input, ecx)
+        (self.0)(ecx, option_as_mut_ptr(stack), option_as_mut_ptr(stack_len))
     }
 
     /// Same as [`call`](Self::call) but with `#[inline(never)]`.
@@ -777,11 +774,9 @@ mod tests {
 
     #[unsafe(no_mangle)]
     extern "C" fn __test_fn(
-        _gas: *mut Gas,
+        _ecx: *mut EvmContext<'_>,
         _stack: *mut EvmStack,
         _stack_len: *mut usize,
-        _input: *const InputsImpl,
-        _ecx: *mut EvmContext<'_>,
     ) -> InstructionResult {
         InstructionResult::Stop
     }

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -4,7 +4,6 @@ use crate::{
     Backend, Builder, Bytecode, EvmCompilerFn, EvmContext, EvmStack, FxHashMap, GasParams, Result,
     bytecode::AnalysisConfig,
 };
-use revm_interpreter::{Gas, InputsImpl};
 use revm_primitives::{Bytes, hardfork::SpecId};
 use revmc_backend::{
     Attribute, BackendConfig, FunctionAttributeLocation, Linkage, OptimizationLevel, eyre::ensure,
@@ -586,21 +585,9 @@ impl<B: Backend> EvmCompiler<B> {
         let ptr = backend.type_ptr();
         let (ret, params, param_names, ptr_attrs) = (
             Some(i8),
-            &[ptr, ptr, ptr, ptr, ptr],
-            &[
-                "arg.gas.addr",
-                "arg.stack.addr",
-                "arg.stack_len.addr",
-                "arg.input.addr",
-                "arg.ecx.addr",
-            ],
-            &[
-                size_align::<Gas>(0),
-                size_align::<EvmStack>(1),
-                size_align::<usize>(2),
-                size_align::<InputsImpl>(3),
-                size_align::<EvmContext<'_>>(4),
-            ],
+            &[ptr, ptr, ptr],
+            &["arg.ecx.addr", "arg.stack.addr", "arg.stack_len.addr"],
+            &[size_align::<EvmContext<'_>>(0), size_align::<EvmStack>(1), size_align::<usize>(2)],
         );
         debug_assert_eq!(params.len(), param_names.len());
         let (mut bcx, id) = backend.build_function(name, ret, params, param_names, linkage)?;
@@ -618,11 +605,8 @@ impl<B: Backend> EvmCompiler<B> {
         if !config.debug_assertions {
             for &(i, size, align) in ptr_attrs {
                 let attrs = default_attrs::for_sized_ptr((size, align))
-                    // `Gas` and `InputsImpl` are reachable through `EvmContext` and can alias
-                    // parameters 0 and 3. Keep `noalias` only for stack and stack_len.
-                    .chain(matches!(i, 1 | 2).then_some(Attribute::NoAlias))
                     // All parameters are `&mut`.
-                    .chain(std::iter::once(Attribute::Writable));
+                    .chain([Attribute::NoAlias, Attribute::Writable]);
                 for attr in attrs {
                     let loc = FunctionAttributeLocation::Param(i as _);
                     bcx.add_function_attribute(None, attr, loc);

--- a/crates/revmc/src/compiler/translate.rs
+++ b/crates/revmc/src/compiler/translate.rs
@@ -207,12 +207,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let address_type = bcx.type_int(160);
 
         // Set up entry block.
-        let gas_ptr = bcx.fn_param(0);
-        let gas_remaining = {
-            let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, tracker.remaining) as i64);
-            let name = "gas.remaining.addr";
-            Pointer::new_address(i64_type, bcx.gep(i8_type, gas_ptr, &[offset], name))
-        };
+        let ecx = bcx.fn_param(0);
 
         let sp_arg = bcx.fn_param(1);
         // Use a local alloca for the stack to allow the backend to eliminate dead stores to
@@ -230,8 +225,18 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // This is initialized later in `post_entry_block`.
         let stack_len = bcx.new_stack_slot(isize_type, "len.addr");
 
-        let input = bcx.fn_param(3);
-        let ecx = bcx.fn_param(4);
+        // Load gas pointer from ecx.
+        let ptr_type = bcx.type_ptr();
+        let gas_ptr = {
+            let gas_field =
+                get_field(&mut bcx, ecx, mem::offset_of!(EvmContext<'_>, gas), "ecx.gas.addr");
+            bcx.load(ptr_type, gas_field, "ecx.gas")
+        };
+        let gas_remaining = {
+            let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, tracker.remaining) as i64);
+            let name = "gas.remaining.addr";
+            Pointer::new_address(i64_type, bcx.gep(i8_type, gas_ptr, &[offset], name))
+        };
 
         // Create all instruction entry blocks.
         // Dead-code instructions map to `unreachable_block`, except when block deduplication
@@ -306,12 +311,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
         // Add debug assertions for the parameters.
         if config.debug_assertions {
-            fx.pointer_panic_with_bool(
-                config.gas_metering,
-                gas_ptr,
-                "gas pointer",
-                "gas metering is enabled",
-            );
+            fx.pointer_panic_with_bool(true, ecx, "EVM context pointer", "");
             fx.pointer_panic_with_bool(
                 !local_stack || bytecode.may_suspend(),
                 sp_arg,
@@ -332,8 +332,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                     "bytecode suspends execution"
                 },
             );
-            fx.pointer_panic_with_bool(true, input, "input pointer", "");
-            fx.pointer_panic_with_bool(true, ecx, "EVM context pointer", "");
 
             // Assert that the runtime spec_id matches the compilation spec_id.
             let compiled_spec = fx.bcx.iconst(fx.i8_type, bytecode.spec_id as i64);


### PR DESCRIPTION
Remove `gas` and `input` parameters from the compiled function signature, keeping only `(ecx, stack, stack_len)`. The gas pointer is now loaded from `ecx` at the start of the IR prologue instead of being passed as a separate argument. The `input` pointer was unused in generated code (builtins already read it from `ecx`) and is removed entirely.

This simplifies the ABI from 5 pointer params to 3, reducing register pressure at call sites and removing redundant state that was already accessible through `EvmContext`.