### PR TITLE
refactor: make iconst_256 take impl TryInto<U256>

### DIFF
--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -298,7 +298,7 @@ pub trait Builder: BackendTypes + TypeMethods {
     /// Sign-extends negative values to `ty`.
     fn iconst(&mut self, ty: Self::Type, value: i64) -> Self::Value;
     fn uconst(&mut self, ty: Self::Type, value: u64) -> Self::Value;
-    fn iconst_256(&mut self, value: U256) -> Self::Value;
+    fn iconst_256(&mut self, value: impl TryInto<U256>) -> Self::Value;
     fn cstr_const(&mut self, value: &std::ffi::CStr) -> Self::Value {
         self.str_const(value.to_str().unwrap())
     }

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1355,7 +1355,8 @@ impl Builder for EvmLlvmBuilder<'_> {
         ty.into_int_type().const_int(value, false).into()
     }
 
-    fn iconst_256(&mut self, value: U256) -> Self::Value {
+    fn iconst_256(&mut self, value: impl TryInto<U256>) -> Self::Value {
+        let value = value.try_into().ok().expect("invalid U256 value");
         if let Ok(low) = value.try_into() {
             return self.ty_i256.const_int(low, false).into();
         }

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -795,7 +795,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 let might_do_something = self.bcx.icmp_imm(IntCC::UnsignedLessThan, ext, 31);
 
                 let shift = self.bcx.imul_imm(ext, 8);
-                let c248 = self.bcx.iconst_256(U256::from(248));
+                let c248 = self.bcx.iconst_256(248);
                 let shift = self.bcx.isub(c248, shift);
                 let shifted = self.bcx.ishl(x, shift);
                 let sext = self.bcx.sshr(shifted, shift);
@@ -838,23 +838,23 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, index, 32);
 
                 let shift = self.bcx.imul_imm(index, 8);
-                let c248 = self.bcx.iconst_256(U256::from(248));
+                let c248 = self.bcx.iconst_256(248);
                 let shift = self.bcx.isub(c248, shift);
                 let shifted = self.bcx.ushr(value, shift);
-                let mask = self.bcx.iconst_256(U256::from(0xFF));
+                let mask = self.bcx.iconst_256(0xFF);
                 let byte = self.bcx.bitand(shifted, mask);
 
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
 
                 let r = self.bcx.select(in_range, byte, zero);
                 self.push(r);
             }
-            op::SHL => binop!(@shift ishl, |value, shift| self.bcx.iconst_256(U256::ZERO)),
-            op::SHR => binop!(@shift ushr, |value, shift| self.bcx.iconst_256(U256::ZERO)),
+            op::SHL => binop!(@shift ishl, |value, shift| self.bcx.iconst_256(0)),
+            op::SHR => binop!(@shift ushr, |value, shift| self.bcx.iconst_256(0)),
             op::SAR => binop!(@shift sshr, |value, shift| {
                 let is_negative = self.bcx.icmp_imm(IntCC::SignedLessThan, value, 0);
                 let max = self.bcx.iconst_256(U256::MAX);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.bcx.select(is_negative, max, zero)
             }),
             op::CLZ => unop!(clz),
@@ -1078,7 +1078,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 goto_return!(no_branch);
             }
             op::PC => {
-                let pc = self.bcx.iconst_256(U256::from(data.pc));
+                let pc = self.bcx.iconst_256(data.pc);
                 self.push(pc);
             }
             op::MSIZE => {
@@ -1108,7 +1108,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }
 
             op::PUSH0 => {
-                let value = self.bcx.iconst_256(U256::ZERO);
+                let value = self.bcx.iconst_256(0);
                 self.push(value);
             }
             op::PUSH1..=op::PUSH32 => {

--- a/crates/revmc/src/compiler/translate/peephole.rs
+++ b/crates/revmc/src/compiler/translate/peephole.rs
@@ -52,7 +52,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x / 0 => 0.
             Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             // x / 1 => x.
@@ -70,7 +70,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // 0 / x => 0 (EVM: 0 / 0 = 0).
             _ if dividend == Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => return false,
@@ -88,7 +88,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x / 0 => 0.
             Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             // x / 1 => x.
@@ -99,7 +99,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x / -1 => -x.
             Some(U256::MAX) => {
                 let [a, _] = self.popn();
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 let r = self.bcx.isub(zero, a);
                 self.push(r);
             }
@@ -114,7 +114,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // 0 / x => 0 (EVM: 0 / 0 = 0).
             _ if dividend == Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => return false,
@@ -131,7 +131,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x % 0 => 0, x % 1 => 0.
             Some(U256::ZERO) | Some(U256::ONE) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             // x % C (pow2) => native urem, LLVM lowers to and.
@@ -144,7 +144,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // 0 % x => 0 (EVM: 0 % 0 = 0).
             _ if dividend == Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => return false,
@@ -159,13 +159,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x % 0 => 0, x % 1 => 0, x % -1 => 0.
             Some(U256::ZERO) | Some(U256::ONE) | Some(U256::MAX) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             // 0 % x => 0 (EVM: 0 % 0 = 0).
             _ if dividend == Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => return false,
@@ -180,14 +180,14 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // (a + b) % 0 => 0, (a + b) % 1 => 0.
             Some(U256::ZERO) | Some(U256::ONE) => {
                 self.pop_ignore(3);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => match (a, b) {
                 // (0 + 0) % N => 0.
                 (Some(U256::ZERO), Some(U256::ZERO)) => {
                     self.pop_ignore(3);
-                    let zero = self.bcx.iconst_256(U256::ZERO);
+                    let zero = self.bcx.iconst_256(0);
                     self.push(zero);
                 }
                 _ => return false,
@@ -203,14 +203,14 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // (a * b) % 0 => 0, (a * b) % 1 => 0.
             Some(U256::ZERO) | Some(U256::ONE) => {
                 self.pop_ignore(3);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => {
                 // a * 0 => 0, 0 * b => 0.
                 if a == Some(U256::ZERO) || b == Some(U256::ZERO) {
                     self.pop_ignore(3);
-                    let zero = self.bcx.iconst_256(U256::ZERO);
+                    let zero = self.bcx.iconst_256(0);
                     self.push(zero);
                 } else {
                     return false;
@@ -230,7 +230,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // x ** 0 => 1.
             Some(U256::ZERO) => {
                 self.pop_ignore(2);
-                let one = self.bcx.iconst_256(U256::from(1));
+                let one = self.bcx.iconst_256(1);
                 self.push(one);
             }
             // x ** 1 => x.
@@ -270,7 +270,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             // BYTE(i, x) with i >= 32 => 0.
             Some(i) if i >= U256::from(32) => {
                 self.pop_ignore(2);
-                let zero = self.bcx.iconst_256(U256::ZERO);
+                let zero = self.bcx.iconst_256(0);
                 self.push(zero);
             }
             _ => return false,


### PR DESCRIPTION
Use bare integer literals at all callsites instead of `U256::from(...)` and `U256::ZERO`. `U256::MAX` and `INT_MIN` remain as-is since they need the full 256-bit type.