### PR TITLE
refactor: use EvmCompiler::new_llvm where backend is concrete

### DIFF
--- a/crates/revmc-cli/benches/bench.rs
+++ b/crates/revmc-cli/benches/bench.rs
@@ -113,8 +113,7 @@ fn run_bytecode_bench(c: &mut Criterion, bench: &revmc_cli::Bench) {
     host.apply_bench(def);
     let table = instruction_table::<EthInterpreter, BenchHost>();
 
-    let backend = EvmLlvmBackend::new(false).unwrap();
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(false).unwrap();
     compiler.inspect_stack(!def.stack_input.is_empty());
     compiler.gas_metering(true);
 
@@ -194,8 +193,7 @@ fn run_bytecode_bench(c: &mut Criterion, bench: &revmc_cli::Bench) {
 }
 
 fn new_compiler(opt_level: OptimizationLevel) -> EvmCompiler<EvmLlvmBackend> {
-    let backend = EvmLlvmBackend::new(false).unwrap();
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(false).unwrap();
     compiler.set_opt_level(opt_level);
     compiler
 }

--- a/crates/revmc-cli/src/cmd/run.rs
+++ b/crates/revmc-cli/src/cmd/run.rs
@@ -6,8 +6,8 @@ use revm_interpreter::{
     interpreter::{EthInterpreter, ExtBytecode},
 };
 use revmc::{
-    EvmCompiler, EvmContext, EvmLlvmBackend, OptimizationLevel, eyre::ensure,
-    primitives::hardfork::SpecId, shared_library_path,
+    EvmCompiler, EvmContext, OptimizationLevel, eyre::ensure, primitives::hardfork::SpecId,
+    shared_library_path,
 };
 use revmc_cli::{Bench, BenchHost, PreparedFixtureBench, get_benches, read_code};
 use std::{
@@ -145,8 +145,7 @@ impl RunArgs {
         let Bench { bytecode, calldata, stack_input, .. } = bench_entry.clone();
 
         // Build the compiler.
-        let backend = EvmLlvmBackend::new(self.aot)?;
-        let mut compiler = EvmCompiler::new(backend);
+        let mut compiler = EvmCompiler::new_llvm(self.aot)?;
         compiler.set_opt_level(self.opt_level);
         let out_dir = if self.out_dir.is_some() {
             self.out_dir

--- a/crates/revmc-cli/src/fixture.rs
+++ b/crates/revmc-cli/src/fixture.rs
@@ -234,8 +234,7 @@ impl PreparedFixtureBench {
         };
 
         // JIT compile all contract bytecodes.
-        let backend = EvmLlvmBackend::new(false).expect("LLVM backend");
-        let mut compiler = Box::new(EvmCompiler::new(backend));
+        let mut compiler = Box::new(EvmCompiler::new_llvm(false).expect("LLVM backend"));
         let mut seen = HashSet::new();
         let mut pending = Vec::new();
         for acct in &accounts {

--- a/crates/revmc-statetest/src/compiled.rs
+++ b/crates/revmc-statetest/src/compiled.rs
@@ -406,7 +406,7 @@ impl CompileCache {
 }
 
 fn make_compiler(aot: bool) -> RefCell<EvmCompiler<EvmLlvmBackend>> {
-    RefCell::new(EvmCompiler::new(EvmLlvmBackend::new(aot).unwrap()))
+    RefCell::new(EvmCompiler::new_llvm(aot).unwrap())
 }
 
 // ── Compiled test execution ─────────────────────────────────────────────────

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -11,7 +11,6 @@ use revmc_backend::{
 };
 use revmc_builtins::Builtins;
 use revmc_context::RawEvmCompilerFn;
-use revmc_llvm::EvmLlvmBackend;
 use std::{
     cell::Cell,
     fs,
@@ -91,10 +90,11 @@ pub struct EvmCompiler<B: Backend> {
     finalized: bool,
 }
 
-impl EvmCompiler<EvmLlvmBackend> {
+#[cfg(feature = "llvm")]
+impl EvmCompiler<revmc_llvm::EvmLlvmBackend> {
     /// Creates a new instance of the compiler with the LLVM backend.
     pub fn new_llvm(aot: bool) -> Result<Self> {
-        EvmLlvmBackend::new(aot).map(Self::new)
+        revmc_llvm::EvmLlvmBackend::new(aot).map(Self::new)
     }
 }
 

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -11,6 +11,7 @@ use revmc_backend::{
 };
 use revmc_builtins::Builtins;
 use revmc_context::RawEvmCompilerFn;
+use revmc_llvm::EvmLlvmBackend;
 use std::{
     cell::Cell,
     fs,
@@ -88,6 +89,13 @@ pub struct EvmCompiler<B: Backend> {
 
     remarks: Remarks,
     finalized: bool,
+}
+
+impl EvmCompiler<EvmLlvmBackend> {
+    /// Creates a new instance of the compiler with the LLVM backend.
+    pub fn new_llvm(aot: bool) -> Result<Self> {
+        EvmLlvmBackend::new(aot).map(Self::new)
+    }
 }
 
 impl<B: Backend> EvmCompiler<B> {

--- a/crates/revmc/src/lib.rs
+++ b/crates/revmc/src/lib.rs
@@ -52,7 +52,7 @@ type FxHashMap<K, V> = alloy_primitives::map::HashMap<K, V, alloy_primitives::ma
 /// Enable for `cargo asm -p revmc --lib`.
 #[cfg(any())]
 pub fn generate_all_assembly() -> EvmCompiler<EvmLlvmBackend> {
-    let mut compiler = EvmCompiler::new(EvmLlvmBackend::new(false).unwrap());
+    let mut compiler = EvmCompiler::new_llvm(false).unwrap();
     let _ = compiler.jit(None, &[], primitives::SpecId::ARROW_GLACIER).unwrap();
     unsafe { compiler.clear().unwrap() };
     compiler

--- a/crates/revmc/src/linker.rs
+++ b/crates/revmc/src/linker.rs
@@ -116,8 +116,7 @@ mod tests {
         let shared_lib = shared_library_path(tmp.path(), "out");
 
         // Compile and build object file.
-        let backend = crate::EvmLlvmBackend::new(true).unwrap();
-        let mut compiler = crate::EvmCompiler::new(backend);
+        let mut compiler = crate::EvmCompiler::new_llvm(true).unwrap();
         if let Err(e) = compiler.translate("link_test_basic", &[][..], SpecId::CANCUN) {
             panic!("failed to compile: {e}");
         }

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -65,8 +65,7 @@ pub fn with_jit_compiler<R>(
     f: fn(&mut EvmCompiler<crate::llvm::EvmLlvmBackend>) -> R,
 ) -> R {
     init_tracing();
-    let backend = crate::llvm::EvmLlvmBackend::new(false).unwrap();
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(false).unwrap();
     compiler.set_opt_level(opt_level);
     f(&mut compiler)
 }

--- a/examples/compiler/src/main.rs
+++ b/examples/compiler/src/main.rs
@@ -5,7 +5,7 @@
 use clap::Parser;
 use eyre::Context;
 use revmc::{
-    EvmCompiler, EvmLlvmBackend, SpecId,
+    EvmCompiler, SpecId,
     context_interface::host::DummyHost,
     interpreter::{
         Interpreter,
@@ -36,8 +36,7 @@ fn main() -> eyre::Result<()> {
         .wrap_err("Failed to decode hex-encoded code")?;
 
     // Compile the code.
-    let backend = EvmLlvmBackend::new(false)?;
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(false)?;
     let f = unsafe { compiler.jit("test", &bytecode[..], SpecId::CANCUN) }
         .wrap_err("Failed to JIT-compile code")?;
 

--- a/examples/runner/build.rs
+++ b/examples/runner/build.rs
@@ -1,4 +1,4 @@
-use revmc::{EvmCompiler, EvmLlvmBackend, Result, SpecId, primitives::hex};
+use revmc::{EvmCompiler, Result, SpecId, primitives::hex};
 use std::path::PathBuf;
 
 include!("./src/common.rs");
@@ -13,8 +13,7 @@ fn main() -> Result<()> {
     let bytecode = FIBONACCI_CODE;
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
-    let backend = EvmLlvmBackend::new(true)?;
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(true)?;
     compiler.translate(name, bytecode, SpecId::CANCUN)?;
     let object = out_dir.join(name).with_extension("o");
     compiler.write_object_to_file(&object)?;

--- a/fuzz/fuzz_targets/vs_interpreter.rs
+++ b/fuzz/fuzz_targets/vs_interpreter.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 use revmc::{
     revm_bytecode::opcode::OPCODE_INFO,
     tests::{run_test_case, TestCase},
-    EvmCompiler, EvmLlvmBackend, OpcodesIter, OptimizationLevel, SpecId,
+    EvmCompiler, OpcodesIter, OptimizationLevel, SpecId,
 };
 use std::path::PathBuf;
 
@@ -13,8 +13,7 @@ fuzz_target!(|test_case: TestCase<'_>| {
         return;
     }
 
-    let backend = EvmLlvmBackend::new(false).unwrap();
-    let mut compiler = EvmCompiler::new(backend);
+    let mut compiler = EvmCompiler::new_llvm(false).unwrap();
     compiler.set_opt_level(OptimizationLevel::None);
     if let Ok(dump_location) = std::env::var("COMPILER_DUMP") {
         compiler.set_dump_to(Some(PathBuf::from(dump_location)));


### PR DESCRIPTION
Add `EvmCompiler::new_llvm(aot)` convenience constructor that combines `EvmLlvmBackend::new` and `EvmCompiler::new`. Replace all call sites that were using the two-step pattern with the concrete LLVM backend.