### PR TITLE
perf: optimize SIGNEXTEND IR builtin with arithmetic shift

### DIFF
--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -786,8 +786,17 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::Exp, &[self.ecx, sp]);
             }
             op::SIGNEXTEND => {
+                // Sign-extend x from (ext+1) bytes using arithmetic shift:
+                //   shift = 248 - 8 * ext
+                //   result = (x << shift) >>s shift
                 let [ext, x] = self.popn();
-                let r = self.call_signextend(ext, x);
+                let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
+                let shift = self.bcx.imul_imm(ext, 8);
+                let c248 = self.bcx.iconst_256(U256::from(248));
+                let shift = self.bcx.isub(c248, shift);
+                let shifted = self.bcx.ishl(x, shift);
+                let sext = self.bcx.sshr(shifted, shift);
+                let r = self.bcx.select(might_do_something, sext, x);
                 self.push(r);
             }
 
@@ -1702,41 +1711,6 @@ impl<B: Backend> FunctionCx<'_, B> {
         let zero = self.bcx.iconst_256(U256::ZERO);
         let r = self.bcx.select(cond, byte, zero);
 
-        self.bcx.ret(&[r]);
-    }
-
-    fn call_signextend(&mut self, ext: B::Value, x: B::Value) -> B::Value {
-        self.call_ir_binop_builtin("signextend", ext, x, Self::build_signextend)
-    }
-
-    /// Builds: `fn signextend(ext: u256, x: u256) -> u256`
-    fn build_signextend(&mut self) {
-        // Sign-extend x from (ext+1) bytes using arithmetic shift:
-        //   shift = 256 - 8 * (ext + 1) = 248 - 8 * ext
-        //   result = (x << shift) >>s shift
-        // The left shift moves the sign bit to bit 255, then the arithmetic
-        // right shift propagates it back down.
-
-        let ext = self.bcx.fn_param(0);
-        let x = self.bcx.fn_param(1);
-
-        // For ext >= 31 the value already fills 32 bytes; nothing to do.
-        let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
-        let r = self.bcx.lazy_select(
-            might_do_something,
-            self.bcx.type_int(256),
-            |bcx| {
-                // shift = 248 - 8 * ext
-                let shift = bcx.imul_imm(ext, 8);
-                let c248 = bcx.iconst_256(U256::from(248));
-                let shift = bcx.isub(c248, shift);
-
-                // (x << shift) >>s shift
-                let shifted = bcx.ishl(x, shift);
-                bcx.sshr(shifted, shift)
-            },
-            |_bcx| x,
-        );
         self.bcx.ret(&[r]);
     }
 

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -1711,48 +1711,29 @@ impl<B: Backend> FunctionCx<'_, B> {
 
     /// Builds: `fn signextend(ext: u256, x: u256) -> u256`
     fn build_signextend(&mut self) {
-        // From the yellow paper:
-        /*
-        let [ext, x] = stack.pop();
-        let t = 256 - 8 * (ext + 1);
-        let mut result = x;
-        result[..t] = [x[t]; t]; // Index by bits.
-        */
+        // Sign-extend x from (ext+1) bytes using arithmetic shift:
+        //   shift = 256 - 8 * (ext + 1) = 248 - 8 * ext
+        //   result = (x << shift) >>s shift
+        // The left shift moves the sign bit to bit 255, then the arithmetic
+        // right shift propagates it back down.
 
         let ext = self.bcx.fn_param(0);
         let x = self.bcx.fn_param(1);
 
-        // For 31 we also don't need to do anything.
+        // For ext >= 31 the value already fills 32 bytes; nothing to do.
         let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
         let r = self.bcx.lazy_select(
             might_do_something,
             self.bcx.type_int(256),
             |bcx| {
-                // Adapted from revm: https://github.com/bluealloy/revm/blob/fda371f73aba2c30a83c639608be78145fd1123b/crates/interpreter/src/instructions/arithmetic.rs#L89
-                // let bit_index = 8 * ext + 7;
-                // let bit = (x >> bit_index) & 1 != 0;
-                // let mask = (1 << bit_index) - 1;
-                // let r = if bit { x | !mask } else { *x & mask };
+                // shift = 248 - 8 * ext
+                let shift = bcx.imul_imm(ext, 8);
+                let c248 = bcx.iconst_256(U256::from(248));
+                let shift = bcx.isub(c248, shift);
 
-                // let bit_index = 8 * ext + 7;
-                let bit_index = bcx.imul_imm(ext, 8);
-                let bit_index = bcx.iadd_imm(bit_index, 7);
-
-                // let bit = (x >> bit_index) & 1 != 0;
-                let one = bcx.iconst_256(U256::from(1));
-                let bit = bcx.ushr(x, bit_index);
-                let bit = bcx.bitand(bit, one);
-                let bit = bcx.icmp_imm(IntCC::NotEqual, bit, 0);
-
-                // let mask = (1 << bit_index) - 1;
-                let mask = bcx.ishl(one, bit_index);
-                let mask = bcx.isub_imm(mask, 1);
-
-                // let r = if bit { x | !mask } else { *x & mask };
-                let not_mask = bcx.bitnot(mask);
-                let sext = bcx.bitor(x, not_mask);
-                let zext = bcx.bitand(x, mask);
-                bcx.select(bit, sext, zext)
+                // (x << shift) >>s shift
+                let shifted = bcx.ishl(x, shift);
+                bcx.sshr(shifted, shift)
             },
             |_bcx| x,
         );

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -786,16 +786,20 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::Exp, &[self.ecx, sp]);
             }
             op::SIGNEXTEND => {
-                // Sign-extend x from (ext+1) bytes using arithmetic shift:
-                //   shift = 248 - 8 * ext
-                //   result = (x << shift) >>s shift
+                // let shift = 248 - 8 * ext;
+                // ext < 31
+                //   ? (x << shift) >>s shift
+                //   : x
                 let [ext, x] = self.popn();
+
                 let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
+
                 let shift = self.bcx.imul_imm(ext, 8);
                 let c248 = self.bcx.iconst_256(U256::from(248));
                 let shift = self.bcx.isub(c248, shift);
                 let shifted = self.bcx.ishl(x, shift);
                 let sext = self.bcx.sshr(shifted, shift);
+
                 let r = self.bcx.select(might_do_something, sext, x);
                 self.push(r);
             }

