### PR TITLE
perf: cache gas_params in EvmContext

### DIFF
--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 extern crate tracing;
 
 use alloc::{boxed::Box, vec::Vec};
+use revm_context_interface::either::Either;
 use revm_interpreter::{
     CallInput, CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, FrameInput,
     InstructionResult, InterpreterAction, InterpreterResult, as_u64_saturated, as_usize_saturated,
@@ -127,7 +128,7 @@ pub unsafe extern "C" fn __revmc_builtin_exp(
     rev![base, exponent_ptr]: &mut [EvmWord; 2],
 ) -> BuiltinResult {
     let exponent = exponent_ptr.to_u256();
-    gas!(ecx, ecx.host.gas_params().exp_cost(exponent));
+    gas!(ecx, ecx.gas_params.exp_cost(exponent));
     *exponent_ptr = base.to_u256().pow(exponent).into();
     Ok(())
 }
@@ -160,7 +161,7 @@ fn do_keccak256(
     *out = EvmWord::from_be_bytes(if len == 0 {
         KECCAK_EMPTY
     } else {
-        gas!(ecx, ecx.host.gas_params().keccak256_cost(len));
+        gas!(ecx, ecx.gas_params.keccak256_cost(len));
         let offset = try_into_usize!(offset);
         ensure_memory(ecx, offset, len)?;
         let data = ecx.memory.slice(offset..offset + len);
@@ -210,25 +211,7 @@ pub unsafe extern "C" fn __revmc_builtin_calldataload(
     ecx: &EvmContext<'_>,
     offset_ptr: &mut EvmWord,
 ) {
-    let mut word = B256::ZERO;
-    let offset = as_usize_saturated!(offset_ptr.to_u256());
-    let input = ecx.input.input();
-    let input_len = input.len();
-    if offset < input_len {
-        let count = 32.min(input_len - offset);
-        let input = match ecx.input.input() {
-            CallInput::Bytes(bytes) => &bytes[..],
-            CallInput::SharedBuffer(range) => &*ecx.memory.global_slice(range.clone()),
-        };
-        // SAFETY: `count` is bounded by the calldata length.
-        // This is `word[..count].copy_from_slice(input[offset..offset + count])`, written using
-        // raw pointers as apparently the compiler cannot optimize the slice version, and using
-        // `get_unchecked` twice is uglier.
-        unsafe {
-            core::ptr::copy_nonoverlapping(input.as_ptr().add(offset), word.as_mut_ptr(), count)
-        };
-    }
-    *offset_ptr = EvmWord::from_be_bytes(word);
+    do_calldataload(ecx, offset_ptr, as_usize_saturated!(offset_ptr.to_u256()));
 }
 
 #[unsafe(no_mangle)]
@@ -237,8 +220,25 @@ pub unsafe extern "C" fn __revmc_builtin_calldataload_c(
     offset_ptr: &mut EvmWord,
     offset: u64,
 ) {
-    *offset_ptr = U256::from(offset).into();
-    __revmc_builtin_calldataload(ecx, offset_ptr);
+    do_calldataload(ecx, offset_ptr, offset as usize);
+}
+
+fn do_calldataload(ecx: &EvmContext<'_>, out: &mut EvmWord, offset: usize) {
+    let mut word = B256::ZERO;
+    let input = ecx.input.input();
+    let input_len = input.len();
+    if offset < input_len {
+        let count = 32.min(input_len - offset);
+        let input = ecx.input.input().as_bytes_memory(ecx.memory);
+        // SAFETY: `count` is bounded by the calldata length.
+        // This is `word[..count].copy_from_slice(input[offset..offset + count])`, written using
+        // raw pointers as apparently the compiler cannot optimize the slice version, and using
+        // `get_unchecked` twice is uglier.
+        unsafe {
+            core::ptr::copy_nonoverlapping(input.as_ptr().add(offset), word.as_mut_ptr(), count)
+        };
+    }
+    *out = EvmWord::from_be_bytes(word);
 }
 
 #[unsafe(no_mangle)]
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn __revmc_builtin_calldatacopy(
 ) -> BuiltinResult {
     let len = try_into_usize!(len);
     if len != 0 {
-        gas!(ecx, ecx.host.gas_params().copy_cost(len));
+        gas!(ecx, ecx.gas_params.copy_cost(len));
         let memory_offset = try_into_usize!(memory_offset);
         ensure_memory(ecx, memory_offset, len)?;
         let data_offset = as_usize_saturated!(data_offset.to_u256());
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn __revmc_builtin_extcodecopy(
 ) -> BuiltinResult {
     let addr = address.to_address();
     let len = try_into_usize!(len);
-    gas!(ecx, ecx.host.gas_params().extcodecopy(len));
+    gas!(ecx, ecx.gas_params.extcodecopy(len));
 
     let mut memory_offset_usize = 0;
     if len != 0 {
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn __revmc_builtin_returndatacopy(
         return Err(InstructionResult::OutOfOffset.into());
     }
 
-    gas!(ecx, ecx.host.gas_params().copy_cost(len));
+    gas!(ecx, ecx.gas_params.copy_cost(len));
     if len != 0 {
         let memory_offset = try_into_usize!(memory_offset);
         ensure_memory(ecx, memory_offset, len)?;
@@ -450,10 +450,7 @@ pub unsafe extern "C" fn __revmc_builtin_mload(
     ecx: &mut EvmContext<'_>,
     offset_ptr: &mut EvmWord,
 ) -> BuiltinResult {
-    let offset = try_into_usize!(offset_ptr);
-    ensure_memory(ecx, offset, 32)?;
-    *offset_ptr = EvmWord::from_be_slice(&ecx.memory.slice(offset..offset + 32));
-    Ok(())
+    do_mload(ecx, offset_ptr, try_into_usize!(offset_ptr))
 }
 
 #[unsafe(no_mangle)]
@@ -462,8 +459,13 @@ pub unsafe extern "C" fn __revmc_builtin_mload_c(
     offset_ptr: &mut EvmWord,
     offset: u64,
 ) -> BuiltinResult {
-    *offset_ptr = U256::from(offset).into();
-    __revmc_builtin_mload(ecx, offset_ptr)
+    do_mload(ecx, offset_ptr, offset as usize)
+}
+
+fn do_mload(ecx: &mut EvmContext<'_>, out: &mut EvmWord, offset: usize) -> BuiltinResult {
+    ensure_memory(ecx, offset, 32)?;
+    *out = EvmWord::from_be_slice(&ecx.memory.slice(offset..offset + 32));
+    Ok(())
 }
 
 #[unsafe(no_mangle)]
@@ -471,7 +473,7 @@ pub unsafe extern "C" fn __revmc_builtin_mstore(
     ecx: &mut EvmContext<'_>,
     rev![offset, value]: &mut [EvmWord; 2],
 ) -> BuiltinResult {
-    do_mstore(ecx, try_into_usize!(offset), value)
+    do_mstore(ecx, try_into_usize!(offset), Either::Left(value))
 }
 
 #[unsafe(no_mangle)]
@@ -480,7 +482,7 @@ pub unsafe extern "C" fn __revmc_builtin_mstore_cd(
     offset: u64,
     value: &mut EvmWord,
 ) -> BuiltinResult {
-    do_mstore(ecx, offset as usize, value)
+    do_mstore(ecx, offset as usize, Either::Left(value))
 }
 
 #[unsafe(no_mangle)]
@@ -489,7 +491,7 @@ pub unsafe extern "C" fn __revmc_builtin_mstore_dc(
     offset: &mut EvmWord,
     value: u64,
 ) -> BuiltinResult {
-    do_mstore(ecx, try_into_usize!(offset), &U256::from(value).into())
+    do_mstore(ecx, try_into_usize!(offset), Either::Right(value))
 }
 
 #[unsafe(no_mangle)]
@@ -498,12 +500,20 @@ pub unsafe extern "C" fn __revmc_builtin_mstore_cc(
     offset: u64,
     value: u64,
 ) -> BuiltinResult {
-    do_mstore(ecx, offset as usize, &U256::from(value).into())
+    do_mstore(ecx, offset as usize, Either::Right(value))
 }
 
-fn do_mstore(ecx: &mut EvmContext<'_>, offset: usize, value: &EvmWord) -> BuiltinResult {
+fn do_mstore(
+    ecx: &mut EvmContext<'_>,
+    offset: usize,
+    value: Either<&EvmWord, u64>,
+) -> BuiltinResult {
     ensure_memory(ecx, offset, 32)?;
-    ecx.memory.set(offset, value.to_be_bytes().as_ref());
+    let value = match value {
+        Either::Left(word) => word.to_u256(),
+        Either::Right(c) => U256::from(c),
+    };
+    ecx.memory.set(offset, &value.to_be_bytes::<32>());
     Ok(())
 }
 
@@ -531,7 +541,7 @@ pub unsafe extern "C" fn __revmc_builtin_sload(
     let address = ecx.input.target_address;
     let key = index.to_u256();
     if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        let additional_cold_cost = ecx.host.gas_params().cold_storage_additional_cost();
+        let additional_cold_cost = ecx.gas_params.cold_storage_additional_cost();
         let skip_cold = ecx.gas.remaining() < additional_cold_cost;
         let storage = ecx.host.sload_skip_cold_load(address, key, skip_cold)?;
         if storage.is_cold {
@@ -567,21 +577,21 @@ pub unsafe extern "C" fn __revmc_builtin_sstore(
     let is_istanbul = ecx.spec_id.is_enabled_in(SpecId::ISTANBUL);
 
     // EIP-2200: If gasleft is less than or equal to gas stipend, fail with OOG.
-    if is_istanbul && ecx.gas.remaining() <= ecx.host.gas_params().call_stipend() {
+    if is_istanbul && ecx.gas.remaining() <= ecx.gas_params.call_stipend() {
         return Err(InstructionResult::ReentrancySentryOOG.into());
     }
 
-    gas!(ecx, ecx.host.gas_params().sstore_static_gas());
+    gas!(ecx, ecx.gas_params.sstore_static_gas());
 
     let state_load = if ecx.spec_id.is_enabled_in(SpecId::BERLIN) {
-        let additional_cold_cost = ecx.host.gas_params().cold_storage_additional_cost();
+        let additional_cold_cost = ecx.gas_params.cold_storage_additional_cost();
         let skip_cold = ecx.gas.remaining() < additional_cold_cost;
         ecx.host.sstore_skip_cold_load(target, index.to_u256(), value.to_u256(), skip_cold)?
     } else {
         ecx.host.sstore(target, index.to_u256(), value.to_u256()).ok_or_fatal()?
     };
 
-    let gp = ecx.host.gas_params();
+    let gp = &ecx.gas_params;
     gas!(ecx, gp.sstore_dynamic_gas(is_istanbul, &state_load.data, state_load.is_cold));
     ecx.gas.record_refund(gp.sstore_refund(is_istanbul, &state_load.data));
     Ok(())
@@ -613,7 +623,7 @@ pub unsafe extern "C" fn __revmc_builtin_mcopy(
     rev![dst, src, len]: &mut [EvmWord; 3],
 ) -> BuiltinResult {
     let len = try_into_usize!(len);
-    gas!(ecx, ecx.host.gas_params().mcopy_cost(len));
+    gas!(ecx, ecx.gas_params.mcopy_cost(len));
     if len != 0 {
         let dst = try_into_usize!(dst);
         let src = try_into_usize!(src);
@@ -634,7 +644,7 @@ pub unsafe extern "C" fn __revmc_builtin_log(
     let sp = sp.add(n as usize);
     read_words!(sp, offset, len);
     let len = try_into_usize!(len);
-    gas!(ecx, ecx.host.gas_params().log_cost(n, len as u64));
+    gas!(ecx, ecx.gas_params.log_cost(n, len as u64));
     let data = if len != 0 {
         let offset = try_into_usize!(offset);
         ensure_memory(ecx, offset, len)?;
@@ -678,7 +688,7 @@ pub unsafe extern "C" fn __revmc_builtin_create(
             if len > max_initcode_size {
                 return Err(InstructionResult::CreateInitCodeSizeLimit.into());
             }
-            gas!(ecx, ecx.host.gas_params().initcode_cost(len));
+            gas!(ecx, ecx.gas_params.initcode_cost(len));
         }
 
         let code_offset = try_into_usize!(code_offset);
@@ -689,7 +699,7 @@ pub unsafe extern "C" fn __revmc_builtin_create(
     };
 
     let is_create2 = create_kind == CreateKind::Create2;
-    let gp = ecx.host.gas_params();
+    let gp = &ecx.gas_params;
     gas!(ecx, if is_create2 { gp.create2_cost(len) } else { gp.create_cost() });
 
     let scheme = if is_create2 {
@@ -701,12 +711,12 @@ pub unsafe extern "C" fn __revmc_builtin_create(
 
     // State gas for account creation + contract metadata (EIP-8037).
     if ecx.host.is_amsterdam_eip8037_enabled() {
-        state_gas!(ecx, ecx.host.gas_params().create_state_gas());
+        state_gas!(ecx, ecx.gas_params.create_state_gas());
     }
 
     let mut gas_limit = ecx.gas.remaining();
     if ecx.spec_id.is_enabled_in(SpecId::TANGERINE) {
-        gas_limit = ecx.host.gas_params().call_stipend_reduction(gas_limit);
+        gas_limit = ecx.gas_params.call_stipend_reduction(gas_limit);
     }
     gas!(ecx, gas_limit);
 
@@ -778,7 +788,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
     };
 
     if transfers_value {
-        gas!(ecx, ecx.host.gas_params().transfer_value_cost());
+        gas!(ecx, ecx.gas_params.transfer_value_cost());
     }
 
     // Match interpreter call path: load delegated account and pass resolved bytecode/hash
@@ -801,7 +811,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
     // EIP-150: Gas cost changes for IO-heavy operations
     let mut gas_limit = if ecx.spec_id.is_enabled_in(SpecId::TANGERINE) {
         let gas = ecx.gas.remaining();
-        ecx.host.gas_params().call_stipend_reduction(gas).min(local_gas_limit)
+        ecx.gas_params.call_stipend_reduction(gas).min(local_gas_limit)
     } else {
         local_gas_limit
     };
@@ -810,7 +820,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
 
     // Add call stipend if there is value to be transferred.
     if matches!(call_kind, CallKind::Call | CallKind::CallCode) && transfers_value {
-        gas_limit = gas_limit.saturating_add(ecx.host.gas_params().call_stipend());
+        gas_limit = gas_limit.saturating_add(ecx.gas_params.call_stipend());
     }
 
     *ecx.next_action = Some(InterpreterAction::NewFrame(revm_interpreter::FrameInput::Call(
@@ -890,7 +900,7 @@ pub unsafe extern "C" fn __revmc_builtin_selfdestruct(
 ) -> BuiltinResult {
     ensure_non_staticcall!(ecx);
 
-    let cold_load_gas = ecx.host.gas_params().selfdestruct_cold_cost();
+    let cold_load_gas = ecx.gas_params.selfdestruct_cold_cost();
     let skip_cold_load = ecx.gas.remaining() < cold_load_gas;
     let res =
         ecx.host.selfdestruct(ecx.input.target_address, target.to_address(), skip_cold_load)?;
@@ -902,10 +912,10 @@ pub unsafe extern "C" fn __revmc_builtin_selfdestruct(
         !res.target_exists
     };
 
-    gas!(ecx, ecx.host.gas_params().selfdestruct_cost(should_charge_topup, res.is_cold));
+    gas!(ecx, ecx.gas_params.selfdestruct_cost(should_charge_topup, res.is_cold));
 
     if !res.previously_destroyed {
-        ecx.gas.record_refund(ecx.host.gas_params().selfdestruct_refund());
+        ecx.gas.record_refund(ecx.gas_params.selfdestruct_refund());
     }
 
     Err(InstructionResult::SelfDestruct.into())

--- a/crates/revmc-builtins/src/utils.rs
+++ b/crates/revmc-builtins/src/utils.rs
@@ -49,7 +49,7 @@ pub(crate) fn load_account<'a>(
     address: Address,
     load_code: bool,
 ) -> Result<AccountInfoLoad<'a>, BuiltinError> {
-    let cold_load_gas = ecx.host.gas_params().cold_account_additional_cost();
+    let cold_load_gas = ecx.gas_params.cold_account_additional_cost();
     let skip_cold_load = ecx.gas.remaining() < cold_load_gas;
     let account = ecx.host.load_account_info_skip_cold_load(address, load_code, skip_cold_load)?;
     if account.is_cold {
@@ -74,14 +74,8 @@ pub(crate) unsafe fn read_words_rev<'a, const N: usize>(sp: *mut EvmWord) -> &'a
 
 #[inline]
 pub(crate) fn ensure_memory(ecx: &mut EvmContext<'_>, offset: usize, len: usize) -> BuiltinResult {
-    revm_interpreter::interpreter::resize_memory(
-        ecx.gas,
-        ecx.memory,
-        ecx.host.gas_params(),
-        offset,
-        len,
-    )
-    .map_err(Into::into)
+    revm_interpreter::interpreter::resize_memory(ecx.gas, ecx.memory, &ecx.gas_params, offset, len)
+        .map_err(Into::into)
 }
 
 pub(crate) unsafe fn copy_operation(
@@ -91,7 +85,7 @@ pub(crate) unsafe fn copy_operation(
 ) -> BuiltinResult {
     let len = try_into_usize!(len);
     if len != 0 {
-        gas!(ecx, ecx.host.gas_params().copy_cost(len));
+        gas!(ecx, ecx.gas_params.copy_cost(len));
         let memory_offset = try_into_usize!(memory_offset);
         ensure_memory(ecx, memory_offset, len)?;
         let data_offset = data_offset.to_u256();

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -10,6 +10,7 @@ use core::{fmt, mem::MaybeUninit, ptr};
 use revm_interpreter::{
     Gas, Host, InputsImpl, InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
     SharedMemory,
+    context_interface::cfg::GasParams,
     interpreter_types::{Jumps, LegacyBytecode, ReturnData, RuntimeFlag},
 };
 use revm_primitives::{Address, B256, Bytes, U256, hardfork::SpecId, ruint};
@@ -93,13 +94,15 @@ pub struct EvmContext<'a> {
     pub bytecode: *const [u8],
     /// The size of the call input data, cached for CALLDATASIZE.
     pub calldatasize: usize,
+    /// Cached gas parameters from the host.
+    pub gas_params: GasParams,
 }
 
 // Static assertions to ensure the struct layout matches expectations.
 // These offsets are used by the JIT compiler to access fields.
 const _: () = {
     use core::mem::offset_of;
-    assert!(core::mem::size_of::<EvmContext<'_>>() == 104);
+    assert!(core::mem::size_of::<EvmContext<'_>>() == 120);
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
@@ -131,6 +134,7 @@ impl<'a> EvmContext<'a> {
         let (stack, stack_len) = EvmStack::from_interpreter_stack(&mut interpreter.stack);
         let bytecode = interpreter.bytecode.bytecode_slice() as *const [u8];
         let calldatasize = interpreter.input.input.len();
+        let gas_params = host.gas_params().clone();
         let this = Self {
             memory: &mut interpreter.memory,
             input: &mut interpreter.input,
@@ -143,6 +147,7 @@ impl<'a> EvmContext<'a> {
             resume_at,
             bytecode,
             calldatasize,
+            gas_params,
         };
         (this, stack, stack_len)
     }


### PR DESCRIPTION
Clone `GasParams` (Arc-backed, cheap) from the host once at `EvmContext` construction instead of making repeated vtable calls through `dyn Host`.

All ~25 `ecx.host.gas_params()` call sites in builtins/utils now access the cached `ecx.gas_params` field directly.