### PR TITLE
perf: use small code model and dso_local for direct calls

### DIFF
--- a/crates/revmc-llvm/cpp/lib.cpp
+++ b/crates/revmc-llvm/cpp/lib.cpp
@@ -13,6 +13,7 @@
 #include <llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h>
 #include <llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.h>
 #include <llvm/IR/Attributes.h>
+#include <llvm/IR/GlobalValue.h>
 #include <llvm/Target/TargetMachine.h>
 
 #include <atomic>
@@ -356,4 +357,8 @@ revmc_llvm_target_machine_set_opt_level(LLVMTargetMachineRef TM,
     break;
   }
   Machine->setOptLevel(L);
+}
+
+extern "C" void revmc_llvm_set_dso_local(LLVMValueRef Val, bool Local) {
+  unwrap<GlobalValue>(Val)->setDSOLocal(Local);
 }

--- a/crates/revmc-llvm/src/cpp.rs
+++ b/crates/revmc-llvm/src/cpp.rs
@@ -9,9 +9,10 @@ use inkwell::{
             LLVMOrcExecutionSessionRef, LLVMOrcExecutorAddress, LLVMOrcJITDylibRef,
             lljit::{LLVMOrcLLJITBuilderRef, LLVMOrcLLJITRef},
         },
-        prelude::{LLVMAttributeRef, LLVMContextRef},
+        prelude::{LLVMAttributeRef, LLVMContextRef, LLVMValueRef},
         target_machine::{LLVMCodeGenOptLevel, LLVMTargetMachineRef},
     },
+    values::AsValueRef,
 };
 use std::{ffi::c_char, sync::atomic::AtomicUsize};
 
@@ -58,6 +59,12 @@ unsafe extern "C" {
         tm: LLVMTargetMachineRef,
         level: LLVMCodeGenOptLevel,
     );
+
+    fn revmc_llvm_set_dso_local(val: LLVMValueRef, local: bool);
+}
+
+pub(crate) fn set_dso_local(f: inkwell::values::FunctionValue<'_>) {
+    unsafe { revmc_llvm_set_dso_local(f.as_value_ref(), true) };
 }
 
 pub(crate) fn create_initializes_attr(cx: &Context, lower: i64, upper: i64) -> Attribute {

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -506,7 +506,7 @@ impl EvmLlvmBackend {
                 &target_info.features,
                 convert_opt_level(config.opt_level),
                 if aot { RelocMode::PIC } else { RelocMode::Static },
-                if aot { CodeModel::Default } else { CodeModel::JITDefault },
+                CodeModel::Default,
             )
             .ok_or_else(|| eyre::eyre!("failed to create target machine"))?;
 
@@ -882,6 +882,7 @@ impl Backend for EvmLlvmBackend {
             let fn_type = self.fn_type(ret, params);
             let function =
                 self.module().add_function(name, fn_type, Some(convert_linkage(linkage)));
+            cpp::set_dso_local(function);
             if self.backend_config.is_dumping {
                 for (i, &name) in param_names.iter().enumerate() {
                     function.get_nth_param(i as u32).expect(name).set_name(self.name(name));
@@ -1806,6 +1807,7 @@ impl Builder for EvmLlvmBuilder<'_> {
 
         let func_ty = self.fn_type(ret, params);
         let function = self.module().add_function(name, func_ty, Some(convert_linkage(linkage)));
+        cpp::set_dso_local(function);
         let prev_function = std::mem::replace(&mut self.function, function);
 
         let entry = self.cx.append_basic_block(function, self.name("entry"));
@@ -1831,7 +1833,10 @@ impl Builder for EvmLlvmBuilder<'_> {
         }
 
         let ty = self.cx.void_type().fn_type(&[self.ty_ptr.into()], true);
-        self.module().add_function(name, ty, Some(inkwell::module::Linkage::External))
+        let function =
+            self.module().add_function(name, ty, Some(inkwell::module::Linkage::External));
+        cpp::set_dso_local(function);
+        function
     }
 
     fn add_function(
@@ -1844,6 +1849,7 @@ impl Builder for EvmLlvmBuilder<'_> {
     ) -> Self::Function {
         let func_ty = self.fn_type(ret, params);
         let function = self.module().add_function(name, func_ty, Some(convert_linkage(linkage)));
+        cpp::set_dso_local(function);
         if let Some(address) = address
             && let Some(orc) = &mut self.orc
         {

--- a/crates/revmc/src/lib.rs
+++ b/crates/revmc/src/lib.rs
@@ -33,6 +33,9 @@ pub use llvm::EvmLlvmBackend;
 #[doc(inline)]
 pub use revmc_llvm as llvm;
 
+#[doc(hidden)]
+pub use revmc_builtins as builtins;
+
 #[doc(no_inline)]
 pub use revm_bytecode;
 #[doc(no_inline)]


### PR DESCRIPTION
Use `CodeModel::Small` instead of `CodeModel::JITDefault` (which maps to `Large` on x86-64) and mark all function declarations as `dso_local`.

This lets LLVM emit direct `call rel32` instructions instead of `movabs rax, addr` + `call rax` (indirect call through register). JITLink automatically inserts stubs for out-of-range targets.

Before:
```asm
movabs  rax, offset __revmc_builtin_mstore_cc
mov     esi, 64
mov     edx, 128
mov     rbx, rdi
call    rax
```

After:
```asm
mov     esi, 64
mov     edx, 128
mov     rbx, rdi
call    __revmc_builtin_mstore_cc
```

- 5 bytes per call site vs 12 bytes — less icache pressure
- Direct calls are trivially branch-predicted from the first encounter
- Frees up a register previously used for the `movabs` target

`JITDefault` was a holdover from MCJIT/RuntimeDyld which couldn't handle out-of-range relocations. ORC/JITLink handles them automatically with stubs, so `Small` is safe.