--- a/crates/revmc/src/tests/macros.rs
+++ b/crates/revmc/src/tests/macros.rs
@@ -7,7 +7,9 @@ macro_rules! matrix_tests {
             use similar_asserts::assert_eq;
 
             fn run_llvm(compiler: &mut EvmCompiler<crate::llvm::EvmLlvmBackend>) {
-                crate::tests::set_test_dump(compiler, module_path!());
+                if std::env::var_os("REVMC_TEST_DUMP").is_some() {
+                    crate::tests::set_test_dump(compiler, module_path!());
+                }
                 $run(compiler);
             }
 

--- a/crates/revmc/src/tests/macros.rs
+++ b/crates/revmc/src/tests/macros.rs
@@ -72,7 +72,28 @@ macro_rules! tests {
     (@cases $( $name:ident($($t:tt)*) ),* $(,)?) => {
         $(
             matrix_tests!($name = |jit| run_test_case(tests!(@case $($t)*), jit));
+            tests!(@maybe_opaque $name($($t)*));
         )*
+    };
+
+    // Generate an `_opaque` companion test for binop cases (2 args).
+    // Uses MSTORE+MLOAD to make operands invisible to the compiler.
+    (@maybe_opaque $name:ident(@raw { $($fields:tt)* })) => {};
+    (@maybe_opaque $name:ident($op:expr, $a:expr => $($ret:tt)*)) => {};
+    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr, $c:expr => $($ret:tt)*)) => {};
+    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr => $($ret:expr),* $(; $($_rest:tt)*)?)) => {
+        paste::paste! {
+            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
+                &TestCase {
+                    bytecode: &bytecode_binop_opaque($op, $a, $b),
+                    expected_stack: &[$($ret),*],
+                    expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+                    expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+                    ..Default::default()
+                },
+                jit,
+            ));
+        }
     };
 
     (@case @raw { $($fields:tt)* }) => { &TestCase { $($fields)* ..Default::default() } };

--- a/crates/revmc/src/tests/macros.rs
+++ b/crates/revmc/src/tests/macros.rs
@@ -76,16 +76,42 @@ macro_rules! tests {
         )*
     };
 
