### PR TITLE
perf: inline BYTE IR builtin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ cargo r -- run usdc_proxy --parse-only     # parse and analyze only (no codegen)
 cargo r -- run usdc_proxy --display        # print parsed bytecode IR
 cargo r -- run usdc_proxy --dot            # render CFG as DOT/SVG
 cargo r -- run usdc_proxy --aot            # compile to shared library
-cargo r -- run custom --code 6001600201    # run custom bytecode
+cargo r -- run custom --code 6001600201    # run custom bytecode (hex)
+cargo r -- run custom --code 'PUSH1 1 PUSH1 2 ADD' # run custom bytecode (asm string)
 ```
 
 Use `RUST_LOG` to control log output:

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -1708,68 +1708,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
 /// IR builtins.
 impl<B: Backend> FunctionCx<'_, B> {
-
-    /// Builds: `fn signextend(ext: u256, x: u256) -> u256`
-    fn build_signextend(&mut self) {
-        // From the yellow paper:
-        /*
-        let [ext, x] = stack.pop();
-        let t = 256 - 8 * (ext + 1);
-        let mut result = x;
-        result[..t] = [x[t]; t]; // Index by bits.
-        */
-
-        let ext = self.bcx.fn_param(0);
-        let x = self.bcx.fn_param(1);
-
-        // For 31 we also don't need to do anything.
-        let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
-        let r = self.bcx.lazy_select(
-            might_do_something,
-            self.bcx.type_int(256),
-            |bcx| {
-                // Adapted from revm: https://github.com/bluealloy/revm/blob/fda371f73aba2c30a83c639608be78145fd1123b/crates/interpreter/src/instructions/arithmetic.rs#L89
-                // let bit_index = 8 * ext + 7;
-                // let bit = (x >> bit_index) & 1 != 0;
-                // let mask = (1 << bit_index) - 1;
-                // let r = if bit { x | !mask } else { *x & mask };
-
-                // let bit_index = 8 * ext + 7;
-                let bit_index = bcx.imul_imm(ext, 8);
-                let bit_index = bcx.iadd_imm(bit_index, 7);
-
-                // let bit = (x >> bit_index) & 1 != 0;
-                let one = bcx.iconst_256(U256::from(1));
-                let bit = bcx.ushr(x, bit_index);
-                let bit = bcx.bitand(bit, one);
-                let bit = bcx.icmp_imm(IntCC::NotEqual, bit, 0);
-
-                // let mask = (1 << bit_index) - 1;
-                let mask = bcx.ishl(one, bit_index);
-                let mask = bcx.isub_imm(mask, 1);
-
-                // let r = if bit { x | !mask } else { *x & mask };
-                let not_mask = bcx.bitnot(mask);
-                let sext = bcx.bitor(x, not_mask);
-                let zext = bcx.bitand(x, mask);
-                bcx.select(bit, sext, zext)
-            },
-            |_bcx| x,
-        );
-        self.bcx.ret(&[r]);
-    }
-
-    fn call_ir_binop_builtin(
-        &mut self,
-        name: &str,
-        x1: B::Value,
-        x2: B::Value,
-        build: fn(&mut Self),
-    ) -> B::Value {
-        let word = self.word_type;
-        self.call_ir_builtin(name, &[x1, x2], &[word, word], Some(word), build).unwrap()
-    }
-
+    #[allow(dead_code)]
     #[must_use]
     fn call_ir_builtin(
         &mut self,

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -830,20 +830,15 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             op::XOR => binop!(bitxor),
             op::NOT => unop!(bitnot),
             op::BYTE => {
-                // index < 32
-                //   ? (value >> (31 - index) * 8) & 0xFF
-                //   : 0
+                // byte(index, value) = (value >> (248 - index * 8)) & 0xFF, or 0 if index >= 32.
                 let [index, value] = self.popn();
-
                 let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
-
-                let thirty_one = self.bcx.iconst_256(U256::from(31));
-                let shift = self.bcx.isub(thirty_one, index);
-                let shift = self.bcx.imul_imm(shift, 8);
+                let shift = self.bcx.imul_imm(index, 8);
+                let c248 = self.bcx.iconst_256(U256::from(248));
+                let shift = self.bcx.isub(c248, shift);
                 let shifted = self.bcx.ushr(value, shift);
                 let mask = self.bcx.iconst_256(U256::from(0xFF));
                 let byte = self.bcx.bitand(shifted, mask);
-
                 let zero = self.bcx.iconst_256(U256::ZERO);
 
                 let r = self.bcx.select(in_range, byte, zero);

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -817,8 +817,17 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             op::XOR => binop!(bitxor),
             op::NOT => unop!(bitnot),
             op::BYTE => {
+                // byte(index, value) = (value >> (31 - index) * 8) & 0xFF, or 0 if index >= 32.
                 let [index, value] = self.popn();
-                let r = self.call_byte(index, value);
+                let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
+                let thirty_one = self.bcx.iconst_256(U256::from(31));
+                let shift = self.bcx.isub(thirty_one, index);
+                let shift = self.bcx.imul_imm(shift, 8);
+                let shifted = self.bcx.ushr(value, shift);
+                let mask = self.bcx.iconst_256(U256::from(0xFF));
+                let byte = self.bcx.bitand(shifted, mask);
+                let zero = self.bcx.iconst_256(U256::ZERO);
+                let r = self.bcx.select(in_range, byte, zero);
                 self.push(r);
             }
             op::SHL => binop!(@shift ishl, |value, shift| self.bcx.iconst_256(U256::ZERO)),
@@ -1680,31 +1689,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
 /// IR builtins.
 impl<B: Backend> FunctionCx<'_, B> {
-    fn call_byte(&mut self, index: B::Value, value: B::Value) -> B::Value {
-        self.call_ir_binop_builtin("byte", index, value, Self::build_byte)
-    }
-
-    /// Builds: `fn byte(index: u256, value: u256) -> u256`
-    fn build_byte(&mut self) {
-        let index = self.bcx.fn_param(0);
-        let value = self.bcx.fn_param(1);
-
-        let cond = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
-        let byte = {
-            // (value >> (31 - index) * 8) & 0xFF
-            let thirty_one = self.bcx.iconst_256(U256::from(31));
-            let shift = self.bcx.isub(thirty_one, index);
-            let shift = self.bcx.imul_imm(shift, 8);
-            let shifted = self.bcx.ushr(value, shift);
-            let mask = self.bcx.iconst_256(U256::from(0xFF));
-            self.bcx.bitand(shifted, mask)
-        };
-        let zero = self.bcx.iconst_256(U256::ZERO);
-        let r = self.bcx.select(cond, byte, zero);
-
-        self.bcx.ret(&[r]);
-    }
-
     fn call_signextend(&mut self, ext: B::Value, x: B::Value) -> B::Value {
         self.call_ir_binop_builtin("signextend", ext, x, Self::build_signextend)
     }

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -830,15 +830,20 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             op::XOR => binop!(bitxor),
             op::NOT => unop!(bitnot),
             op::BYTE => {
-                // byte(index, value) = (value >> (248 - index * 8)) & 0xFF, or 0 if index >= 32.
+                // index < 32
+                //   ? (value >> (248 - index * 8)) & 0xFF
+                //   : 0
                 let [index, value] = self.popn();
+
                 let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
+
                 let shift = self.bcx.imul_imm(index, 8);
                 let c248 = self.bcx.iconst_256(U256::from(248));
                 let shift = self.bcx.isub(c248, shift);
                 let shifted = self.bcx.ushr(value, shift);
                 let mask = self.bcx.iconst_256(U256::from(0xFF));
                 let byte = self.bcx.bitand(shifted, mask);
+
                 let zero = self.bcx.iconst_256(U256::ZERO);
 
                 let r = self.bcx.select(in_range, byte, zero);

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -817,16 +817,22 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             op::XOR => binop!(bitxor),
             op::NOT => unop!(bitnot),
             op::BYTE => {
-                // byte(index, value) = (value >> (31 - index) * 8) & 0xFF, or 0 if index >= 32.
+                // index < 32
+                //   ? (value >> (31 - index) * 8) & 0xFF
+                //   : 0
                 let [index, value] = self.popn();
+
                 let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
+
                 let thirty_one = self.bcx.iconst_256(U256::from(31));
                 let shift = self.bcx.isub(thirty_one, index);
                 let shift = self.bcx.imul_imm(shift, 8);
                 let shifted = self.bcx.ushr(value, shift);
                 let mask = self.bcx.iconst_256(U256::from(0xFF));
                 let byte = self.bcx.bitand(shifted, mask);
+
                 let zero = self.bcx.iconst_256(U256::ZERO);
+
                 let r = self.bcx.select(in_range, byte, zero);
                 self.push(r);
             }


### PR DESCRIPTION
Same as #330 but for `BYTE` — inline the IR builtin directly into the opcode translation, removing the `call_byte`/`build_byte` helper functions.