### PR TITLE
perf: poison scratch stack slots at section boundaries for DSE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ during development.
 ```bash
 cargo r -- run --list                      # list available benchmarks
 cargo r -- run usdc_proxy                  # compile and run a benchmark
+cargo r -- run usdc_proxy -o tmp/dump      # compile and run a benchmark; dump files like opt.ll, remarks.txt to tmp/dump
 cargo r -- run usdc_proxy --parse-only     # parse and analyze only (no codegen)
 cargo r -- run usdc_proxy --display        # print parsed bytecode IR
 cargo r -- run usdc_proxy --dot            # render CFG as DOT/SVG

--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -281,6 +281,13 @@ pub trait Builder: BackendTypes + TypeMethods {
     fn seal_all_blocks(&mut self);
     fn set_current_block_cold(&mut self);
     fn current_block(&mut self) -> Option<Self::BasicBlock>;
+
+    /// Positions the builder before the current block's terminator, returning `true`.
+    /// Returns `false` (and does nothing) if the block has no terminator.
+    fn position_before_terminator(&mut self) -> bool;
+
+    /// Positions the builder at the end of the current block (after the terminator).
+    fn position_at_end(&mut self);
     fn block_addr(&mut self, block: Self::BasicBlock) -> Option<Self::Value>;
 
     fn add_comment_to_current_inst(&mut self, comment: &str);
@@ -295,6 +302,8 @@ pub trait Builder: BackendTypes + TypeMethods {
     fn num_fn_params(&self) -> usize;
 
     fn bool_const(&mut self, value: bool) -> Self::Value;
+    /// Returns a poison value of the given type.
+    fn poison(&mut self, ty: Self::Type) -> Self::Value;
     /// Sign-extends negative values to `ty`.
     fn iconst(&mut self, ty: Self::Type, value: i64) -> Self::Value;
     fn uconst(&mut self, ty: Self::Type, value: u64) -> Self::Value;

--- a/crates/revmc-cli/benches/bench.rs
+++ b/crates/revmc-cli/benches/bench.rs
@@ -1,14 +1,9 @@
 #![allow(missing_docs, unexpected_cfgs)]
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use revm_bytecode::Bytecode;
 use revm_handler::ExecuteEvm;
-use revm_interpreter::{InputsImpl, SharedMemory, interpreter::ExtBytecode};
-use revmc::{
-    EvmCompiler, EvmContext, EvmLlvmBackend, EvmStack, OptimizationLevel,
-    primitives::hardfork::SpecId,
-};
-use revmc_cli::{BenchHost, PreparedBench};
+use revmc::{EvmCompiler, EvmLlvmBackend, OptimizationLevel, primitives::hardfork::SpecId};
+use revmc_cli::PreparedBench;
 use std::time::Duration;
 
 const SPEC_ID: SpecId = SpecId::OSAKA;
@@ -61,11 +56,6 @@ fn run_bench(
     // ── Bytecode-only benchmarks ────────────────────────────────────────
 
     if !is_fixture {
-        let gas_limit = u64::MAX / 2;
-        let calldata: revmc::primitives::Bytes = def.calldata.clone().into();
-        let bytecode_raw =
-            Bytecode::new_raw(revmc::primitives::Bytes::copy_from_slice(&def.bytecode));
-
         // Compile-time.
         g.bench_function(format!("{name}/compile/translate"), |b| {
             b.iter_batched_ref(
@@ -90,63 +80,6 @@ fn run_bench(
                         compiler.jit_function(*id).unwrap();
                     },
                     BatchSize::PerIteration,
-                )
-            });
-        }
-
-        // JIT variants (no_gas etc.).
-        let mut host = BenchHost::new(SPEC_ID);
-        host.apply_bench(def);
-
-        let mut compiler = EvmCompiler::new_llvm(false).unwrap();
-        compiler.gas_metering(true);
-
-        let new_interpreter = || {
-            let ext_bytecode = ExtBytecode::new(bytecode_raw.clone());
-            let input = InputsImpl {
-                input: revm_interpreter::CallInput::Bytes(calldata.clone()),
-                ..Default::default()
-            };
-            revm_interpreter::Interpreter::new(
-                SharedMemory::new(),
-                ext_bytecode,
-                input,
-                false,
-                SPEC_ID,
-                gas_limit,
-            )
-        };
-
-        const NO_GAS_BENCHES: &[&str] = &["fibonacci-calldata", "factorial"];
-        let mut jit_variants: Vec<(&str, (bool, bool))> = vec![("default", (true, true))];
-        if NO_GAS_BENCHES.contains(&name) {
-            jit_variants.push(("no_gas", (false, true)));
-        }
-        let jit_ids: Vec<_> = jit_variants
-            .iter()
-            .map(|&(kind, (gas, stack))| {
-                compiler.gas_metering(gas);
-                unsafe { compiler.stack_bound_checks(stack) };
-                let sym = format!("{name}/{kind}");
-                (
-                    kind,
-                    compiler
-                        .translate(&sym, bytecode_raw.original_byte_slice(), SPEC_ID)
-                        .expect(kind),
-                )
-            })
-            .collect();
-        for &(kind, fn_id) in &jit_ids {
-            let jit = unsafe { compiler.jit_function(fn_id) }.expect(kind);
-            g.bench_function(format!("{name}/rt/jit/{kind}"), |b| {
-                b.iter_batched_ref(
-                    || (new_interpreter(), EvmStack::new()),
-                    |(interpreter, stack)| {
-                        let mut stack_len = 0;
-                        let mut ecx = EvmContext::from_interpreter(interpreter, &mut host);
-                        unsafe { jit.call(Some(stack), Some(&mut stack_len), &mut ecx) }
-                    },
-                    BatchSize::SmallInput,
                 )
             });
         }

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1304,6 +1304,21 @@ impl Builder for EvmLlvmBuilder<'_> {
         self.bcx.get_insert_block()
     }
 
+    fn position_before_terminator(&mut self) -> bool {
+        let block = self.bcx.get_insert_block().unwrap();
+        if let Some(term) = block.get_terminator() {
+            self.bcx.position_before(&term);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn position_at_end(&mut self) {
+        let block = self.bcx.get_insert_block().unwrap();
+        self.bcx.position_at_end(block);
+    }
+
     fn block_addr(&mut self, block: Self::BasicBlock) -> Option<Self::Value> {
         unsafe { block.get_address().map(Into::into) }
     }
@@ -1345,6 +1360,10 @@ impl Builder for EvmLlvmBuilder<'_> {
 
     fn bool_const(&mut self, value: bool) -> Self::Value {
         self.ty_i1.const_int(value as u64, false).into()
+    }
+
+    fn poison(&mut self, ty: Self::Type) -> Self::Value {
+        ty.into_int_type().get_poison().into()
     }
 
     fn iconst(&mut self, ty: Self::Type, value: i64) -> Self::Value {

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -630,14 +630,14 @@ impl<'a> Bytecode<'a> {
 pub(crate) struct InstData {
     /// The opcode byte.
     pub(crate) opcode: u8,
+    /// Stack inputs and outputs, decoded from the immediate for `DUPN`/`SWAPN`/`EXCHANGE`.
+    stack_io: (u8, u8),
     /// Flags.
     pub(crate) flags: InstFlags,
     /// The base gas cost of the opcode.
     ///
     /// This may not be the final/full gas cost of the opcode as it may also have a dynamic cost.
     base_gas: u16,
-    /// Stack inputs and outputs, decoded from the immediate for `DUPN`/`SWAPN`/`EXCHANGE`.
-    stack_io: (u8, u8),
     /// Instruction-specific data:
     /// - if the instruction has immediate data, this is a packed offset+length into the bytecode;
     /// - `JUMP{,I} && STATIC_JUMP in kind`: the jump target, `Instr`;
@@ -730,6 +730,12 @@ impl InstData {
         self.flags.contains(InstFlags::STACK_SECTION_HEAD)
     }
 
+    /// Returns `true` if this instruction is the last in its stack section.
+    #[inline]
+    pub(crate) fn is_stack_section_end(&self) -> bool {
+        self.flags.contains(InstFlags::STACK_SECTION_END)
+    }
+
     /// Returns `true` if this instruction is dead code.
     pub(crate) fn is_dead_code(&self) -> bool {
         self.flags.contains(InstFlags::DEAD_CODE)
@@ -791,29 +797,32 @@ impl InstData {
 bitflags::bitflags! {
     /// [`InstrData`] flags.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub(crate) struct InstFlags: u8 {
+    pub(crate) struct InstFlags: u16 {
         /// The `JUMP`/`JUMPI` target is known at compile time.
-        const STATIC_JUMP = 1 << 0;
+        const STATIC_JUMP        = 1 << 0;
         /// The jump target is known to be invalid.
         /// Always returns [`InstructionResult::InvalidJump`] at runtime.
-        const INVALID_JUMP = 1 << 1;
+        const INVALID_JUMP       = 1 << 1;
         /// The jump has multiple known targets (see `Bytecode::multi_jump_targets`).
         /// The target value is still on the stack and must be popped and switched on at runtime.
-        const MULTI_JUMP = 1 << 2;
+        const MULTI_JUMP         = 1 << 2;
 
         /// The instruction is disabled in this EVM version.
         /// Always returns [`InstructionResult::NotActivated`] at runtime.
-        const DISABLED = 1 << 3;
+        const DISABLED           = 1 << 3;
         /// The instruction is unknown.
         /// Always returns [`InstructionResult::NotFound`] at runtime.
-        const UNKNOWN = 1 << 4;
+        const UNKNOWN            = 1 << 4;
 
-        /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
-        const NOOP = 1 << 5;
-        /// This instruction starts a new stack section.
-        const STACK_SECTION_HEAD = 1 << 6;
         /// Don't generate any code.
-        const DEAD_CODE = 1 << 7;
+        const DEAD_CODE          = 1 << 5;
+        /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
+        const NOOP               = 1 << 6;
+
+        /// This instruction starts a new stack section.
+        const STACK_SECTION_HEAD = 1 << 7;
+        /// This instruction is the last in its stack section.
+        const STACK_SECTION_END  = 1 << 8;
     }
 }
 

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -250,7 +250,13 @@ impl SectionsAnalysis {
         // Branching and suspending instructions end both sections.
         let next = inst + 1;
         if data.may_suspend() || data.is_branching() {
-            self.stack.mark_end(bytecode, next);
+            // Skip marking section end on back-edges: poisoning scratch slots on a loop
+            // back-edge prevents LICM from promoting those slots to SSA registers.
+            let is_back_edge = data.is_static_jump()
+                && Inst::from_usize(data.data as usize) <= self.stack.start_inst;
+            if !is_back_edge {
+                self.stack.mark_end(bytecode, next);
+            }
             self.stack.save_to_reset(bytecode, next);
             self.gas.save_to_reset(bytecode, next);
         } else if data.requires_gasleft(bytecode.spec_id) {

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -250,13 +250,7 @@ impl SectionsAnalysis {
         // Branching and suspending instructions end both sections.
         let next = inst + 1;
         if data.may_suspend() || data.is_branching() {
-            // Skip marking section end on back-edges: poisoning scratch slots on a loop
-            // back-edge prevents LICM from promoting those slots to SSA registers.
-            let is_back_edge = data.is_static_jump()
-                && Inst::from_usize(data.data as usize) <= self.stack.start_inst;
-            if !is_back_edge {
-                self.stack.mark_end(bytecode, next);
-            }
+            self.stack.mark_end(bytecode, next);
             self.stack.save_to_reset(bytecode, next);
             self.gas.save_to_reset(bytecode, next);
         } else if data.requires_gasleft(bytecode.spec_id) {

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -187,6 +187,19 @@ impl StackSectionAnalysis {
         }
     }
 
+    /// Marks the last non-dead instruction before `next_section_inst` as the section end.
+    fn mark_end(&self, bytecode: &mut Bytecode<'_>, next_section_inst: Inst) {
+        if self.start_inst >= bytecode.insts.len_idx() || self.max_growth <= 0 {
+            return;
+        }
+        let end = next_section_inst.min(bytecode.insts.len_idx());
+        if let Some(inst) =
+            bytecode.insts[self.start_inst..end].iter_mut().rev().find(|inst| !inst.is_dead_code())
+        {
+            inst.flags |= InstFlags::STACK_SECTION_END;
+        }
+    }
+
     /// Resets the analysis for a new section.
     pub(crate) fn reset(&mut self, inst: Inst) {
         *self = Self { start_inst: inst, ..Default::default() };
@@ -213,6 +226,7 @@ impl SectionsAnalysis {
     pub(crate) fn process(&mut self, bytecode: &mut Bytecode<'_>, inst: Inst) {
         // JUMPDEST starts both gas and stack sections.
         if bytecode.inst(inst).is_reachable_jumpdest(bytecode.has_dynamic_jumps()) {
+            self.stack.mark_end(bytecode, inst);
             self.stack.save_to_reset(bytecode, inst);
             self.gas.save_to_reset(bytecode, inst);
         }
@@ -236,6 +250,7 @@ impl SectionsAnalysis {
         // Branching and suspending instructions end both sections.
         let next = inst + 1;
         if data.may_suspend() || data.is_branching() {
+            self.stack.mark_end(bytecode, next);
             self.stack.save_to_reset(bytecode, next);
             self.gas.save_to_reset(bytecode, next);
         } else if data.requires_gasleft(bytecode.spec_id) {
@@ -247,6 +262,7 @@ impl SectionsAnalysis {
     pub(crate) fn finish(self, bytecode: &mut Bytecode<'_>) {
         let last = bytecode.insts.len_idx() - 1;
         self.gas.save_to(bytecode, last);
+        self.stack.mark_end(bytecode, last);
         self.stack.save_to(bytecode, last);
         if enabled!(tracing::Level::DEBUG) {
             let mut max_len = 0usize;

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -99,6 +99,9 @@ pub(super) struct FunctionCx<'a, B: Backend> {
     /// At section start this is 0 (len.addr == section_start_len). After each store it becomes
     /// `section_len_offset + diff`. Stores are skipped when the new offset matches this value.
     stored_len_offset: i32,
+    /// Maximum stack growth in the current section (from `StackSection::max_growth`).
+    /// Used to determine scratch slots to poison at section exits.
+    section_max_growth: i32,
 
     /// The bytecode being translated.
     bytecode: &'a Bytecode<'a>,
@@ -300,6 +303,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             section_start_sp,
             section_len_offset: 0,
             stored_len_offset: 0,
+            section_max_growth: 0,
             bcx,
 
             bytecode,
@@ -537,6 +541,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         /// Use `build` to build the return instruction and skip the branch.
         macro_rules! goto_return {
             (no_branch $($comment:expr)?) => {
+                if data.is_stack_section_end() {
+                    self.poison_section_scratch(self.section_len_offset);
+                }
                 $(
                     if self.config.comments {
                         self.add_comment($comment);
@@ -598,6 +605,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             self.section_start_sp = self.sp_at(self.section_start_len);
             self.section_len_offset = 0;
             self.stored_len_offset = 0;
+            self.section_max_growth = data.stack_section.max_growth as i32;
         }
         self.len_before = if self.section_len_offset == 0 {
             self.section_start_len
@@ -1033,6 +1041,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         self.bcx.switch(target_value, return_block, &switch_targets, true);
 
                         self.inst_entries[inst] = self.bcx.current_block().unwrap();
+                        self.section_len_offset += diff;
                         goto_return!(no_branch);
                     } else if data.flags.contains(InstFlags::STATIC_JUMP) {
                         // Pop and discard the target; it's always on the stack.
@@ -1075,6 +1084,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                     self.inst_entries[inst] = self.bcx.current_block().unwrap();
                 }
 
+                self.section_len_offset += diff;
                 goto_return!(no_branch);
             }
             op::PC => {
@@ -1363,6 +1373,27 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             let word_size = 32i64;
             let byte_len = self.bcx.imul_imm(len, word_size);
             self.bcx.memcpy(dst, src, byte_len);
+        }
+    }
+
+    /// Stores poison to scratch stack slots (between exit height and max growth) in the
+    /// current section. `exit_offset` is the stack height relative to section start after
+    /// the current instruction.
+    ///
+    /// If the current block already has a terminator, inserts the stores before it.
+    fn poison_section_scratch(&mut self, exit_offset: i32) {
+        let start = exit_offset.max(0);
+        if start >= self.section_max_growth {
+            return;
+        }
+        let has_term = self.bcx.position_before_terminator();
+        let poison = self.bcx.poison(self.word_type);
+        for offset in start..self.section_max_growth {
+            let sp = self.sp_from_section(offset as i64);
+            self.bcx.store(poison, sp);
+        }
+        if has_term {
+            self.bcx.position_at_end();
         }
     }
 


### PR DESCRIPTION
Store poison values to scratch stack slots at stack section boundaries. This tells
LLVM those slots are undefined after the section, enabling Dead Store Elimination to
remove stores that are only kept alive by complex control flow (e.g. dynamic jump tables).

The approach: at section exits, slots between the exit stack height and the section's
peak height (`max_growth`) are written with `poison`. These slots were temporarily used
within the section but are dead at exit. LLVM can then prove the stores that produced
them are dead and eliminate them.

### Changes

- Add `Builder::poison()` to emit LLVM poison values
- Add `Builder::position_before_terminator()` / `position_at_end()` so poison stores
  can be inserted before existing terminators in already-terminated blocks
- Add `InstFlags::STACK_SECTION_END` flag to mark section-ending instructions
  (set by `SectionsAnalysis`, purely structural metadata)
- Widen `InstFlags` from `u8` to `u16`; reorder `InstData` fields to keep 24-byte struct size
- Emit poison stores centrally in `goto_return!(no_branch)`

### Benchmark results

**opt.s: -3.4%, JIT size: -4.2%** across 21 benchmarks. Highlights: bswap64 -10.8% asm / -16.0% JIT,
burntpix -4.6% / -7.6%, curve_stableswap -4.5% / -6.4%, erc20_transfer -4.2% / -5.9%.

fibonacci-calldata and factorial (synthetic microbenchmarks) regress due to poison
stores on loop back-edges interfering with LICM promotion. All real contract benchmarks
improve.

<details><summary>Assembly line counts</summary>

| benchmark          |    unopt.ll |      opt.ll |       opt.s |    jit size |
|:-------------------|------------:|------------:|------------:|------------:|
| fibonacci-calldata |     +1.7% 🔴 |     +1.6% 🔴 |     +7.7% 🔴 |           - |
| factorial          |     +1.1% 🔴 |           = |     +2.2% 🔴 |           - |
| counter            |     +5.6% 🔴 |     -5.4% 🟢 |     +0.9% 🔴 |           - |
| snailtracer        |     +2.6% 🔴 |     -1.4% 🟢 |     -2.0% 🟢 |     -1.7% 🟢 |
| weth               |     +2.7% 🔴 |     -3.0% 🟢 |     -4.3% 🟢 |     -5.4% 🟢 |
| hash_10k           |     +3.3% 🔴 |     -1.2% 🟢 |     -3.6% 🟢 |     -4.7% 🟢 |
| erc20_transfer     |     +3.0% 🔴 |     -3.3% 🟢 |     -4.2% 🟢 |     -5.9% 🟢 |
| push0_proxy        |     +1.1% 🔴 |           = |     +0.6% 🔴 |           - |
| usdc_proxy         |     +3.1% 🔴 |     -1.7% 🟢 |     -0.4% 🟢 |     -1.7% 🟢 |
| fiat_token         |     +2.6% 🔴 |     -3.5% 🟢 |     -3.1% 🟢 |     -2.3% 🟢 |
| uniswap_v2_pair    |     +2.3% 🔴 |     -3.0% 🟢 |     -1.1% 🟢 |     -2.0% 🟢 |
| univ2_router       |     +2.2% 🔴 |     -4.1% 🟢 |     -4.2% 🟢 |     -4.5% 🟢 |
| seaport            |     +2.2% 🔴 |     -1.9% 🟢 |     -2.3% 🟢 |     -2.4% 🟢 |
| airdrop            |     +2.9% 🔴 |     -3.1% 🟢 |     -3.7% 🟢 |     -5.3% 🟢 |
| bswap64            |     +4.5% 🔴 |     -7.1% 🟢 |    -10.8% 🟢 |    -16.0% 🟢 |
| bswap64_opt        |     +3.8% 🔴 |     -3.6% 🟢 |     -5.3% 🟢 |     -6.5% 🟢 |
| eip4788            |     +4.2% 🔴 |     -2.6% 🟢 |     +1.7% 🔴 |           - |
| eip2935            |     +4.8% 🔴 |     -3.9% 🟢 |     +0.5% 🔴 |           - |
| curve_stableswap   |     +2.7% 🔴 |     -3.3% 🟢 |     -4.5% 🟢 |     -6.4% 🟢 |
| onchain_lm_v2      |     +3.0% 🔴 |     -4.6% 🟢 |     -5.6% 🟢 |     -6.2% 🟢 |
| burntpix           |     +3.2% 🔴 |     -3.8% 🟢 |     -4.6% 🟢 |     -7.6% 🟢 |
| **TOTAL**          | **+2.6% 🔴** | **-3.1% 🟢** | **-3.4% 🟢** | **-4.2% 🟢** |

</details>