-    // Generate an `_opaque` companion test for binop cases (2 args).
+    // Generate an `_opaque` companion test for each arity.
     // Uses MSTORE+MLOAD to make operands invisible to the compiler.
     (@maybe_opaque $name:ident(@raw { $($fields:tt)* })) => {};
-    (@maybe_opaque $name:ident($op:expr, $a:expr => $($ret:tt)*)) => {};
-    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr, $c:expr => $($ret:tt)*)) => {};
-    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr => $($ret:expr),* $(; $($_rest:tt)*)?)) => {
+    (@maybe_opaque $name:ident($op:expr, $a:expr => $($ret:expr),* $(; $($_r1:tt)*)?)) => {
+        paste::paste! {
+            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
+                &TestCase {
+                    bytecode: &bytecode_unop_opaque($op, $a),
+                    expected_stack: &[$($ret),*],
+                    expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+                    expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+                    ..Default::default()
+                },
+                jit,
+            ));
+        }
+    };
+    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr => $($ret:expr),* $(; $($_r2:tt)*)?)) => {
         paste::paste! {
             matrix_tests!([<$name _opaque>] = |jit| run_test_case(
                 &TestCase {
                     bytecode: &bytecode_binop_opaque($op, $a, $b),
+                    expected_stack: &[$($ret),*],
+                    expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+                    expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+                    ..Default::default()
+                },
+                jit,
+            ));
+        }
+    };
+    (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr, $c:expr => $($ret:expr),* $(; $($_r3:tt)*)?)) => {
+        paste::paste! {
+            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
+                &TestCase {
+                    bytecode: &bytecode_ternop_opaque($op, $a, $b, $c),
                     expected_stack: &[$($ret),*],
                     expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
                     expected_gas: GAS_WHAT_INTERPRETER_SAYS,

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -1866,121 +1866,6 @@ tests! {
     }
 }
 
-// DIV/MOD/SMOD/SDIV with zero divisor loaded from memory (opaque to LLVM).
-//
-// When the divisor is opaque (e.g. loaded via MLOAD), `udiv/urem/srem i256` with
-// divisor==0 is UB in LLVM IR. The fix uses `lazy_select` (conditional branch) so
-// the division is never executed when b==0.
-//
-// EVM spec: x DIV 0 = 0, x MOD 0 = 0, x SMOD 0 = 0, x SDIV 0 = 0.
-mod div_zero_opaque {
-    use super::*;
-
-    /// Build bytecode: MSTORE(a, 0), MSTORE(b, 32), MLOAD(32), MLOAD(0), `<op>`
-    ///
-    /// The operands pass through MLOAD (an opaque builtin), preventing LLVM from
-    /// constant-folding or exploiting division-by-zero UB at compile time.
-    fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
-        let mut code = Vec::with_capacity(128);
-        code.push(op::PUSH32);
-        code.extend_from_slice(&a.to_be_bytes::<32>());
-        code.push(op::PUSH1);
-        code.push(0x00);
-        code.push(op::MSTORE);
-        code.push(op::PUSH32);
-        code.extend_from_slice(&b.to_be_bytes::<32>());
-        code.push(op::PUSH1);
-        code.push(0x20);
-        code.push(op::MSTORE);
-        code.push(op::PUSH1);
-        code.push(0x20);
-        code.push(op::MLOAD);
-        code.push(op::PUSH1);
-        code.push(0x00);
-        code.push(op::MLOAD);
-        code.push(opcode);
-        code
-    }
-
-    fn run<B: Backend>(compiler: &mut EvmCompiler<B>, name: &str, opcode: u8, a: U256) {
-        let code = bytecode_binop_opaque(opcode, a, U256::ZERO);
-        unsafe { compiler.clear() }.unwrap();
-        compiler.inspect_stack(true);
-        let f = unsafe { compiler.jit(name, &code, DEF_SPEC) }.unwrap();
-        with_evm_context(&code, DEF_SPEC, |ecx, stack, stack_len| {
-            let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
-            assert_eq!(r, InstructionResult::Stop, "{name}: unexpected return");
-            assert_eq!(*stack_len, 1, "{name}: expected 1 stack element");
-            let actual = unsafe { stack.as_slice(*stack_len)[0].to_u256() };
-            assert_eq!(actual, U256::ZERO, "{name}: EVM spec mandates 0 for division by zero");
-        });
-    }
-
-    matrix_tests!(div = |jit| run(jit, "div_zero", op::DIV, U256::from(32)));
-    matrix_tests!(r#mod = |jit| run(jit, "mod_zero", op::MOD, U256::from(32)));
-    matrix_tests!(smod = |jit| run(jit, "smod_zero", op::SMOD, U256::from(5)));
-    matrix_tests!(sdiv = |jit| run(jit, "sdiv_zero", op::SDIV, U256::from(5)));
-}
-
-/// Tests SIGNEXTEND with operands that are opaque to the compiler (loaded via
-/// MLOAD), exercising the dynamic-shift codepath instead of constant folding.
-mod signextend_opaque {
-    use super::*;
-
-    fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
-        let mut code = Vec::with_capacity(128);
-        code.push(op::PUSH32);
-        code.extend_from_slice(&a.to_be_bytes::<32>());
-        code.push(op::PUSH1);
-        code.push(0x00);
-        code.push(op::MSTORE);
-        code.push(op::PUSH32);
-        code.extend_from_slice(&b.to_be_bytes::<32>());
-        code.push(op::PUSH1);
-        code.push(0x20);
-        code.push(op::MSTORE);
-        code.push(op::PUSH1);
-        code.push(0x20);
-        code.push(op::MLOAD);
-        code.push(op::PUSH1);
-        code.push(0x00);
-        code.push(op::MLOAD);
-        code.push(opcode);
-        code
-    }
-
-    fn run<B: Backend>(
-        compiler: &mut EvmCompiler<B>,
-        name: &str,
-        ext: U256,
-        x: U256,
-        expected: U256,
-    ) {
-        let code = bytecode_binop_opaque(op::SIGNEXTEND, ext, x);
-        unsafe { compiler.clear() }.unwrap();
-        compiler.inspect_stack(true);
-        let f = unsafe { compiler.jit(name, &code, DEF_SPEC) }.unwrap();
-        with_evm_context(&code, DEF_SPEC, |ecx, stack, stack_len| {
-            let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
-            assert_eq!(r, InstructionResult::Stop, "{name}: unexpected return");
-            assert_eq!(*stack_len, 1, "{name}: expected 1 stack element");
-            let actual = unsafe { stack.as_slice(*stack_len)[0].to_u256() };
-            assert_eq!(actual, expected, "{name}");
-        });
-    }
-
-    uint! {
-        matrix_tests!(sext_byte0_pos = |jit| run(jit, "sext_byte0_pos", 0_U256, 0x7f_U256, 0x7f_U256));
-        matrix_tests!(sext_byte0_neg = |jit| run(jit, "sext_byte0_neg", 0_U256, 0x80_U256, -0x80_U256));
-        matrix_tests!(sext_byte0_ff = |jit| run(jit, "sext_byte0_ff", 0_U256, 0xff_U256, U256::MAX));
-        matrix_tests!(sext_byte1_pos = |jit| run(jit, "sext_byte1_pos", 1_U256, 0x7fff_U256, 0x7fff_U256));
-        matrix_tests!(sext_byte1_neg = |jit| run(jit, "sext_byte1_neg", 1_U256, 0x8000_U256, -0x8000_U256));
-        matrix_tests!(sext_byte16 = |jit| run(jit, "sext_byte16", 16_U256, 0x80_U256.wrapping_shl(128), -0x80_U256.wrapping_shl(128)));
-        matrix_tests!(sext_noop_31 = |jit| run(jit, "sext_noop_31", 31_U256, 0x42_U256, 0x42_U256));
-        matrix_tests!(sext_noop_max = |jit| run(jit, "sext_noop_max", U256::MAX, 0x42_U256, 0x42_U256));
-    }
-}
-
 fn bytecode_unop(op: u8, a: U256) -> [u8; 34] {
     let mut code = [0; 34];
     let mut i = 0;
@@ -1995,6 +1880,32 @@ fn bytecode_binop(op: u8, a: U256, b: U256) -> [u8; 67] {
     build_push32!(code[i], b);
     build_push32!(code[i], a);
     code[i] = op;
+    code
+}
+
+/// Build bytecode: MSTORE(a, 0), MSTORE(b, 32), MLOAD(32), MLOAD(0), `<op>`
+///
+/// The operands pass through MLOAD (an opaque builtin), preventing the compiler
+/// from constant-folding or exploiting UB at compile time.
+fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
+    let mut code = Vec::with_capacity(128);
+    code.push(op::PUSH32);
+    code.extend_from_slice(&a.to_be_bytes::<32>());
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MSTORE);
+    code.push(op::PUSH32);
+    code.extend_from_slice(&b.to_be_bytes::<32>());
+    code.push(op::PUSH1);
+    code.push(0x20);
+    code.push(op::MSTORE);
+    code.push(op::PUSH1);
+    code.push(0x20);
+    code.push(op::MLOAD);
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MLOAD);
+    code.push(opcode);
     code
 }
 

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -1866,21 +1866,6 @@ tests! {
     }
 }
 
