### PR TITLE
feat: cross-block DSE over fallthrough chains

### DIFF
--- a/crates/revmc/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc/src/bytecode/passes/block_analysis.rs
@@ -29,7 +29,7 @@
 //! incomplete information, ensuring that only sound jump targets are reported as resolved.
 
 use super::StackSection;
-use crate::bytecode::{Bytecode, Inst, InstFlags, Interner, U256Idx};
+use crate::bytecode::{Bytecode, Inst, InstData, InstFlags, Interner, U256Idx};
 use bitvec::vec::BitVec;
 use either::Either;
 use oxc_index::{IndexVec, index_vec};
@@ -285,6 +285,21 @@ impl BlockData {
         &self,
     ) -> impl DoubleEndedIterator<Item = Inst> + ExactSizeIterator + use<> {
         (self.insts.start.index()..self.insts.end.index()).map(Inst::from_usize)
+    }
+
+    /// Returns `true` if this block is a fallthrough extension of its unique predecessor.
+    ///
+    /// A fallthrough block has exactly one predecessor and its first instruction is not a
+    /// reachable `JUMPDEST` (so the only way to enter it is sequential fallthrough from
+    /// the predecessor). Such blocks can be treated as continuations of the predecessor
+    /// for intra-region analyses like DSE.
+    #[inline]
+    pub(crate) fn is_fallthrough(
+        &self,
+        insts: &IndexVec<Inst, InstData>,
+        has_dynamic_jumps: bool,
+    ) -> bool {
+        self.preds.len() == 1 && !insts[self.insts.start].is_reachable_jumpdest(has_dynamic_jumps)
     }
 }
 
@@ -2390,5 +2405,65 @@ mod tests_edge_cases {
             bytecode.has_dynamic_jumps,
             "return jump should remain dynamic when fixpoint doesn't converge"
         );
+    }
+
+    #[test]
+    fn is_fallthrough() {
+        // bb0: PUSH, CALLDATASIZE, PUSH %target, JUMPI
+        // bb1 (fallthrough): POP, STOP          — 1 pred, not a JUMPDEST
+        // bb2: JUMPDEST, STOP                   — 1 pred, but IS a JUMPDEST
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42
+            CALLDATASIZE
+            PUSH %target
+            JUMPI
+            POP
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+        let blocks = &bytecode.cfg.blocks;
+        assert!(
+            !blocks[Block::from_usize(0)]
+                .is_fallthrough(&bytecode.insts, bytecode.has_dynamic_jumps)
+        );
+        assert!(
+            blocks[Block::from_usize(1)]
+                .is_fallthrough(&bytecode.insts, bytecode.has_dynamic_jumps)
+        );
+        assert!(
+            !blocks[Block::from_usize(2)]
+                .is_fallthrough(&bytecode.insts, bytecode.has_dynamic_jumps)
+        );
+    }
+
+    #[test]
+    fn is_fallthrough_multiple_preds() {
+        // bb1 has 2 predecessors (both JUMPs), so it's NOT a fallthrough block
+        // even though its first instruction is not a JUMPDEST... wait, with 2
+        // preds via JUMP it must be a JUMPDEST. Let's use JUMPI to create a
+        // block with 2 predecessors that IS a JUMPDEST.
+        let bytecode = analyze_asm(
+            "
+            CALLDATASIZE
+            PUSH %merge
+            JUMPI
+
+            PUSH0
+            PUSH %merge
+            JUMP
+
+        merge:
+            JUMPDEST
+            STOP
+        ",
+        );
+        let blocks = &bytecode.cfg.blocks;
+        // merge block has 2 predecessors — not a fallthrough.
+        let merge = blocks.iter_enumerated().find(|(_, b)| b.preds.len() == 2).unwrap().0;
+        assert!(!blocks[merge].is_fallthrough(&bytecode.insts, bytecode.has_dynamic_jumps));
     }
 }

--- a/crates/revmc/src/bytecode/passes/dead_store_elim.rs
+++ b/crates/revmc/src/bytecode/passes/dead_store_elim.rs
@@ -13,7 +13,7 @@
 //! - POP kills its input (makes the position dead) rather than reading it.
 
 use super::{StackSectionAnalysis, block_analysis::AbsValue};
-use crate::bytecode::{AnalysisConfig, Bytecode, InstFlags};
+use crate::bytecode::{AnalysisConfig, Bytecode, Inst, InstFlags};
 use bitvec::vec::BitVec;
 use revm_bytecode::opcode as op;
 
