### PR TITLE
chore: fix sections stats, log longest blocks, improve bench script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ counts, compile times, jump resolution stats, and constant-input statistics.
 ./scripts/bench.py /tmp/bench --diff main --codegen-lines          # codegen lines only
 ./scripts/bench.py /tmp/bench --jump-resolution                    # jump resolution stats
 ./scripts/bench.py /tmp/bench --input-stats                        # constant-input stats
+./scripts/bench.py /tmp/bench --block-stats                        # block stats (min/max/avg/median, suspends)
 ./scripts/bench.py /tmp/bench --codegen-lines --jump-resolution    # combine multiple analyses
 ```
 

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -44,8 +44,8 @@ impl Bytecode<'_> {
         lines.push((
             String::new(),
             format!(
-                "insts={} live={} dead={} noops={} suspends={} blocks={}",
-                s.total, s.live, s.dead, s.noops, s.suspends, s.blocks,
+                "insts={} live={} dead={} noops={} suspends={} blocks={} block_min={} block_max={} block_avg={:.1} block_median={}",
+                s.total, s.live, s.dead, s.noops, s.suspends, s.blocks, s.block_min, s.block_max, s.block_avg, s.block_median,
             ),
         ));
         lines.push((String::new(), String::new()));

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -32,11 +32,24 @@ impl Bytecode<'_> {
         let ic_width = decimal_width(max_ic);
         let pc_width = decimal_width(max_pc);
 
+        let total_insts = self.insts.len();
+        let live_insts = self.iter_insts().count();
+        let dead_insts = total_insts - live_insts;
+        let noops = self.iter_insts().filter(|(_, d)| d.flags.contains(InstFlags::NOOP)).count();
+        let suspends = self.iter_insts().filter(|(_, d)| d.may_suspend()).count();
+        let n_blocks = self.cfg.blocks.len();
+
         lines.push((
             String::new(),
             format!(
                 "spec_id={} has_dynamic_jumps={} may_suspend={}",
                 self.spec_id, self.has_dynamic_jumps, self.may_suspend,
+            ),
+        ));
+        lines.push((
+            String::new(),
+            format!(
+                "insts={total_insts} live={live_insts} dead={dead_insts} noops={noops} suspends={suspends} blocks={n_blocks}",
             ),
         ));
         lines.push((String::new(), String::new()));

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -565,7 +565,8 @@ mod tests {
         snapbox::assert_data_eq!(
             actual,
             snapbox::str![[r#"
-               ; spec_id=Osaka has_dynamic_jumps=false may_suspend=true
+; spec_id=Osaka has_dynamic_jumps=false may_suspend=true
+; insts=19 live=19 dead=0 noops=11 suspends=1 blocks=3 block_min=2 block_max=10 block_avg=6.3 block_median=7
 
 bb0:           ; stack_in=0 max_growth=1 predecessors=
   PUSH1 0x03   ; ic= 0 pc= 0 gas=11 noop

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -183,6 +183,8 @@ impl Bytecode<'_> {
                 writeln!(f)?;
             } else if comment.is_empty() {
                 writeln!(f, "{text}")?;
+            } else if text.is_empty() {
+                writeln!(f, "; {comment}")?;
             } else {
                 writeln!(f, "{text:<comment_col$} ; {comment}")?;
             }

--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -32,12 +32,7 @@ impl Bytecode<'_> {
         let ic_width = decimal_width(max_ic);
         let pc_width = decimal_width(max_pc);
 
-        let total_insts = self.insts.len();
-        let live_insts = self.iter_insts().count();
-        let dead_insts = total_insts - live_insts;
-        let noops = self.iter_insts().filter(|(_, d)| d.flags.contains(InstFlags::NOOP)).count();
-        let suspends = self.iter_insts().filter(|(_, d)| d.may_suspend()).count();
-        let n_blocks = self.cfg.blocks.len();
+        let s = self.ir_stats();
 
         lines.push((
             String::new(),
@@ -49,7 +44,8 @@ impl Bytecode<'_> {
         lines.push((
             String::new(),
             format!(
-                "insts={total_insts} live={live_insts} dead={dead_insts} noops={noops} suspends={suspends} blocks={n_blocks}",
+                "insts={} live={} dead={} noops={} suspends={} blocks={}",
+                s.total, s.live, s.dead, s.noops, s.suspends, s.blocks,
             ),
         ));
         lines.push((String::new(), String::new()));

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -605,12 +605,9 @@ impl<'a> Bytecode<'a> {
         trace!("{buf}");
     }
 
-    /// Logs IR statistics: instruction counts, block size distribution, and top 5 longest blocks.
-    #[inline(never)]
-    fn log_ir_stats(&self) {
-        use std::fmt::Write;
-
-        let total_insts = self.insts.len();
+    /// Collects IR statistics: instruction counts and block count.
+    fn ir_stats(&self) -> IrStats {
+        let total = self.insts.len();
         let mut live = 0usize;
         let mut noops = 0usize;
         let mut dead = 0usize;
@@ -628,13 +625,23 @@ impl<'a> Bytecode<'a> {
                 }
             }
         }
+        IrStats { total, live, dead, noops, suspends, blocks: self.cfg.blocks.len() }
+    }
+
+    /// Logs IR statistics and top 5 longest blocks at trace level.
+    #[inline(never)]
+    fn log_ir_stats(&self) {
+        use std::fmt::Write;
+
+        let s = self.ir_stats();
 
         let mut lens: Vec<(Block, usize)> = self
             .cfg
             .blocks
             .iter_enumerated()
             .map(|(block, data)| {
-                let n = data.insts().filter(|&i| !self.inst(i).is_dead_code()).count();
+                let n = data.insts().len();
+                debug_assert_eq!(n, data.insts().filter(|&i| !self.inst(i).is_dead_code()).count());
                 (block, n)
             })
             .collect();
@@ -648,12 +655,12 @@ impl<'a> Bytecode<'a> {
         let median = if n_blocks > 0 { lens[n_blocks / 2].1 } else { 0 };
 
         trace!(
-            total_insts,
-            live,
-            dead,
-            noops,
-            suspends,
-            blocks = n_blocks,
+            total_insts = s.total,
+            live = s.live,
+            dead = s.dead,
+            noops = s.noops,
+            suspends = s.suspends,
+            blocks = s.blocks,
             block_min = min,
             block_max = max,
             block_avg = format_args!("{avg:.1}"),
@@ -691,6 +698,16 @@ impl<'a> Bytecode<'a> {
         }
         s
     }
+}
+
+/// Summary IR statistics for a compiled bytecode.
+pub(crate) struct IrStats {
+    pub(crate) total: usize,
+    pub(crate) live: usize,
+    pub(crate) dead: usize,
+    pub(crate) noops: usize,
+    pub(crate) suspends: usize,
+    pub(crate) blocks: usize,
 }
 
 /// A single instruction in the bytecode.

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -347,11 +347,8 @@ impl<'a> Bytecode<'a> {
             "constant folding gas budget",
         );
 
-        if tracing::enabled!(tracing::Level::DEBUG) {
-            self.log_block_stats();
-        }
-
         if tracing::enabled!(tracing::Level::TRACE) {
+            self.log_ir_stats();
             self.log_const_input_stats();
         }
 
@@ -608,51 +605,71 @@ impl<'a> Bytecode<'a> {
         trace!("{buf}");
     }
 
-    /// Logs basic block statistics at debug level and top 5 longest blocks at trace level.
+    /// Logs IR statistics: instruction counts, block size distribution, and top 5 longest blocks.
     #[inline(never)]
-    fn log_block_stats(&self) {
+    fn log_ir_stats(&self) {
         use std::fmt::Write;
+
+        let total_insts = self.insts.len();
+        let mut live = 0usize;
+        let mut noops = 0usize;
+        let mut dead = 0usize;
+        let mut suspends = 0usize;
+        for (_inst, data) in self.iter_all_insts() {
+            if data.is_dead_code() {
+                dead += 1;
+            } else {
+                live += 1;
+                if data.flags.contains(InstFlags::NOOP) {
+                    noops += 1;
+                }
+                if data.may_suspend() {
+                    suspends += 1;
+                }
+            }
+        }
 
         let mut lens: Vec<(Block, usize)> = self
             .cfg
             .blocks
             .iter_enumerated()
             .map(|(block, data)| {
-                let live = data.insts().filter(|&i| !self.inst(i).is_dead_code()).count();
-                (block, live)
+                let n = data.insts().filter(|&i| !self.inst(i).is_dead_code()).count();
+                (block, n)
             })
             .collect();
-        let n = lens.len();
-        let suspends = self.iter_insts().filter(|(_, d)| d.may_suspend()).count();
+        let n_blocks = lens.len();
 
         lens.sort_unstable_by_key(|b| b.1);
         let min = lens.first().map_or(0, |b| b.1);
         let max = lens.last().map_or(0, |b| b.1);
         let sum: usize = lens.iter().map(|b| b.1).sum();
-        let avg = if n > 0 { sum as f64 / n as f64 } else { 0.0 };
-        let median = if n > 0 { lens[n / 2].1 } else { 0 };
+        let avg = if n_blocks > 0 { sum as f64 / n_blocks as f64 } else { 0.0 };
+        let median = if n_blocks > 0 { lens[n_blocks / 2].1 } else { 0 };
 
-        debug!(
-            blocks = n,
-            min,
-            max,
-            avg = format_args!("{avg:.1}"),
-            median,
+        trace!(
+            total_insts,
+            live,
+            dead,
+            noops,
             suspends,
-            "block stats",
+            blocks = n_blocks,
+            block_min = min,
+            block_max = max,
+            block_avg = format_args!("{avg:.1}"),
+            block_median = median,
+            "ir stats",
         );
 
-        if enabled!(tracing::Level::TRACE) {
-            lens.reverse();
-            lens.truncate(5);
-            let mut buf = String::from("top 5 longest blocks:");
-            for (block, len) in &lens {
-                let data = &self.cfg.blocks[*block];
-                let first = self.inst(data.insts.start);
-                let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
-            }
-            trace!("{buf}");
+        lens.reverse();
+        lens.truncate(5);
+        let mut buf = String::from("top 5 longest blocks:");
+        for (block, len) in &lens {
+            let data = &self.cfg.blocks[*block];
+            let first = self.inst(data.insts.start);
+            let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
         }
+        trace!("{buf}");
     }
 
     /// Returns the name for a basic block.

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -605,7 +605,7 @@ impl<'a> Bytecode<'a> {
         trace!("{buf}");
     }
 
-    /// Collects IR statistics: instruction counts and block count.
+    /// Collects IR statistics: instruction counts and block size distribution.
     fn ir_stats(&self) -> IrStats {
         let total = self.insts.len();
         let mut live = 0usize;
@@ -625,7 +625,28 @@ impl<'a> Bytecode<'a> {
                 }
             }
         }
-        IrStats { total, live, dead, noops, suspends, blocks: self.cfg.blocks.len() }
+
+        let mut lens: Vec<usize> = self.cfg.blocks.iter().map(|data| data.insts().len()).collect();
+        let n = lens.len();
+        lens.sort_unstable();
+        let block_min = lens.first().copied().unwrap_or(0);
+        let block_max = lens.last().copied().unwrap_or(0);
+        let sum: usize = lens.iter().sum();
+        let block_avg = if n > 0 { sum as f64 / n as f64 } else { 0.0 };
+        let block_median = if n > 0 { lens[n / 2] } else { 0 };
+
+        IrStats {
+            total,
+            live,
+            dead,
+            noops,
+            suspends,
+            blocks: n,
+            block_min,
+            block_max,
+            block_avg,
+            block_median,
+        }
     }
 
     /// Logs IR statistics and top 5 longest blocks at trace level.
@@ -634,26 +655,6 @@ impl<'a> Bytecode<'a> {
         use std::fmt::Write;
 
         let s = self.ir_stats();
-
-        let mut lens: Vec<(Block, usize)> = self
-            .cfg
-            .blocks
-            .iter_enumerated()
-            .map(|(block, data)| {
-                let n = data.insts().len();
-                debug_assert_eq!(n, data.insts().filter(|&i| !self.inst(i).is_dead_code()).count());
-                (block, n)
-            })
-            .collect();
-        let n_blocks = lens.len();
-
-        lens.sort_unstable_by_key(|b| b.1);
-        let min = lens.first().map_or(0, |b| b.1);
-        let max = lens.last().map_or(0, |b| b.1);
-        let sum: usize = lens.iter().map(|b| b.1).sum();
-        let avg = if n_blocks > 0 { sum as f64 / n_blocks as f64 } else { 0.0 };
-        let median = if n_blocks > 0 { lens[n_blocks / 2].1 } else { 0 };
-
         trace!(
             total_insts = s.total,
             live = s.live,
@@ -661,14 +662,20 @@ impl<'a> Bytecode<'a> {
             noops = s.noops,
             suspends = s.suspends,
             blocks = s.blocks,
-            block_min = min,
-            block_max = max,
-            block_avg = format_args!("{avg:.1}"),
-            block_median = median,
+            block_min = s.block_min,
+            block_max = s.block_max,
+            block_avg = format_args!("{:.1}", s.block_avg),
+            block_median = s.block_median,
             "ir stats",
         );
 
-        lens.reverse();
+        let mut lens: Vec<(Block, usize)> = self
+            .cfg
+            .blocks
+            .iter_enumerated()
+            .map(|(block, data)| (block, data.insts().len()))
+            .collect();
+        lens.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
         lens.truncate(5);
         let mut buf = String::from("top 5 longest blocks:");
         for (block, len) in &lens {
@@ -708,6 +715,10 @@ pub(crate) struct IrStats {
     pub(crate) noops: usize,
     pub(crate) suspends: usize,
     pub(crate) blocks: usize,
+    pub(crate) block_min: usize,
+    pub(crate) block_max: usize,
+    pub(crate) block_avg: f64,
+    pub(crate) block_median: usize,
 }
 
 /// A single instruction in the bytecode.

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -12,7 +12,7 @@ use std::{borrow::Cow, cell::RefCell};
 pub(crate) use revm_context_interface::cfg::GasParams;
 
 mod passes;
-use passes::{Cfg, GasSection, SectionsAnalysis, Snapshots, StackSection};
+use passes::{Block, Cfg, GasSection, SectionsAnalysis, Snapshots, StackSection};
 
 mod asm;
 pub use asm::parse_asm;
@@ -349,6 +349,7 @@ impl<'a> Bytecode<'a> {
 
         if tracing::enabled!(tracing::Level::TRACE) {
             self.log_const_input_stats();
+            self.log_longest_blocks();
         }
 
         Ok(())
@@ -600,6 +601,33 @@ impl<'a> Bytecode<'a> {
                     );
                 }
             }
+        }
+        trace!("{buf}");
+    }
+
+    /// Logs the top 5 longest basic blocks (by live instruction count) at trace level.
+    #[inline(never)]
+    fn log_longest_blocks(&self) {
+        use std::fmt::Write;
+
+        // Collect (block, live_len).
+        let mut block_lens: Vec<(Block, usize)> = self
+            .cfg
+            .blocks
+            .iter_enumerated()
+            .map(|(block, data)| {
+                let live = data.insts().filter(|&i| !self.inst(i).is_dead_code()).count();
+                (block, live)
+            })
+            .collect();
+        block_lens.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
+        block_lens.truncate(5);
+
+        let mut buf = String::from("top 5 longest blocks:");
+        for (block, len) in &block_lens {
+            let data = &self.cfg.blocks[*block];
+            let first = self.inst(data.insts.start);
+            let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
         }
         trace!("{buf}");
     }

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -347,9 +347,12 @@ impl<'a> Bytecode<'a> {
             "constant folding gas budget",
         );
 
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            self.log_block_stats();
+        }
+
         if tracing::enabled!(tracing::Level::TRACE) {
             self.log_const_input_stats();
-            self.log_longest_blocks();
         }
 
         Ok(())
@@ -605,13 +608,12 @@ impl<'a> Bytecode<'a> {
         trace!("{buf}");
     }
 
-    /// Logs the top 5 longest basic blocks (by live instruction count) at trace level.
+    /// Logs basic block statistics at debug level and top 5 longest blocks at trace level.
     #[inline(never)]
-    fn log_longest_blocks(&self) {
+    fn log_block_stats(&self) {
         use std::fmt::Write;
 
-        // Collect (block, live_len).
-        let mut block_lens: Vec<(Block, usize)> = self
+        let mut lens: Vec<(Block, usize)> = self
             .cfg
             .blocks
             .iter_enumerated()
@@ -620,16 +622,37 @@ impl<'a> Bytecode<'a> {
                 (block, live)
             })
             .collect();
-        block_lens.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
-        block_lens.truncate(5);
+        let n = lens.len();
+        let suspends = self.iter_insts().filter(|(_, d)| d.may_suspend()).count();
 
-        let mut buf = String::from("top 5 longest blocks:");
-        for (block, len) in &block_lens {
-            let data = &self.cfg.blocks[*block];
-            let first = self.inst(data.insts.start);
-            let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
+        lens.sort_unstable_by_key(|b| b.1);
+        let min = lens.first().map_or(0, |b| b.1);
+        let max = lens.last().map_or(0, |b| b.1);
+        let sum: usize = lens.iter().map(|b| b.1).sum();
+        let avg = if n > 0 { sum as f64 / n as f64 } else { 0.0 };
+        let median = if n > 0 { lens[n / 2].1 } else { 0 };
+
+        debug!(
+            blocks = n,
+            min,
+            max,
+            avg = format_args!("{avg:.1}"),
+            median,
+            suspends,
+            "block stats",
+        );
+
+        if enabled!(tracing::Level::TRACE) {
+            lens.reverse();
+            lens.truncate(5);
+            let mut buf = String::from("top 5 longest blocks:");
+            for (block, len) in &lens {
+                let data = &self.cfg.blocks[*block];
+                let first = self.inst(data.insts.start);
+                let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
+            }
+            trace!("{buf}");
         }
-        trace!("{buf}");
     }
 
     /// Returns the name for a basic block.

--- a/crates/revmc/src/bytecode/passes/mod.rs
+++ b/crates/revmc/src/bytecode/passes/mod.rs
@@ -1,7 +1,7 @@
 //! Analysis and optimization passes over EVM bytecode.
 
 pub(crate) mod block_analysis;
-pub(crate) use block_analysis::{Cfg, Snapshots};
+pub(crate) use block_analysis::{Block, Cfg, Snapshots};
 
 mod const_fold;
 

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -250,17 +250,22 @@ impl SectionsAnalysis {
         self.stack.save_to(bytecode, last);
         if enabled!(tracing::Level::DEBUG) {
             let mut max_len = 0usize;
-            let mut current = Inst::from_usize(0);
             let mut count = 0usize;
-            for (inst, data) in bytecode.iter_insts() {
+            let mut section_len = 0usize;
+            for (_inst, data) in bytecode.iter_insts() {
+                section_len += 1;
                 if !data.is_stack_section_head() {
                     continue;
                 }
-                let len = inst.index() - current.index();
-                max_len = max_len.max(len);
-                current = inst;
+                // `section_len` includes this head; the previous section had `section_len - 1`.
+                if count > 0 {
+                    max_len = max_len.max(section_len - 1);
+                }
+                section_len = 1;
                 count += 1;
             }
+            // Account for the last section.
+            max_len = max_len.max(section_len);
             debug!(count, max_len, "sections");
         }
     }

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -110,12 +110,13 @@ impl GasSectionAnalysis {
         }
         let section = self.section();
         if !section.is_empty() {
-            trace!(
-                inst = %self.start_inst,
-                len = %(next_section_inst - self.start_inst).0,
-                ?section,
-                "saving gas"
-            );
+            let _ = next_section_inst;
+            // trace!(
+            //     inst = %self.start_inst,
+            //     len = %(next_section_inst - self.start_inst).0,
+            //     ?section,
+            //     "saving gas"
+            // );
             let mut insts = bytecode.insts[self.start_inst..].iter_mut();
             if let Some(inst) = insts.find(|inst| !inst.is_dead_code()) {
                 inst.gas_section = section;
@@ -174,12 +175,13 @@ impl StackSectionAnalysis {
             return;
         }
         let section = self.section();
-        trace!(
-            inst = %self.start_inst,
-            len = %(next_section_inst - self.start_inst).0,
-            ?section,
-            "saving stack"
-        );
+        let _ = next_section_inst;
+        // trace!(
+        //     inst = %self.start_inst,
+        //     len = %(next_section_inst - self.start_inst).0,
+        //     ?section,
+        //     "saving stack"
+        // );
         let mut insts = bytecode.insts[self.start_inst..].iter_mut();
         if let Some(inst) = insts.find(|inst| !inst.is_dead_code()) {
             inst.flags |= InstFlags::STACK_SECTION_HEAD;

--- a/crates/revmc/src/bytecode/passes/sections.rs
+++ b/crates/revmc/src/bytecode/passes/sections.rs
@@ -112,7 +112,7 @@ impl GasSectionAnalysis {
         if !section.is_empty() {
             trace!(
                 inst = %self.start_inst,
-                len = %(next_section_inst - self.start_inst),
+                len = %(next_section_inst - self.start_inst).0,
                 ?section,
                 "saving gas"
             );
@@ -176,7 +176,7 @@ impl StackSectionAnalysis {
         let section = self.section();
         trace!(
             inst = %self.start_inst,
-            len = %(next_section_inst - self.start_inst),
+            len = %(next_section_inst - self.start_inst).0,
             ?section,
             "saving stack"
         );

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -314,7 +314,7 @@ class CodegenLines(Analysis):
         rows, totals, total_size, total_spills, total_reloads = self._collect(
             benches, dump_dir
         )
-        print("### Assembly line counts\n")
+        print("### Codegen statistics\n")
         table = [
             [name, *counts, fmt_size(jit_size), spills, reloads]
             for name, counts, jit_size, spills, reloads in rows
@@ -348,7 +348,7 @@ class CodegenLines(Analysis):
         }
 
         # Summary table.
-        print("### Assembly line counts\n")
+        print("### Codegen statistics\n")
         headers = ["benchmark", "unopt.ll", "opt.ll", "opt.s", "jit size", "spills", "reloads"]
         table = []
         for name, counts, jit_size, spills, reloads in cur_rows:
@@ -360,8 +360,8 @@ class CodegenLines(Analysis):
                     name,
                     *[fmt_pct(b, c) for b, c in zip(base_counts, counts)],
                     fmt_pct(base_jit, jit_size),
-                    fmt_diff(base_sp, spills),
-                    fmt_diff(base_rl, reloads),
+                    fmt_pct(base_sp, spills),
+                    fmt_pct(base_rl, reloads),
                 ]
             )
         table.append(
@@ -369,14 +369,14 @@ class CodegenLines(Analysis):
                 "**TOTAL**",
                 *[f"**{fmt_pct(b, c)}**" for b, c in zip(base_totals, cur_totals)],
                 f"**{fmt_pct(base_total_size, cur_total_size)}**",
-                f"**{fmt_diff(base_tsp, cur_tsp)}**",
-                f"**{fmt_diff(base_trl, cur_trl)}**",
+                f"**{fmt_pct(base_tsp, cur_tsp)}**",
+                f"**{fmt_pct(base_trl, cur_trl)}**",
             ]
         )
         print_table(headers, table)
 
         # Detailed table.
-        print("<details><summary>Full line counts</summary>\n")
+        print("<details><summary>Full details</summary>\n")
         detail_headers = ["benchmark"]
         for f in ["unopt.ll", "opt.ll", "opt.s"]:
             detail_headers += [f"{f} ({base_label})", "diff"]

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -583,10 +583,13 @@ class JumpResolution(Analysis):
 
 
 # ---------------------------------------------------------------------------
-# Block stats analysis
+# IR stats analysis
 # ---------------------------------------------------------------------------
 
-BLOCK_STAT_KEYS = ["blocks", "min", "max", "avg", "median", "suspends"]
+IR_STAT_KEYS = [
+    "total_insts", "live", "dead", "noops", "suspends",
+    "blocks", "block_min", "block_max", "block_avg", "block_median",
+]
 
 
 class BlockStats(Analysis):
@@ -594,47 +597,55 @@ class BlockStats(Analysis):
         return False
 
     def rust_log(self) -> str | None:
-        return "revmc::bytecode=debug"
+        return "revmc::bytecode=trace"
 
     @staticmethod
     def _parse(output: str) -> dict[str, float] | None:
         m = re.search(
-            r"block stats"
+            r"ir stats"
+            r" total_insts=(\d+)"
+            r" live=(\d+)"
+            r" dead=(\d+)"
+            r" noops=(\d+)"
+            r" suspends=(\d+)"
             r" blocks=(\d+)"
-            r" min=(\d+)"
-            r" max=(\d+)"
-            r" avg=([\d.]+)"
-            r" median=(\d+)"
-            r" suspends=(\d+)",
+            r" block_min=(\d+)"
+            r" block_max=(\d+)"
+            r" block_avg=([\d.]+)"
+            r" block_median=(\d+)",
             output,
         )
         if not m:
             return None
         return {
-            "blocks": int(m.group(1)),
-            "min": int(m.group(2)),
-            "max": int(m.group(3)),
-            "avg": float(m.group(4)),
-            "median": int(m.group(5)),
-            "suspends": int(m.group(6)),
+            "total_insts": int(m.group(1)),
+            "live": int(m.group(2)),
+            "dead": int(m.group(3)),
+            "noops": int(m.group(4)),
+            "suspends": int(m.group(5)),
+            "blocks": int(m.group(6)),
+            "block_min": int(m.group(7)),
+            "block_max": int(m.group(8)),
+            "block_avg": float(m.group(9)),
+            "block_median": int(m.group(10)),
         }
 
     def report(self, benches, dump_dir, outputs):
-        print("### Block stats\n")
-        headers = ["benchmark"] + BLOCK_STAT_KEYS
+        print("### IR stats\n")
+        headers = ["benchmark"] + IR_STAT_KEYS
         table = []
         for bench in benches:
             s = self._parse(outputs.get(bench, ""))
             if not s:
                 continue
-            table.append([bench_name(bench)] + [s[k] for k in BLOCK_STAT_KEYS])
+            table.append([bench_name(bench)] + [s[k] for k in IR_STAT_KEYS])
         print_table(headers, table)
 
     def report_diff(
         self, benches, dump_dir, outputs, base_dump, base_outputs, base_label
     ):
-        print("### Block stats\n")
-        headers = ["benchmark"] + BLOCK_STAT_KEYS
+        print("### IR stats\n")
+        headers = ["benchmark"] + IR_STAT_KEYS
         table = []
         for bench in benches:
             cur = self._parse(outputs.get(bench, ""))
@@ -642,11 +653,11 @@ class BlockStats(Analysis):
             if not cur:
                 continue
             if not base:
-                table.append([bench_name(bench)] + [cur[k] for k in BLOCK_STAT_KEYS])
+                table.append([bench_name(bench)] + [cur[k] for k in IR_STAT_KEYS])
             else:
                 table.append(
                     [bench_name(bench)]
-                    + [fmt_pct(base[k], cur[k]) for k in BLOCK_STAT_KEYS]
+                    + [fmt_pct(base[k], cur[k]) for k in IR_STAT_KEYS]
                 )
         print_table(headers, table)
 
@@ -863,7 +874,7 @@ def main():
     parser.add_argument(
         "--block-stats",
         action="store_true",
-        help="Report basic block statistics (min/max/avg/median, suspends)",
+        help="Report IR stats (inst counts, block size distribution, suspends)",
     )
     args = parser.parse_args()
 

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -583,6 +583,75 @@ class JumpResolution(Analysis):
 
 
 # ---------------------------------------------------------------------------
+# Block stats analysis
+# ---------------------------------------------------------------------------
+
+BLOCK_STAT_KEYS = ["blocks", "min", "max", "avg", "median", "suspends"]
+
+
+class BlockStats(Analysis):
+    def needs_codegen(self) -> bool:
+        return False
+
+    def rust_log(self) -> str | None:
+        return "revmc::bytecode=debug"
+
+    @staticmethod
+    def _parse(output: str) -> dict[str, float] | None:
+        m = re.search(
+            r"block stats"
+            r" blocks=(\d+)"
+            r" min=(\d+)"
+            r" max=(\d+)"
+            r" avg=([\d.]+)"
+            r" median=(\d+)"
+            r" suspends=(\d+)",
+            output,
+        )
+        if not m:
+            return None
+        return {
+            "blocks": int(m.group(1)),
+            "min": int(m.group(2)),
+            "max": int(m.group(3)),
+            "avg": float(m.group(4)),
+            "median": int(m.group(5)),
+            "suspends": int(m.group(6)),
+        }
+
+    def report(self, benches, dump_dir, outputs):
+        print("### Block stats\n")
+        headers = ["benchmark"] + BLOCK_STAT_KEYS
+        table = []
+        for bench in benches:
+            s = self._parse(outputs.get(bench, ""))
+            if not s:
+                continue
+            table.append([bench_name(bench)] + [s[k] for k in BLOCK_STAT_KEYS])
+        print_table(headers, table)
+
+    def report_diff(
+        self, benches, dump_dir, outputs, base_dump, base_outputs, base_label
+    ):
+        print("### Block stats\n")
+        headers = ["benchmark"] + BLOCK_STAT_KEYS
+        table = []
+        for bench in benches:
+            cur = self._parse(outputs.get(bench, ""))
+            base = self._parse(base_outputs.get(bench, ""))
+            if not cur:
+                continue
+            if not base:
+                table.append([bench_name(bench)] + [cur[k] for k in BLOCK_STAT_KEYS])
+            else:
+                table.append(
+                    [bench_name(bench)]
+                    + [fmt_pct(base[k], cur[k]) for k in BLOCK_STAT_KEYS]
+                )
+        print_table(headers, table)
+
+
+# ---------------------------------------------------------------------------
 # Constant-input stats analysis
 # ---------------------------------------------------------------------------
 
@@ -791,6 +860,11 @@ def main():
         action="store_true",
         help="Report per-opcode constant-input statistics",
     )
+    parser.add_argument(
+        "--block-stats",
+        action="store_true",
+        help="Report basic block statistics (min/max/avg/median, suspends)",
+    )
     args = parser.parse_args()
 
     # Default to codegen-lines + compile-times if no analysis flags given.
@@ -799,6 +873,7 @@ def main():
         or args.compile_times
         or args.jump_resolution
         or args.input_stats
+        or args.block_stats
     ):
         args.codegen_lines = True
         args.compile_times = True
@@ -813,6 +888,8 @@ def main():
         analyses.append(JumpResolution())
     if args.input_stats:
         analyses.append(InputStats())
+    if args.block_stats:
+        analyses.append(BlockStats())
 
     if not analyses:
         eprint("No analyses selected.")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -20,8 +20,13 @@ def repo_root() -> str:
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def _shared_target_dir() -> str:
+    """Return a shared CARGO_TARGET_DIR so worktrees reuse the same build cache."""
+    return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "target")
+
+
 def cargo_env(rust_log: str | None = None) -> dict[str, str]:
-    env = {**os.environ, "NO_COLOR": "1"}
+    env = {**os.environ, "NO_COLOR": "1", "CARGO_TARGET_DIR": _shared_target_dir()}
     if rust_log:
         env["RUST_LOG"] = rust_log
     return env
@@ -29,8 +34,10 @@ def cargo_env(rust_log: str | None = None) -> dict[str, str]:
 
 def cargo_build(root: str) -> str:
     """Build the CLI binary and return its path."""
-    subprocess.run(["cargo", "build", "--quiet"], check=True, cwd=root)
-    return os.path.join(root, "target", "debug", "revmc")
+    target_dir = _shared_target_dir()
+    env = {**os.environ, "CARGO_TARGET_DIR": target_dir}
+    subprocess.run(["cargo", "build", "--quiet"], check=True, cwd=root, env=env)
+    return os.path.join(target_dir, "debug", "revmc")
 
 
 def get_benches(binary: str) -> list[str]:


### PR DESCRIPTION
- Fix sections `max_len` to only count live instructions instead of using raw instruction indices that included dead code gaps
- Log top 5 longest basic blocks at trace level after analysis completes
- Show spill/reload changes as percentages in bench diff summary table (matching other columns)
- Share `CARGO_TARGET_DIR` across worktrees in bench script to avoid full recompilation on `--diff`
- Rename 'Assembly line counts' heading to 'Codegen statistics'