### PR TITLE
perf: store calldatasize as a field in EvmContext

### DIFF
--- a/crates/revmc-builtins/src/ir.rs
+++ b/crates/revmc-builtins/src/ir.rs
@@ -262,7 +262,6 @@ builtins! {
     CallValue      = __revmc_builtin_call_value(@[ecx_ro] ptr, @[sp] ptr) None,
     CallDataLoad   = __revmc_builtin_calldataload(@[ecx_ro] ptr, @[sp] ptr) None,
     CallDataLoadC  = __revmc_builtin_calldataload_c(@[ecx_ro] ptr, @[sp] ptr, usize) None,
-    CallDataSize   = __revmc_builtin_calldatasize(@[ecx_ro] ptr) Some(usize),
     CallDataCopy   = __revmc_builtin_calldatacopy(@[ecx] ptr, @[sp] ptr) Some(u8),
     CodeCopy       = __revmc_builtin_codecopy(@[ecx] ptr, @[sp] ptr) Some(u8),
     GasPrice       = __revmc_builtin_gas_price(@[ecx_ro] ptr, @[sp] ptr) None,

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -242,14 +242,6 @@ pub unsafe extern "C" fn __revmc_builtin_calldataload_c(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __revmc_builtin_calldatasize(ecx: &EvmContext<'_>) -> usize {
-    match ecx.input.input() {
-        CallInput::Bytes(bytes) => bytes.len(),
-        CallInput::SharedBuffer(range) => range.len(),
-    }
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn __revmc_builtin_calldatacopy(
     ecx: &mut EvmContext<'_>,
     rev![memory_offset, data_offset, len]: &mut [EvmWord; 3],

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -91,18 +91,21 @@ pub struct EvmContext<'a> {
     pub resume_at: ResumeAt,
     /// The contract bytecode, for CODECOPY at runtime.
     pub bytecode: *const [u8],
+    /// The size of the call input data, cached for CALLDATASIZE.
+    pub calldatasize: usize,
 }
 
 // Static assertions to ensure the struct layout matches expectations.
 // These offsets are used by the JIT compiler to access fields.
 const _: () = {
     use core::mem::offset_of;
-    assert!(core::mem::size_of::<EvmContext<'_>>() == 96);
+    assert!(core::mem::size_of::<EvmContext<'_>>() == 104);
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
     assert!(offset_of!(EvmContext<'_>, spec_id) == 65);
     assert!(offset_of!(EvmContext<'_>, resume_at) == 72);
+    assert!(offset_of!(EvmContext<'_>, calldatasize) == 96);
 };
 
 impl fmt::Debug for EvmContext<'_> {
@@ -127,6 +130,7 @@ impl<'a> EvmContext<'a> {
         let resume_at = ResumeAt::load(interpreter);
         let (stack, stack_len) = EvmStack::from_interpreter_stack(&mut interpreter.stack);
         let bytecode = interpreter.bytecode.bytecode_slice() as *const [u8];
+        let calldatasize = interpreter.input.input.len();
         let this = Self {
             memory: &mut interpreter.memory,
             input: &mut interpreter.input,
@@ -138,6 +142,7 @@ impl<'a> EvmContext<'a> {
             spec_id: interpreter.runtime_flag.spec_id(),
             resume_at,
             bytecode,
+            calldatasize,
         };
         (this, stack, stack_len)
     }

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -3,7 +3,7 @@
 use crate::FxHashMap;
 use bitvec::vec::BitVec;
 use oxc_index::IndexVec;
-use revm_bytecode::{opcode as op, opcode::OpCode};
+use revm_bytecode::opcode as op;
 use revm_primitives::{U256, hardfork::SpecId};
 use revmc_backend::Result;
 use smallvec::SmallVec;
@@ -524,6 +524,7 @@ impl<'a> Bytecode<'a> {
     /// Logs per-opcode constant-input statistics at trace level.
     #[inline(never)]
     fn log_const_input_stats(&self) {
+        use op::*;
         use std::fmt::Write;
 
         // per_input[depth] = [total, const_count, fits_usize_count].
@@ -538,8 +539,7 @@ impl<'a> Bytecode<'a> {
         let mut stats = [const { None }; 256];
         for (inst, data) in self.iter_insts() {
             let (inputs, outputs) = data.stack_io();
-            if inputs == 0
-                || matches!(data.opcode, op::DUP1..=op::DUP16 | op::SWAP1..=op::SWAP16 | op::DUPN | op::SWAPN)
+            if matches!(data.opcode, PUSH0..=PUSH32 | DUP1..=DUP16 | SWAP1..=SWAP16 | DUPN | SWAPN)
             {
                 continue;
             }

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -832,7 +832,12 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 let _ = self.call_builtin(Builtin::CallDataLoad, &[self.ecx, sp]);
             }
             op::CALLDATASIZE => {
-                let size = self.call_builtin(Builtin::CallDataSize, &[self.ecx]).unwrap();
+                let calldatasize_ptr = self.get_field(
+                    self.ecx,
+                    mem::offset_of!(EvmContext<'_>, calldatasize),
+                    "ecx.calldatasize.addr",
+                );
+                let size = self.bcx.load(self.isize_type, calldatasize_ptr, "ecx.calldatasize");
                 let size = self.bcx.zext(self.word_type, size);
                 self.push(size);
             }


### PR DESCRIPTION
Replace the `__revmc_builtin_calldatasize` function call with a direct field load from `EvmContext`. The call input length is cached at context construction time, so `CALLDATASIZE` now compiles to a simple pointer load + zext instead of an indirect call that matches on `CallInput`.