### PR TITLE
perf: always store gas before overflow check

### DIFF
--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1930,7 +1930,17 @@ fn init_() -> Result<()> {
     }
 
     // The first arg is only used in `-help` output AFAICT.
-    let args = [c"revmc-llvm".as_ptr(), c"-x86-asm-syntax=intel".as_ptr()];
+    let args = [
+        c"revmc-llvm".as_ptr(),
+        c"-x86-asm-syntax=intel".as_ptr(),
+        // CodeGenPrepare's memory optimization has a pathological interaction with our IR shape:
+        // repeated stores to the same `gas_remaining` pointer in a huge function cause
+        // MemoryDependenceResults::getNonLocalPointerDependency to do superlinear work.
+        // Mark functions with ≥1000 BBs as "huge" to skip the expensive CGP memory opts,
+        // which produce identical codegen at that scale. Small functions still benefit from
+        // CGP's address sinking and branch optimizations.
+        c"--cgpp-huge-func=1000".as_ptr(),
+    ];
     unsafe {
         inkwell::llvm_sys::support::LLVMParseCommandLineOptions(
             args.len() as i32,

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -472,13 +472,6 @@ impl<'a> Bytecode<'a> {
         !self.redirects.is_empty()
     }
 
-    /// Returns `true` if the bytecode is small.
-    ///
-    /// This is arbitrarily chosen to speed up compilation for larger contracts.
-    pub(crate) fn is_small(&self) -> bool {
-        self.insts.len() < 2000
-    }
-
     /// Returns `true` if the instruction is diverging.
     pub(crate) fn is_instr_diverging(&self, inst: Inst) -> bool {
         self.insts[inst].is_diverging()

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -1431,17 +1431,8 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // This can overflow the gas counters, which has to be adjusted for after the call.
         let gas_remaining = self.load_gas_remaining();
         let (res, overflow) = self.bcx.usub_overflow(gas_remaining, cost);
-        // TODO: revisit this
-        if self.bytecode.is_small() {
-            // Storing the result before the check significantly increases time spent in
-            // `llvm::MemoryDependenceResults::getNonLocalPointerDependency`, but it might produce
-            // slightly better code.
-            self.store_gas_remaining(res);
-            self.build_check(overflow, InstructionResult::OutOfGas);
-        } else {
-            self.build_check(overflow, InstructionResult::OutOfGas);
-            self.store_gas_remaining(res);
-        }
+        self.store_gas_remaining(res);
+        self.build_check(overflow, InstructionResult::OutOfGas);
     }
 
     /*


### PR DESCRIPTION
## Summary

Three changes:

1. **fix**: Lazily build `inst_lines` in `take_inst_lines` — fixes a panic when debug info is enabled but bytecode hasn't been formatted.
2. **perf**: Always store `gas_remaining` before the overflow check, removing the `is_small()` heuristic.  
3. **perf**: Set `--cgpp-huge-func=1000` to mitigate LLVM's `CodeGenPrepare` compile-time pathology.

## Codegen impact

**-4.4% assembly lines** across all benchmarks:

| Benchmark | Δ asm lines |
|---|---|
| seaport | -7.4% |
| airdrop | -6.5% |
| snailtracer | -4.1% |
| uniswap_v2_pair | -3.4% |
| fiat_token | -3.0% |
| univ2_router | -2.3% |
| small contracts | 0% |

## Compile-time analysis

### The problem

Storing gas before the branch keeps the store in the large opcode basic block. This triggers a pathology in LLVM's **`CodeGenPrepare`** pass — specifically `MemoryDependenceResults::getNonLocalPointerDependency()`:

- CGP sees a store in a block with high predecessor fan-in
- The target pointer is always the same must-alias location (`gas_remaining`)
- Every prior gas store is a potential clobber, so alias analysis can't prune
- Cost ≈ `(#gas_stores) × (predecessor_search_depth)` → quadratic on large functions

This is entirely in codegen, **not** the optimization passes — `opt` takes identical time for both versions. Isolated per-pass breakdown:

| Contract | Baseline CGP | Patched CGP (no flag) | Patched CGP (huge=1000) |
|---|---|---|---|
| seaport | 0.01s | **3.97s** | 0.52s |
| fiat_token | 0.01s | **0.61s** | 0.13s |

### The mitigation

`--cgpp-huge-func=1000` tells CGP to skip its expensive memory optimizations for functions ≥1000 post-opt basic blocks. **This produces identical codegen** — CGP's memory opts do nothing useful at that scale. Small functions (< 1000 BBs) still get full CGP benefits.

CGP still runs non-memory passes even in "huge" mode, which accounts for the residual cost (0.52s on seaport, 0.13s on fiat_token). This is inherent to CGP's architecture — the flag reduces the worst of the pathology but can't eliminate all of it. Fully disabling CGP (`--disable-cgp`) eliminates this but loses CGP's address sinking benefits on small contracts.

### Final compile-time comparison (both sides have cgpp-huge-func=1000)

| Benchmark | Baseline | Patched | Delta |
|---|---|---|---|
| snailtracer | 2.99s | 3.04s | +2% |
| fiat_token | 0.89s | 1.04s | +17% |
| uniswap_v2_pair | 0.53s | 0.53s | 0% |
| univ2_router | 0.96s | 1.00s | +4% |
| seaport | 2.05s | 2.56s | +25% |
| airdrop | 0.38s | 0.39s | +3% |

The remaining regression is entirely CGP residual — all other codegen passes (ISel, RA, scheduling) take the same time. Without the flag, seaport was +226%.

Runtime benchmarks needed to confirm the asm reduction translates to actual speedups.