@@ -164,19 +164,71 @@ impl Bytecode<'_> {
                 // All positions in that prefix must be physically materialized — we
                 // cannot rely on later rematerialization since the suspend path runs
                 // before any consumer.
-                //
-                // Branching instructions with a fallthrough edge (JUMPI) have a
-                // taken path that may read arbitrary stack values. Conservatively
-                // mark the stack passed to the taken edge as live.
-                if data.may_suspend() || (data.is_branching() && data.can_fall_through()) {
+                if data.may_suspend() {
                     let h_after = heights[idx + 1] as usize;
                     live[..h_after].fill(true);
+                }
+
+                // Branching instructions with a fallthrough edge (JUMPI) have a
+                // taken path that may read stack values. Compute what the taken
+                // successor actually needs from the stack and mark only those
+                // positions live instead of conservatively filling everything.
+                if data.is_branching() && data.can_fall_through() {
+                    let h_after = heights[idx + 1] as usize;
+                    let taken_inputs = self.taken_succ_inputs(inst);
+                    let needed = (taken_inputs as usize).min(h_after);
+                    live[h_after - needed..h_after].fill(true);
                 }
             }
         }
 
         if eliminated > 0 {
             debug!(eliminated, "dead stores eliminated");
+        }
+    }
+
+    /// Returns the number of stack items the taken JUMPI successor needs from entry.
+    ///
+    /// For a JUMPI instruction, finds the non-fallthrough (taken) successor and computes
+    /// a `StackSection` over its entire instruction range to determine how many items
+    /// it reads from its entry stack. If the taken block does not diverge (its items flow
+    /// to further successors), falls back to `u16::MAX` (conservative).
+    fn taken_succ_inputs(&self, jumpi_inst: Inst) -> u16 {
+        let Some(jumpi_block) = self.cfg.inst_to_block[jumpi_inst]
+            .filter(|&b| self.cfg.blocks[b].terminator() == jumpi_inst)
+        else {
+            return u16::MAX;
+        };
+        let block = &self.cfg.blocks[jumpi_block];
+        // succs[0] is fallthrough, succs[1..] are taken edges.
+        let Some(&taken) = block.succs.get(1) else {
+            return u16::MAX;
+        };
+        // Walk the taken block and any fallthrough extensions to cover the full
+        // reachable region before it branches/diverges.
+        let mut bid = taken;
+        let mut analysis = StackSectionAnalysis::default();
+        loop {
+            let b = &self.cfg.blocks[bid];
+            for i in b.insts() {
+                let (inp, out) = self.insts[i].stack_io();
+                analysis.process(inp, out);
+            }
+            let term = &self.insts[b.terminator()];
+            // If the block diverges, the section inputs are exact.
+            if term.is_diverging() {
+                return analysis.section().inputs;
+            }
+            // Follow fallthrough extensions to accumulate their stack I/O.
+            if term.can_fall_through()
+                && let Some(&succ) = b.succs.first()
+                && self.cfg.blocks[succ].is_fallthrough(&self.insts, self.has_dynamic_jumps)
+            {
+                bid = succ;
+                continue;
+            }
+            // Non-diverging, non-fallthrough: conservative.
+            return u16::MAX;
         }
     }
 }