-/// Build opaque unop bytecode: MSTORE(a, 0), MLOAD(0), `<op>`.
-fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
-    let mut code = Vec::with_capacity(64);
-    code.push(op::PUSH32);
-    code.extend_from_slice(&a.to_be_bytes::<32>());
-    code.push(op::PUSH1);
-    code.push(0x00);
-    code.push(op::MSTORE);
-    code.push(op::PUSH1);
-    code.push(0x00);
-    code.push(op::MLOAD);
-    code.push(opcode);
-    code
-}
-
 fn bytecode_unop(op: u8, a: U256) -> [u8; 34] {
     let mut code = [0; 34];
     let mut i = 0;
@@ -1895,6 +1880,31 @@ fn bytecode_binop(op: u8, a: U256, b: U256) -> [u8; 67] {
     build_push32!(code[i], b);
     build_push32!(code[i], a);
     code[i] = op;
+    code
+}
+
+fn bytecode_ternop(op: u8, a: U256, b: U256, c: U256) -> [u8; 100] {
+    let mut code = [0; 100];
+    let mut i = 0;
+    build_push32!(code[i], c);
+    build_push32!(code[i], b);
+    build_push32!(code[i], a);
+    code[i] = op;
+    code
+}
+
+/// Build opaque unop bytecode: MSTORE(a, 0), MLOAD(0), `<op>`.
+fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
+    let mut code = Vec::with_capacity(64);
+    code.push(op::PUSH32);
+    code.extend_from_slice(&a.to_be_bytes::<32>());
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MSTORE);
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MLOAD);
+    code.push(opcode);
     code
 }
 
