### PR TITLE
feat: improve debug display and dead code elimination

### DIFF
--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -61,6 +61,16 @@ impl Bytecode<'_> {
                 )
                 .unwrap();
             }
+            if !comment.is_empty() {
+                comment.push(' ');
+            }
+            write!(comment, "predecessors=").unwrap();
+            for (i, pred) in block.preds.iter().enumerate() {
+                if i > 0 {
+                    comment.push(',');
+                }
+                write!(comment, "{pred}").unwrap();
+            }
             // Pad header to align with indented instructions.
             while header.len() < 2 {
                 header.push(' ');
@@ -546,11 +556,11 @@ mod tests {
             snapbox::str![[r#"
                ; spec_id=Osaka has_dynamic_jumps=false may_suspend=true
 
-bb0:           ; stack_in=0 max_growth=1
+bb0:           ; stack_in=0 max_growth=1 predecessors=
   PUSH1 0x03   ; ic= 0 pc= 0 gas=11 noop
   JUMP %bb1    ; ic= 1 pc= 2
 
-bb1:           ; stack_in=0 max_growth=2
+bb1:           ; stack_in=0 max_growth=2 predecessors=bb0,bb1
   JUMPDEST     ; ic= 2 pc= 3 gas=7 reachable
   PUSH1 0x01   ; ic= 3 pc= 4 noop
   PUSH1 0x00   ; ic= 4 pc= 6 noop
@@ -559,7 +569,7 @@ bb1:           ; stack_in=0 max_growth=2
   PUSH1 0x03   ; ic= 7 pc=11 noop
   JUMPI %bb1   ; ic= 8 pc=13
 
-bb2:           ; stack_in=0 max_growth=7
+bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
   PUSH1 0x00   ; ic= 9 pc=14 gas=121
   PUSH1 0x00   ; ic=10 pc=16 noop
   PUSH1 0x00   ; ic=11 pc=18 noop

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -50,7 +50,7 @@ oxc_index::define_nonmax_u32_index_type! {
     /// Also known as `ic`, or instruction counter; not to be confused with SSA `inst`s.
     pub(crate) struct Inst;
 }
-impl_index_display!(Inst, "{}");
+impl_index_display!(Inst, "ic{}");
 
 oxc_index::define_nonmax_u32_index_type! {
     /// Index into the deduplicated U256 constant pool.
@@ -363,7 +363,7 @@ impl<'a> Bytecode<'a> {
     fn mark_dead_code(&mut self) {
         let mut iter = self.insts.iter_mut_enumerated();
         while let Some((i, data)) = iter.next() {
-            if data.is_diverging() {
+            if !data.can_fall_through() {
                 let mut end = i;
                 let mut any_new = false;
                 for (j, data) in &mut iter {
@@ -617,8 +617,11 @@ impl<'a> Bytecode<'a> {
         };
         let data = self.inst(inst);
 
-        let mut s = String::new();
-        let _ = write!(s, "OP{inst}.{}", data.to_op());
+        let mut s = String::with_capacity(64);
+        if let Some(block) = self.cfg.inst_to_block[inst] {
+            let _ = write!(s, "{block}.");
+        }
+        let _ = write!(s, "{inst}.{}", data.to_op());
         if !name.is_empty() {
             let _ = write!(s, ".{name}");
         }


### PR DESCRIPTION
Prefix LLVM IR basic block names with the CFG block index (e.g. `bb0.ic0.PUSH1`) so generated IR can be correlated back to the bytecode CFG.

Show predecessor blocks in the bytecode display header comment (`predecessors=bb0,bb1`).

Fix dead code elimination to use `!can_fall_through()` instead of `is_diverging()`. Previously, code after an unconditional `JUMP` (which is non-fall-through but not diverging) was not marked as dead. For example, a trailing `STOP` after a dynamic `JUMP` in WETH would survive as an empty block with no predecessors.

Also renames the `Inst` display format from `{}` to `ic{}` for clarity.