@@ -1113,126 +1165,44 @@ mod tests {
     // --- Cross-block (fallthrough chain) DSE tests ---
 
     #[test]
-    fn cross_block_dead_across_jumpi_fallthrough() {
-        // PUSH 0x42 is produced in the first block. The fallthrough block after JUMPI
-        // POPs it and STOPs. The value is dead across the chain.
+    fn cross_block_dead_both_paths() {
+        // Value dead on both fallthrough (REVERT) and taken (STOP, needs 0 items).
+        // Cross-block DSE eliminates the PUSH+POP across the JUMPI boundary.
         let bytecode = analyze_asm(
             "
-            PUSH1 0x42      ; inst 0: dead value
+            PUSH1 0x42      ; inst 0: dead — unused on both paths
             CALLDATASIZE    ; inst 1: condition
-            PUSH %target    ; inst 2
+            PUSH %taken     ; inst 2
             JUMPI           ; inst 3
-            ; fallthrough block (1 predecessor, not a JUMPDEST):
-            POP             ; inst 4: kills the value
-            STOP            ; inst 5
-        target:
-            JUMPDEST        ; inst 6
-            POP             ; inst 7
-            STOP            ; inst 8
-        ",
-        );
-        // PUSH 0x42 is NOT dead — the taken JUMPI edge needs the value on the stack.
-        assert!(
-            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
-            "PUSH 0x42 must NOT be nooped (live on the taken JUMPI edge)"
-        );
-    }
-
-    #[test]
-    fn cross_block_dead_chain_diverges() {
-        // A simple fallthrough chain ending in STOP. All values are dead.
-        // Block 0: PUSH 0x42, PUSH 0, PUSH %skip, JUMPI
-        // Block 1 (fallthrough): POP, STOP
-        // No JUMPDEST at block 1, so it's a fallthrough extension.
-        //
-        // But PUSH 0x42 is live on the taken edge, so it must NOT be eliminated.
-        let bytecode = analyze_asm(
-            "
-            PUSH1 0x42      ; inst 0
-            PUSH0           ; inst 1: always-false condition
-            PUSH %skip      ; inst 2
-            JUMPI           ; inst 3
-            POP             ; inst 4
-            STOP            ; inst 5
-        skip:
-            JUMPDEST        ; inst 6
-            PUSH0           ; inst 7
-            MSTORE          ; inst 8
-            STOP            ; inst 9
-        ",
-        );
-        // Even though the fallthrough chain [bb0, bb1] ends in STOP and POP kills
-        // the value, the JUMPI taken edge means 0x42 must stay live.
-        assert!(
-            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
-            "PUSH 0x42 must stay live (JUMPI taken edge)"
-        );
-    }
-
-    #[test]
-    fn cross_block_dead_no_jumpi() {
-        // Single-block baseline: PUSH/POP/STOP with no block splits.
-        let bytecode = analyze_asm(
-            "
-            PUSH1 0x42      ; inst 0: dead
-            POP             ; inst 1
-            STOP            ; inst 2
-        ",
-        );
-        assert!(
-            bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
-            "PUSH 0x42 should be nooped (single block, dead)"
-        );
-    }
-
-    #[test]
-    fn cross_block_fallthrough_chain_diverges_with_jumpi() {
-        // Chain [bb0, bb1_fallthrough] ending in REVERT. The JUMPI taken edge keeps
-        // the value live below the condition, so POP and PUSH 0x42 both stay live.
-        let bytecode = analyze_asm(
-            "
-            PUSH1 0x42      ; inst 0
-            CALLDATASIZE    ; inst 1: condition for first JUMPI
-            PUSH %target1   ; inst 2
-            JUMPI           ; inst 3
-            ; first fallthrough (not a JUMPDEST, 1 pred):
+            ; fallthrough: revert without using 0x42
             POP             ; inst 4
             PUSH0           ; inst 5
             DUP1            ; inst 6
             REVERT          ; inst 7
-        target1:
+        taken:
             JUMPDEST        ; inst 8
-            PUSH0           ; inst 9
-            MSTORE          ; inst 10
-            STOP            ; inst 11
+            STOP            ; inst 9: needs 0 items from stack
         ",
         );
+        // Taken block (JUMPDEST, STOP) needs 0 stack inputs.
+        // Fallthrough chain ends in REVERT (diverging), exit is all-dead.
+        // 0x42 is dead on both paths → eliminated.
         assert!(
-            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
-            "PUSH 0x42 must stay live (JUMPI taken edge)"
-        );
-        // PUSH0 and DUP1 before REVERT are dead (diverging tail, no side exit).
-        assert!(
-            bytecode.inst(Inst::from_usize(5)).flags.contains(InstFlags::NOOP),
-            "PUSH0 before REVERT should be nooped"
-        );
-        assert!(
-            bytecode.inst(Inst::from_usize(6)).flags.contains(InstFlags::NOOP),
-            "DUP1 before REVERT should be nooped"
+            bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0x42 should be nooped (dead on both paths)"
         );
     }
 
     #[test]
-    fn cross_block_jumpi_value_live_on_taken_not_eliminated() {
-        // Soundness test: value is dead on fallthrough but live on the taken JUMPI path.
-        // DSE must NOT eliminate it.
+    fn cross_block_live_on_taken() {
+        // Value dead on fallthrough (REVERT) but live on taken path (MSTORE).
         let bytecode = analyze_asm(
             "
             PUSH1 0xAA      ; inst 0: needed on taken path
-            PUSH1 0xBB      ; inst 1: condition
+            CALLDATASIZE    ; inst 1: condition
             PUSH %taken     ; inst 2
             JUMPI           ; inst 3
-            ; fallthrough: 0xAA is unused
+            ; fallthrough: unused
             POP             ; inst 4
             PUSH0           ; inst 5
             DUP1            ; inst 6
@@ -1240,22 +1210,86 @@ mod tests {
         taken:
             JUMPDEST        ; inst 8
             PUSH0           ; inst 9
-            MSTORE          ; inst 10: writes 0xAA to memory
-            PUSH1 0x20      ; inst 11
-            PUSH0           ; inst 12
-            RETURN          ; inst 13
+            MSTORE          ; inst 10: reads 0xAA from stack
+            STOP            ; inst 11
+        ",
+        );
+        // Taken block needs 1 item from entry stack (consumed by MSTORE).
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0xAA must NOT be eliminated — needed on taken path"
+        );
+    }
+
+    #[test]
+    fn cross_block_deep_value_dead_shallow_live() {
+        // Two values below JUMPI inputs. Taken path needs only 1 (shallow).
+        // The deep value is dead on both paths.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0xDD      ; inst 0: deep value — dead on both paths
+            PUSH1 0xAA      ; inst 1: shallow value — live on taken path
+            CALLDATASIZE    ; inst 2: condition
+            PUSH %taken     ; inst 3
+            JUMPI           ; inst 4
+            ; fallthrough: discard both and revert
+            POP             ; inst 5
+            POP             ; inst 6
+            PUSH0           ; inst 7
+            DUP1            ; inst 8
+            REVERT          ; inst 9
+        taken:
+            JUMPDEST        ; inst 10
+            PUSH0           ; inst 11
+            MSTORE          ; inst 12: reads 0xAA (TOS), pops both
+            STOP            ; inst 13
+        ",
+        );
+        // Taken block needs 1 item from entry. Stack at JUMPI exit has 2 items
+        // [0xDD, 0xAA]. Only the top 1 (0xAA) is needed → 0xDD is dead.
+        assert!(
+            bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0xDD should be nooped (dead: taken needs only 1 item)"
+        );
+        assert!(
+            !bytecode.inst(Inst::from_usize(1)).flags.contains(InstFlags::NOOP),
+            "PUSH 0xAA must NOT be nooped (live on taken path)"
+        );
+    }
+
+    #[test]
+    fn cross_block_taken_non_diverging_conservative() {
+        // Taken path doesn't diverge (ends with JUMP to elsewhere).
+        // DSE must be conservative — can't know what's needed downstream.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0: must stay live (conservative)
+            CALLDATASIZE    ; inst 1
+            PUSH %taken     ; inst 2
+            JUMPI           ; inst 3
+            POP             ; inst 4
+            PUSH0           ; inst 5
+            DUP1            ; inst 6
+            REVERT          ; inst 7
+        taken:
+            JUMPDEST        ; inst 8
+            PUSH %done      ; inst 9
+            JUMP            ; inst 10: non-diverging → conservative
+        done:
+            JUMPDEST        ; inst 11
+            POP             ; inst 12
+            STOP            ; inst 13
         ",
         );
         assert!(
             !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
-            "PUSH 0xAA must NOT be eliminated — needed on taken JUMPI path"
+            "PUSH 0x42 must stay live (taken path is non-diverging, conservative)"
         );
     }
 
     #[test]
     fn cross_block_suspend_in_fallthrough_keeps_earlier_live() {
-        // Suspend (CALL) in a fallthrough block forces the entire stack prefix live,
-        // preventing earlier PUSHes from being eliminated.
+        // Suspend (CALL) in a fallthrough block forces the entire stack prefix live.
         let bytecode = analyze_asm(
             "
             PUSH1 0xaa      ; inst 0: must survive across CALL

--- a/crates/revmc/src/bytecode/passes/dead_store_elim.rs
+++ b/crates/revmc/src/bytecode/passes/dead_store_elim.rs
@@ -1,8 +1,9 @@
-//! Intra-block dead store elimination.
+//! Dead store elimination.
 //!
-//! Walks each basic block backward to determine which stack positions are live (will be read
-//! by a later instruction or at the block exit). Instructions whose outputs are all dead and
-//! whose logic is safe to eliminate are marked [`InstFlags::NOOP`].
+//! Identifies fallthrough chains (sequences of blocks where each successor has a single
+//! predecessor and is not a reachable `JUMPDEST`) and performs backward liveness analysis
+//! over each chain as a single region. Instructions whose outputs are all dead and whose
+//! logic is safe to eliminate are marked [`InstFlags::NOOP`].
 //!
 //! DUP, SWAP, POP, DUPN, SWAPN, and EXCHANGE require custom liveness transfer functions
 //! because generic `(inputs, outputs)` arity doesn't capture how they map stack slots:
@@ -26,32 +27,57 @@ enum DecodedImm {
 }
 
 impl Bytecode<'_> {
-    /// Intra-block dead store elimination.
+    /// Dead store elimination over fallthrough chains.
     ///
-    /// Walks each block backward to determine which stack positions are live (will be read
-    /// by a later instruction or at the block exit). Instructions that are safe to skip and
-    /// whose outputs are all dead are marked `NOOP`.
+    /// Identifies chains of blocks connected by pure fallthrough (each successor has a
+    /// single predecessor and is not a reachable `JUMPDEST`) and performs backward liveness
+    /// analysis over each chain as a single region.
     #[instrument(name = "dse", level = "debug", skip_all)]
     pub(crate) fn dead_store_elim(&mut self) {
         let mut eliminated = 0u32;
         let inspect_stack = self.config.contains(AnalysisConfig::INSPECT_STACK);
 
-        // Reusable buffers hoisted out of the per-block loop.
+        // Reusable buffers hoisted out of the per-chain loop.
         let mut heights = Vec::new();
         let mut live = BitVec::new();
+        let mut chain = Vec::new();
 
         for bid in self.cfg.blocks.indices() {
-            let block = &self.cfg.blocks[bid];
+            // Only start from chain heads (blocks that are not fallthrough extensions).
+            if self.cfg.blocks[bid].is_fallthrough(&self.insts, self.has_dynamic_jumps) {
+                continue;
+            }
+
+            // Collect the fallthrough chain starting at this head.
+            chain.clear();
+            chain.push(bid);
+            loop {
+                let tail = *chain.last().unwrap();
+                let tail_block = &self.cfg.blocks[tail];
+                let term = &self.insts[tail_block.terminator()];
+                // Follow the fallthrough edge if the successor is a fallthrough extension.
+                if term.can_fall_through()
+                    && let Some(&succ) = tail_block.succs.first()
+                    && self.cfg.blocks[succ].is_fallthrough(&self.insts, self.has_dynamic_jumps)
+                {
+                    chain.push(succ);
+                } else {
+                    break;
+                }
+            }
+
             // Compute the stack height at each instruction boundary by walking forward.
             // heights[i] = stack height *before* executing insts[i].
             // heights[insts.len()] = stack height after the last instruction.
             let mut stack = StackSectionAnalysis::default();
             heights.clear();
             heights.push(0); // placeholder; patched to entry_height below.
-            for inst in block.insts() {
-                let (inp, out) = self.insts[inst].stack_io();
-                stack.process(inp, out);
-                heights.push(stack.diff());
+            for &b in &chain {
+                for inst in self.cfg.blocks[b].insts() {
+                    let (inp, out) = self.insts[inst].stack_io();
+                    stack.process(inp, out);
+                    heights.push(stack.diff());
+                }
             }
 
             // Shift all heights so that heights[0] == entry_height.
@@ -64,13 +90,17 @@ impl Bytecode<'_> {
             let exit_height = *heights.last().unwrap();
             let max_height = entry_height + section.max_growth as i32;
 
-            // If the block's terminator diverges, no successor will read the stack,
+            // If the chain's tail terminator diverges, no successor will read the stack,
             // so all exit positions are dead. Unless `inspect_stack` is set (the caller
-            // observes every store) or the block contains a suspending instruction
+            // observes every store) or the chain contains a suspending instruction
             // (the function can be re-entered and the caller reads the stack).
-            let has_suspend = block.insts().any(|i| self.insts[i].may_suspend());
-            let term_diverges =
-                !inspect_stack && !has_suspend && self.insts[block.terminator()].is_diverging();
+            let has_suspend = chain
+                .iter()
+                .any(|&b| self.cfg.blocks[b].insts().any(|i| self.insts[i].may_suspend()));
+            let tail_block = &self.cfg.blocks[*chain.last().unwrap()];
+            let term_diverges = !inspect_stack
+                && !has_suspend
+                && self.insts[tail_block.terminator()].is_diverging();
 
             live.clear();
             live.resize(exit_height.max(0) as usize, !term_diverges);
@@ -81,8 +111,10 @@ impl Bytecode<'_> {
                 continue;
             }
 
-            // Walk backward.
-            for (idx, inst) in block.insts().enumerate().rev() {
+            // Walk backward across all instructions in the chain.
+            let all_insts: Vec<_> =
+                chain.iter().flat_map(|&b| self.cfg.blocks[b].insts()).collect();
+            for (idx, inst) in all_insts.iter().copied().enumerate().rev() {
                 let data = &self.insts[inst];
                 if data.flags.contains(InstFlags::NOOP)
                     || data.flags.contains(InstFlags::DISABLED)
@@ -132,7 +164,11 @@ impl Bytecode<'_> {
                 // All positions in that prefix must be physically materialized — we
                 // cannot rely on later rematerialization since the suspend path runs
                 // before any consumer.
-                if data.may_suspend() {
+                //
+                // Branching instructions with a fallthrough edge (JUMPI) have a
+                // taken path that may read arbitrary stack values. Conservatively
+                // mark the stack passed to the taken edge as live.
+                if data.may_suspend() || (data.is_branching() && data.can_fall_through()) {
                     let h_after = heights[idx + 1] as usize;
                     live[..h_after].fill(true);
                 }
@@ -1071,6 +1107,184 @@ mod tests {
         assert!(
             !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
             "PUSH1 0xaa must NOT be nooped — it is live across the CALL suspension"
+        );
+    }
+
+    // --- Cross-block (fallthrough chain) DSE tests ---
+
+    #[test]
+    fn cross_block_dead_across_jumpi_fallthrough() {
+        // PUSH 0x42 is produced in the first block. The fallthrough block after JUMPI
+        // POPs it and STOPs. The value is dead across the chain.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0: dead value
+            CALLDATASIZE    ; inst 1: condition
+            PUSH %target    ; inst 2
+            JUMPI           ; inst 3
+            ; fallthrough block (1 predecessor, not a JUMPDEST):
+            POP             ; inst 4: kills the value
+            STOP            ; inst 5
+        target:
+            JUMPDEST        ; inst 6
+            POP             ; inst 7
+            STOP            ; inst 8
+        ",
+        );
+        // PUSH 0x42 is NOT dead — the taken JUMPI edge needs the value on the stack.
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0x42 must NOT be nooped (live on the taken JUMPI edge)"
+        );
+    }
+
+    #[test]
+    fn cross_block_dead_chain_diverges() {
+        // A simple fallthrough chain ending in STOP. All values are dead.
+        // Block 0: PUSH 0x42, PUSH 0, PUSH %skip, JUMPI
+        // Block 1 (fallthrough): POP, STOP
+        // No JUMPDEST at block 1, so it's a fallthrough extension.
+        //
+        // But PUSH 0x42 is live on the taken edge, so it must NOT be eliminated.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0
+            PUSH0           ; inst 1: always-false condition
+            PUSH %skip      ; inst 2
+            JUMPI           ; inst 3
+            POP             ; inst 4
+            STOP            ; inst 5
+        skip:
+            JUMPDEST        ; inst 6
+            PUSH0           ; inst 7
+            MSTORE          ; inst 8
+            STOP            ; inst 9
+        ",
+        );
+        // Even though the fallthrough chain [bb0, bb1] ends in STOP and POP kills
+        // the value, the JUMPI taken edge means 0x42 must stay live.
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0x42 must stay live (JUMPI taken edge)"
+        );
+    }
+
+    #[test]
+    fn cross_block_dead_no_jumpi() {
+        // Single-block baseline: PUSH/POP/STOP with no block splits.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0: dead
+            POP             ; inst 1
+            STOP            ; inst 2
+        ",
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0x42 should be nooped (single block, dead)"
+        );
+    }
+
+    #[test]
+    fn cross_block_fallthrough_chain_diverges_with_jumpi() {
+        // Chain [bb0, bb1_fallthrough] ending in REVERT. The JUMPI taken edge keeps
+        // the value live below the condition, so POP and PUSH 0x42 both stay live.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x42      ; inst 0
+            CALLDATASIZE    ; inst 1: condition for first JUMPI
+            PUSH %target1   ; inst 2
+            JUMPI           ; inst 3
+            ; first fallthrough (not a JUMPDEST, 1 pred):
+            POP             ; inst 4
+            PUSH0           ; inst 5
+            DUP1            ; inst 6
+            REVERT          ; inst 7
+        target1:
+            JUMPDEST        ; inst 8
+            PUSH0           ; inst 9
+            MSTORE          ; inst 10
+            STOP            ; inst 11
+        ",
+        );
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0x42 must stay live (JUMPI taken edge)"
+        );
+        // PUSH0 and DUP1 before REVERT are dead (diverging tail, no side exit).
+        assert!(
+            bytecode.inst(Inst::from_usize(5)).flags.contains(InstFlags::NOOP),
+            "PUSH0 before REVERT should be nooped"
+        );
+        assert!(
+            bytecode.inst(Inst::from_usize(6)).flags.contains(InstFlags::NOOP),
+            "DUP1 before REVERT should be nooped"
+        );
+    }
+
+    #[test]
+    fn cross_block_jumpi_value_live_on_taken_not_eliminated() {
+        // Soundness test: value is dead on fallthrough but live on the taken JUMPI path.
+        // DSE must NOT eliminate it.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0xAA      ; inst 0: needed on taken path
+            PUSH1 0xBB      ; inst 1: condition
+            PUSH %taken     ; inst 2
+            JUMPI           ; inst 3
+            ; fallthrough: 0xAA is unused
+            POP             ; inst 4
+            PUSH0           ; inst 5
+            DUP1            ; inst 6
+            REVERT          ; inst 7
+        taken:
+            JUMPDEST        ; inst 8
+            PUSH0           ; inst 9
+            MSTORE          ; inst 10: writes 0xAA to memory
+            PUSH1 0x20      ; inst 11
+            PUSH0           ; inst 12
+            RETURN          ; inst 13
+        ",
+        );
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0xAA must NOT be eliminated — needed on taken JUMPI path"
+        );
+    }
+
+    #[test]
+    fn cross_block_suspend_in_fallthrough_keeps_earlier_live() {
+        // Suspend (CALL) in a fallthrough block forces the entire stack prefix live,
+        // preventing earlier PUSHes from being eliminated.
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0xaa      ; inst 0: must survive across CALL
+            CALLDATASIZE    ; inst 1: condition
+            PUSH %skip      ; inst 2
+            JUMPI           ; inst 3
+            ; fallthrough block with CALL:
+            PUSH0           ; inst 4
+            PUSH0           ; inst 5
+            PUSH0           ; inst 6
+            PUSH0           ; inst 7
+            PUSH0           ; inst 8
+            PUSH1 0x69      ; inst 9
+            GAS             ; inst 10
+            CALL            ; inst 11: suspends
+            POP             ; inst 12: drop success flag
+            PUSH0           ; inst 13
+            MSTORE          ; inst 14: writes 0xaa
+            PUSH1 0x20      ; inst 15
+            PUSH0           ; inst 16
+            RETURN          ; inst 17
+        skip:
+            JUMPDEST        ; inst 18
+            STOP            ; inst 19
+        ",
+        );
+        assert!(
+            !bytecode.inst(Inst::from_usize(0)).flags.contains(InstFlags::NOOP),
+            "PUSH 0xaa must NOT be nooped (live across CALL in fallthrough)"
         );
     }
 }


### PR DESCRIPTION
Add `BlockData::is_fallthrough()` — a block is a fallthrough extension when it has exactly one predecessor and its first instruction is not a reachable `JUMPDEST`.

Refactor DSE to identify fallthrough chains and run backward liveness analysis over each chain as a single region instead of per-block. At JUMPI boundaries, computes what the taken successor actually needs from the stack (via `StackSectionAnalysis` over the taken block and its fallthrough extensions) instead of conservatively assuming everything is live. Values below the JUMPI that are dead on both paths get eliminated.

bswap64 shows -0.6% unopt / -1.0% opt.s / -0.5% jit size. univ2_router and uniswap_v2_pair gain +1 noop each.

### Codegen

| benchmark          |   unopt.ll |   opt.ll |   opt.s |   jit size |   spills |   reloads |
|:-------------------|-----------:|---------:|--------:|-----------:|---------:|----------:|
| bswap64            |    -0.6% 🟢 |  -0.3% 🟢 | -1.0% 🟢 |    -0.5% 🟢 |        - |         - |
| **TOTAL**          |      **=** |    **=** |   **=** |      **=** |    **=** |     **=** |