@@ -1941,16 +1951,6 @@ fn bytecode_ternop_opaque(opcode: u8, a: U256, b: U256, c: U256) -> Vec<u8> {
         code.push(op::MLOAD);
     }
     code.push(opcode);
-    code
-}
-
-fn bytecode_ternop(op: u8, a: U256, b: U256, c: U256) -> [u8; 100] {
-    let mut code = [0; 100];
-    let mut i = 0;
-    build_push32!(code[i], c);
-    build_push32!(code[i], b);
-    build_push32!(code[i], a);
-    code[i] = op;
     code
 }
 

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -1866,6 +1866,21 @@ tests! {
     }
 }
 
+/// Build opaque unop bytecode: MSTORE(a, 0), MLOAD(0), `<op>`.
+fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
+    let mut code = Vec::with_capacity(64);
+    code.push(op::PUSH32);
+    code.extend_from_slice(&a.to_be_bytes::<32>());
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MSTORE);
+    code.push(op::PUSH1);
+    code.push(0x00);
+    code.push(op::MLOAD);
+    code.push(opcode);
+    code
+}
+
 fn bytecode_unop(op: u8, a: U256) -> [u8; 34] {
     let mut code = [0; 34];
     let mut i = 0;
@@ -1905,6 +1920,26 @@ fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
     code.push(op::PUSH1);
     code.push(0x00);
     code.push(op::MLOAD);
+    code.push(opcode);
+    code
+}
+
+/// Build opaque ternop bytecode: MSTORE(a,0), MSTORE(b,32), MSTORE(c,64),
+/// MLOAD(64), MLOAD(32), MLOAD(0), `<op>`.
+fn bytecode_ternop_opaque(opcode: u8, a: U256, b: U256, c: U256) -> Vec<u8> {
+    let mut code = Vec::with_capacity(192);
+    for (val, offset) in [(a, 0u8), (b, 0x20), (c, 0x40)] {
+        code.push(op::PUSH32);
+        code.extend_from_slice(&val.to_be_bytes::<32>());
+        code.push(op::PUSH1);
+        code.push(offset);
+        code.push(op::MSTORE);
+    }
+    for offset in [0x40u8, 0x20, 0x00] {
+        code.push(op::PUSH1);
+        code.push(offset);
+        code.push(op::MLOAD);
+    }
     code.push(opcode);
     code
 }

--- a/crates/revmc/src/tests/mod.rs
+++ b/crates/revmc/src/tests/mod.rs
@@ -1922,6 +1922,65 @@ mod div_zero_opaque {
     matrix_tests!(sdiv = |jit| run(jit, "sdiv_zero", op::SDIV, U256::from(5)));
 }
 
+/// Tests SIGNEXTEND with operands that are opaque to the compiler (loaded via
+/// MLOAD), exercising the dynamic-shift codepath instead of constant folding.
+mod signextend_opaque {
+    use super::*;
+
+    fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
+        let mut code = Vec::with_capacity(128);
+        code.push(op::PUSH32);
+        code.extend_from_slice(&a.to_be_bytes::<32>());
+        code.push(op::PUSH1);
+        code.push(0x00);
+        code.push(op::MSTORE);
+        code.push(op::PUSH32);
+        code.extend_from_slice(&b.to_be_bytes::<32>());
+        code.push(op::PUSH1);
+        code.push(0x20);
+        code.push(op::MSTORE);
+        code.push(op::PUSH1);
+        code.push(0x20);
+        code.push(op::MLOAD);
+        code.push(op::PUSH1);
+        code.push(0x00);
+        code.push(op::MLOAD);
+        code.push(opcode);
+        code
+    }
+
+    fn run<B: Backend>(
+        compiler: &mut EvmCompiler<B>,
+        name: &str,
+        ext: U256,
+        x: U256,
+        expected: U256,
+    ) {
+        let code = bytecode_binop_opaque(op::SIGNEXTEND, ext, x);
+        unsafe { compiler.clear() }.unwrap();
+        compiler.inspect_stack(true);
+        let f = unsafe { compiler.jit(name, &code, DEF_SPEC) }.unwrap();
+        with_evm_context(&code, DEF_SPEC, |ecx, stack, stack_len| {
+            let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+            assert_eq!(r, InstructionResult::Stop, "{name}: unexpected return");
+            assert_eq!(*stack_len, 1, "{name}: expected 1 stack element");
+            let actual = unsafe { stack.as_slice(*stack_len)[0].to_u256() };
+            assert_eq!(actual, expected, "{name}");
+        });
+    }
+
+    uint! {
+        matrix_tests!(sext_byte0_pos = |jit| run(jit, "sext_byte0_pos", 0_U256, 0x7f_U256, 0x7f_U256));
+        matrix_tests!(sext_byte0_neg = |jit| run(jit, "sext_byte0_neg", 0_U256, 0x80_U256, -0x80_U256));
+        matrix_tests!(sext_byte0_ff = |jit| run(jit, "sext_byte0_ff", 0_U256, 0xff_U256, U256::MAX));
+        matrix_tests!(sext_byte1_pos = |jit| run(jit, "sext_byte1_pos", 1_U256, 0x7fff_U256, 0x7fff_U256));
+        matrix_tests!(sext_byte1_neg = |jit| run(jit, "sext_byte1_neg", 1_U256, 0x8000_U256, -0x8000_U256));
+        matrix_tests!(sext_byte16 = |jit| run(jit, "sext_byte16", 16_U256, 0x80_U256.wrapping_shl(128), -0x80_U256.wrapping_shl(128)));
+        matrix_tests!(sext_noop_31 = |jit| run(jit, "sext_noop_31", 31_U256, 0x42_U256, 0x42_U256));
+        matrix_tests!(sext_noop_max = |jit| run(jit, "sext_noop_max", U256::MAX, 0x42_U256, 0x42_U256));
+    }
+}
+
 fn bytecode_unop(op: u8, a: U256) -> [u8; 34] {
     let mut code = [0; 34];
     let mut i = 0;


### PR DESCRIPTION
Replace the mask+select approach with `shl`+`ashr`:

```
shift = 248 - 8 * ext
result = (x << shift) >>s shift
```

The left shift moves the sign bit to bit 255, then the arithmetic right shift propagates it back down.

**Unoptimized IR**: 13 → 6 instructions
**Optimized IR**: 11 → 6 instructions (branch+phi → branchless select)
**Assembly**: 125 → 110 lines