### PR TITLE
refactor: remove input value caching in translate

### DIFF
--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -78,8 +78,6 @@ pub(super) struct FunctionCx<'a, B: Backend> {
     gas_remaining: Pointer<B::Builder<'a>>,
     /// The EVM context. Opaque pointer, only passed to builtins.
     ecx: B::Value,
-    /// The `ecx.input` pointer (`&InputsImpl`). Loaded once at entry.
-    input: B::Value,
     /// Stack length before the current instruction.
     len_before: B::Value,
     /// Stack length offset for the current instruction, used for push/pop.
@@ -243,13 +241,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             Pointer::new_address(i64_type, bcx.gep(i8_type, gas_ptr, &[offset], name))
         };
 
-        // Load input pointer from ecx.
-        let input = {
-            let input_field =
-                get_field(&mut bcx, ecx, mem::offset_of!(EvmContext<'_>, input), "ecx.input.addr");
-            bcx.load(ptr_type, input_field, "ecx.input")
-        };
-
         // Create all instruction entry blocks.
         // Dead-code instructions map to `unreachable_block`, except when block deduplication
         // has a redirect — those are resolved in a second pass once all blocks exist.
@@ -293,7 +284,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             sp_arg: local_stack.then_some(sp_arg),
             gas_remaining,
             ecx,
-            input,
             len_before: zero,
             len_offset: 0,
             section_start_len: zero,
@@ -865,7 +855,8 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }
 
             op::ADDRESS => {
-                field!(@push @[endian = "big"] self.address_type, self.input, InputsImpl; target_address);
+                let input = field!(@load self.bcx.type_ptr(), self.ecx, EvmContext<'_>; input);
+                field!(@push @[endian = "big"] self.address_type, input, InputsImpl; target_address);
             }
             op::BALANCE => {
                 let sp = self.sp_after_inputs();
@@ -877,10 +868,12 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.narrow_to_address(slot);
             }
             op::CALLER => {
-                field!(@push @[endian = "big"] self.address_type, self.input, InputsImpl; caller_address);
+                let input = field!(@load self.bcx.type_ptr(), self.ecx, EvmContext<'_>; input);
+                field!(@push @[endian = "big"] self.address_type, input, InputsImpl; caller_address);
             }
             op::CALLVALUE => {
-                field!(@push self.word_type, self.input, InputsImpl; call_value);
+                let input = field!(@load self.bcx.type_ptr(), self.ecx, EvmContext<'_>; input);
+                field!(@push self.word_type, input, InputsImpl; call_value);
             }
             op::CALLDATALOAD => {
                 let sp = self.sp_after_inputs();


### PR DESCRIPTION

Remove the cached `ecx.input` pointer that was loaded once at function entry. Instead, load it on-demand for ADDRESS, CALLER, and CALLVALUE opcodes.

This simplifies the code and reduces state in `FunctionCx`. LLVM can CSE the loads if they appear in the same basic block.

## Benchmarks

### Codegen statistics

| benchmark          |    unopt.ll |      opt.ll |   opt.s |    jit size |       spills |     reloads |
|:-------------------|------------:|------------:|--------:|------------:|-------------:|------------:|
| fibonacci-calldata |     -0.6% 🟢 |           = |       = |           - |            = |           = |
| factorial          |     -0.6% 🟢 |           = |       = |           - |            = |           = |
| counter            |     +0.4% 🔴 |     +1.1% 🔴 | -0.2% 🟢 |           - |            - |           - |
| snailtracer        |           = |           = |       = |           = |      -1.1% 🟢 |     -0.2% 🟢 |
| weth               |     +0.4% 🔴 |     +1.1% 🔴 | -0.1% 🟢 |     +0.2% 🔴 |      -1.5% 🟢 |    -16.2% 🟢 |
| hash_10k           |           = |           = |       = |           = |            = |           = |
| erc20_transfer     |     +0.1% 🔴 |     +0.2% 🔴 | -0.1% 🟢 |     +0.3% 🔴 |      -3.4% 🟢 |     -3.1% 🟢 |
| push0_proxy        |     -0.6% 🟢 |           = |       = |           - |            - |           - |
| usdc_proxy         |     +0.3% 🔴 |     +0.9% 🔴 | +0.2% 🔴 |     +0.2% 🔴 |      -5.6% 🟢 |     -1.6% 🟢 |
| fiat_token         |     +0.1% 🔴 |     +0.3% 🔴 | -0.1% 🟢 |     -2.6% 🟢 |      -0.2% 🟢 |     -5.2% 🟢 |
| uniswap_v2_pair    |     +0.1% 🔴 |     +0.3% 🔴 |       = |           = |      -1.1% 🟢 |     -8.1% 🟢 |
| univ2_router       |     +0.1% 🔴 |     +0.3% 🔴 | -0.1% 🟢 |     -0.5% 🟢 |    +145.2% 🔴 |     +1.9% 🔴 |
| seaport            |     +0.1% 🔴 |     +0.2% 🔴 |       = |           = |      -0.6% 🟢 |     -0.9% 🟢 |
| airdrop            |     +0.1% 🔴 |     +0.2% 🔴 |       = |           = |      -0.5% 🟢 |     -3.7% 🟢 |
| bswap64            |           = |           = |       = |     -0.1% 🟢 |            - |           - |
| bswap64_opt        |           = |           = |       = |     -0.1% 🟢 |            = |           = |
| eip4788            |           = |           = | -0.2% 🟢 |           - |            - |           - |
| eip2935            |           = |           = | -0.3% 🟢 |           - |            - |           - |
| curve_stableswap   |     +0.1% 🔴 |     +0.1% 🔴 |       = |           = |      -2.7% 🟢 |     -1.8% 🟢 |
| onchain_lm_v2      |     +0.1% 🔴 |     +0.3% 🔴 |       = |     -0.1% 🟢 |      -1.8% 🟢 |    -24.4% 🟢 |
| burntpix           |     +0.1% 🔴 |     +0.3% 🔴 | +0.1% 🔴 |     -1.3% 🟢 |      -2.3% 🟢 |     -1.1% 🟢 |
| **TOTAL**          | **+0.1% 🔴** | **+0.3% 🔴** |   **=** | **-0.6% 🟢** | **+10.7% 🔴** | **-2.6% 🟢** |

<details><summary>Full details</summary>

| benchmark          |   unopt.ll (main) |        diff |   opt.ll (main) |        diff |   opt.s (main) |    diff |   jit size (main) |        diff |   spills (main) |     diff |   reloads (main) |     diff |
|:-------------------|------------------:|------------:|----------------:|------------:|---------------:|--------:|------------------:|------------:|----------------:|---------:|-----------------:|---------:|
| fibonacci-calldata |               363 |     -0.6% 🟢 |             126 |           = |            351 |       = |                 - |           - |              12 |        = |               13 |        = |
| factorial          |               360 |     -0.6% 🟢 |             123 |           = |            370 |       = |                 - |           - |               8 |        = |                9 |        = |
| counter            |              1023 |     +0.4% 🔴 |             350 |     +1.1% 🔴 |            539 | -0.2% 🟢 |                 - |           - |               0 |        = |                0 |        = |
| snailtracer        |             54225 |           = |           23175 |           = |          38965 |       = |         122.4 KiB |           = |              95 |       -1 |              401 |       -1 |
| weth               |             13164 |     +0.4% 🔴 |            4137 |     +1.1% 🔴 |           6746 | -0.1% 🟢 |          22.1 KiB |     +0.2% 🔴 |              65 |       -1 |              148 |      -24 |
| hash_10k           |               998 |           = |             326 |           = |            601 |       = |           1.5 KiB |           = |               1 |        = |                1 |        = |
| erc20_transfer     |             13900 |     +0.1% 🔴 |            5678 |     +0.2% 🔴 |           9854 | -0.1% 🟢 |          28.6 KiB |     +0.3% 🔴 |              29 |       -1 |              194 |       -6 |
| push0_proxy        |               349 |     -0.6% 🟢 |             185 |           = |            345 |       = |                 - |           - |               0 |        = |                0 |        = |
| usdc_proxy         |              7215 |     +0.3% 🔴 |            2920 |     +0.9% 🔴 |           4494 | +0.2% 🔴 |          12.9 KiB |     +0.2% 🔴 |              18 |       -1 |               61 |       -1 |
| fiat_token         |             80677 |     +0.1% 🔴 |           27346 |     +0.3% 🔴 |          45141 | -0.1% 🟢 |         155.6 KiB |     -2.6% 🟢 |             453 |       -1 |              736 |      -38 |
| uniswap_v2_pair    |             45142 |     +0.1% 🔴 |           15785 |     +0.3% 🔴 |          25089 |       = |          83.6 KiB |           = |              87 |       -1 |              309 |      -25 |
| univ2_router       |             85422 |     +0.1% 🔴 |           29893 |     +0.3% 🔴 |          47736 | -0.1% 🟢 |         190.6 KiB |     -0.5% 🟢 |             126 |     +183 |              851 |      +16 |
| seaport            |            133192 |     +0.1% 🔴 |           57128 |     +0.2% 🔴 |          93698 |       = |         305.5 KiB |           = |             168 |       -1 |             2362 |      -22 |
| airdrop            |             27097 |     +0.1% 🔴 |           10699 |     +0.2% 🔴 |          16622 |       = |          52.6 KiB |           = |             198 |       -1 |              244 |       -9 |
| bswap64            |              2082 |           = |             578 |           = |           1136 |       = |           3.3 KiB |     -0.1% 🟢 |               0 |        = |                0 |        = |
| bswap64_opt        |              1908 |           = |             525 |           = |           1001 |       = |           3.1 KiB |     -0.1% 🟢 |               2 |        = |                2 |        = |
| eip4788            |               597 |           = |             234 |           = |            410 | -0.2% 🟢 |                 - |           - |               0 |        = |                0 |        = |
| eip2935            |               543 |           = |             205 |           = |            381 | -0.3% 🟢 |                 - |           - |               0 |        = |                0 |        = |
| curve_stableswap   |             17291 |     +0.1% 🔴 |            7770 |     +0.1% 🔴 |          11725 |       = |          36.6 KiB |           = |              37 |       -1 |              275 |       -5 |
| onchain_lm_v2      |             57306 |     +0.1% 🔴 |           23419 |     +0.3% 🔴 |          38555 |       = |         115.6 KiB |     -0.1% 🟢 |              55 |       -1 |              316 |      -77 |
| burntpix           |            124572 |     +0.1% 🔴 |           47099 |     +0.3% 🔴 |          69282 | +0.1% 🔴 |         228.2 KiB |     -1.3% 🟢 |             214 |       -5 |             2312 |      -26 |
| **TOTAL**          |        **667426** | **+0.1% 🔴** |      **257701** | **+0.3% 🔴** |     **413041** |   **=** |       **1.3 MiB** | **-0.6% 🟢** |        **1568** | **+168** |         **8234** | **-218** |

</details>

### Compile times

| benchmark          |       total |       parse |   translate |    finalize |   codegen |
|:-------------------|------------:|------------:|------------:|------------:|----------:|
| fibonacci-calldata |    +25.0% 🔴 |     -6.6% 🟢 |     +1.5% 🔴 |    +27.7% 🔴 |         - |
| factorial          |    +10.7% 🔴 |     -3.4% 🟢 |     +2.2% 🔴 |    +11.8% 🔴 |         - |
| counter            |     +5.6% 🔴 |     +1.0% 🔴 |     +5.6% 🔴 |     +5.8% 🔴 |         - |
| snailtracer        |     -3.6% 🟢 |     +9.4% 🔴 |     +6.6% 🔴 |     -3.7% 🟢 |         - |
| weth               |     -2.2% 🟢 |     -1.1% 🟢 |     -0.5% 🟢 |     -2.2% 🟢 |         - |
| hash_10k           |     -4.2% 🟢 |    -25.2% 🟢 |    -33.6% 🟢 |     -0.1% 🟢 |         - |
| erc20_transfer     |     -3.5% 🟢 |    -15.4% 🟢 |    -13.3% 🟢 |     -3.2% 🟢 |         - |
| push0_proxy        |     +6.9% 🔴 |     -0.5% 🟢 |    +23.6% 🔴 |     +5.9% 🔴 |         - |
| usdc_proxy         |     -0.4% 🟢 |     -4.8% 🟢 |     +0.7% 🔴 |     -0.4% 🟢 |         - |
| fiat_token         |     +3.9% 🔴 |     +2.4% 🔴 |     +8.3% 🔴 |     +3.8% 🔴 |         - |
| uniswap_v2_pair    |     -4.1% 🟢 |     -2.2% 🟢 |     +2.0% 🔴 |     -4.2% 🟢 |         - |
| univ2_router       |     -1.4% 🟢 |     -2.7% 🟢 |     -7.3% 🟢 |     -1.3% 🟢 |         - |
| seaport            |     +3.7% 🔴 |     -1.5% 🟢 |     -0.2% 🟢 |     +3.8% 🔴 |         - |
| airdrop            |     +4.4% 🔴 |     +7.3% 🔴 |     +5.5% 🔴 |     +4.3% 🔴 |         - |
| bswap64            |     -6.7% 🟢 |     -8.0% 🟢 |    -12.7% 🟢 |     -6.3% 🟢 |         - |
| bswap64_opt        |     +4.5% 🔴 |     +0.3% 🔴 |     +1.9% 🔴 |     +4.8% 🔴 |         - |
| eip4788            |     -3.9% 🟢 |     -3.1% 🟢 |     -6.9% 🟢 |     -3.7% 🟢 |         - |
| eip2935            |     +4.5% 🔴 |     -2.9% 🟢 |     -9.7% 🟢 |     +6.2% 🔴 |         - |
| curve_stableswap   |     +1.0% 🔴 |     +2.9% 🔴 |     +8.7% 🔴 |     +0.9% 🔴 |         - |
| onchain_lm_v2      |     +0.1% 🔴 |     -0.8% 🟢 |     +1.5% 🔴 |     +0.1% 🔴 |         - |
| burntpix           |     -1.3% 🟢 |           = |     -3.2% 🟢 |     -1.4% 🟢 |         - |
| **TOTAL**          | **-0.1% 🟢** | **-0.1% 🟢** | **+0.1% 🔴** | **-0.1% 🟢** |     **-** |

<details><summary>Full compile times</summary>

| benchmark          |        main |      branch |        diff |   parse (main) |   parse (branch) |   parse diff |   translate (main) |   translate (branch) |   translate diff |   finalize (main) |   finalize (branch) |   finalize diff |   codegen (main) |   codegen (branch) |   codegen diff |
|:-------------------|------------:|------------:|------------:|---------------:|-----------------:|-------------:|-------------------:|---------------------:|-----------------:|------------------:|--------------------:|----------------:|-----------------:|-------------------:|---------------:|
| fibonacci-calldata |      6.40ms |      8.00ms |    +25.0% 🔴 |        181.1µs |          169.1µs |      -6.6% 🟢 |            423.4µs |              429.6µs |          +1.5% 🔴 |            5.80ms |              7.40ms |        +27.7% 🔴 |                - |                  - |              - |
| factorial          |      6.52ms |      7.22ms |    +10.7% 🔴 |        180.2µs |          174.0µs |      -3.4% 🟢 |            421.2µs |              430.3µs |          +2.2% 🔴 |            5.92ms |              6.62ms |        +11.8% 🔴 |                - |                  - |              - |
| counter            |      8.58ms |      9.06ms |     +5.6% 🔴 |        333.1µs |          336.6µs |      +1.0% 🔴 |            562.3µs |              593.6µs |          +5.6% 🔴 |            7.68ms |              8.13ms |         +5.8% 🔴 |                - |                  - |              - |
| snailtracer        |      2.253s |      2.173s |     -3.6% 🟢 |         8.39ms |           9.17ms |      +9.4% 🔴 |             10.9ms |               11.6ms |          +6.6% 🔴 |            2.234s |              2.152s |         -3.7% 🟢 |                - |                  - |              - |
| weth               |     111.8ms |     109.4ms |     -2.2% 🟢 |         2.23ms |           2.20ms |      -1.1% 🟢 |             2.73ms |               2.72ms |          -0.5% 🟢 |           106.9ms |             104.5ms |         -2.2% 🟢 |                - |                  - |              - |
| hash_10k           |      9.93ms |      9.51ms |     -4.2% 🟢 |        436.3µs |          326.2µs |     -25.2% 🟢 |            879.8µs |              584.3µs |         -33.6% 🟢 |            8.61ms |              8.60ms |         -0.1% 🟢 |                - |                  - |              - |
| erc20_transfer     |     202.5ms |     195.4ms |     -3.5% 🟢 |         2.70ms |           2.28ms |     -15.4% 🟢 |             3.25ms |               2.81ms |         -13.3% 🟢 |           196.6ms |             190.3ms |         -3.2% 🟢 |                - |                  - |              - |
| push0_proxy        |      5.93ms |      6.34ms |     +6.9% 🔴 |        155.8µs |          155.0µs |      -0.5% 🟢 |            406.1µs |              501.8µs |         +23.6% 🔴 |            5.37ms |              5.68ms |         +5.9% 🔴 |                - |                  - |              - |
| usdc_proxy         |      74.2ms |      73.9ms |     -0.4% 🟢 |         1.56ms |           1.49ms |      -4.8% 🟢 |             1.77ms |               1.78ms |          +0.7% 🔴 |            70.9ms |              70.6ms |         -0.4% 🟢 |                - |                  - |              - |
| fiat_token         |     833.9ms |     866.1ms |     +3.9% 🔴 |         15.1ms |           15.4ms |      +2.4% 🔴 |             15.1ms |               16.4ms |          +8.3% 🔴 |           803.7ms |             834.3ms |         +3.8% 🔴 |                - |                  - |              - |
| uniswap_v2_pair    |     442.0ms |     424.0ms |     -4.1% 🟢 |         7.60ms |           7.43ms |      -2.2% 🟢 |             8.83ms |               9.01ms |          +2.0% 🔴 |           425.6ms |             407.6ms |         -4.2% 🟢 |                - |                  - |              - |
| univ2_router       |     893.3ms |     880.4ms |     -1.4% 🟢 |         15.3ms |           14.9ms |      -2.7% 🟢 |             17.0ms |               15.8ms |          -7.3% 🟢 |           861.0ms |             849.7ms |         -1.3% 🟢 |                - |                  - |              - |
| seaport            |      2.157s |      2.237s |     +3.7% 🔴 |         21.2ms |           20.9ms |      -1.5% 🟢 |             24.4ms |               24.3ms |          -0.2% 🟢 |            2.112s |              2.192s |         +3.8% 🔴 |                - |                  - |              - |
| airdrop            |     366.7ms |     382.7ms |     +4.4% 🔴 |         4.80ms |           5.15ms |      +7.3% 🔴 |             5.27ms |               5.56ms |          +5.5% 🔴 |           356.6ms |             372.0ms |         +4.3% 🔴 |                - |                  - |              - |
| bswap64            |      15.6ms |      14.5ms |     -6.7% 🟢 |        509.5µs |          468.9µs |      -8.0% 🟢 |            815.9µs |              712.5µs |         -12.7% 🟢 |            14.3ms |              13.4ms |         -6.3% 🟢 |                - |                  - |              - |
| bswap64_opt        |      14.1ms |      14.7ms |     +4.5% 🔴 |        431.1µs |          432.2µs |      +0.3% 🔴 |            734.5µs |              748.7µs |          +1.9% 🔴 |            12.9ms |              13.5ms |         +4.8% 🔴 |                - |                  - |              - |
| eip4788            |      7.28ms |      6.99ms |     -3.9% 🟢 |        230.2µs |          223.1µs |      -3.1% 🟢 |            513.5µs |              477.8µs |          -6.9% 🟢 |            6.53ms |              6.29ms |         -3.7% 🟢 |                - |                  - |              - |
| eip2935            |      6.38ms |      6.67ms |     +4.5% 🔴 |        220.2µs |          213.8µs |      -2.9% 🟢 |            528.5µs |              477.0µs |          -9.7% 🟢 |            5.63ms |              5.98ms |         +6.2% 🔴 |                - |                  - |              - |
| curve_stableswap   |     223.9ms |     226.2ms |     +1.0% 🔴 |         2.97ms |           3.06ms |      +2.9% 🔴 |             3.47ms |               3.78ms |          +8.7% 🔴 |           217.5ms |             219.3ms |         +0.9% 🔴 |                - |                  - |              - |
| onchain_lm_v2      |      1.371s |      1.373s |     +0.1% 🔴 |         9.33ms |           9.25ms |      -0.8% 🟢 |             11.3ms |               11.5ms |          +1.5% 🔴 |            1.350s |              1.352s |         +0.1% 🔴 |                - |                  - |              - |
| burntpix           |      2.090s |      2.062s |     -1.3% 🟢 |         20.7ms |           20.7ms |            = |             22.7ms |               22.0ms |          -3.2% 🟢 |            2.047s |              2.019s |         -1.4% 🟢 |                - |                  - |              - |
| **TOTAL**          | **11.100s** | **11.086s** | **-0.1% 🟢** |    **114.5ms** |      **114.4ms** |  **-0.1% 🟢** |        **132.0ms** |          **132.2ms** |      **+0.1% 🔴** |       **10.854s** |         **10.839s** |     **-0.1% 🟢** |            **-** |              **-** |          **-** |

</details>


## univ2_router spill increase investigation

The +145% spill increase in univ2_router is a misleading metric. The contract has 49 uses of ADDRESS/CALLER/CALLVALUE across different basic blocks.

Previously, `ecx.input` was loaded once at entry and spilled to `[rbp - 48]`, then reloaded throughout. Now each opcode loads from `ecx.input` inline. Since uses are in different basic blocks, LLVM can't CSE them.

However, the spill count metric counts total spill stores, not unique slots. LLVM now reuses `[rbp - 48]` for different temporaries across blocks - the same slot that previously held the cached input pointer:

```
> mov     qword ptr [rbp - 48], rax       # 8-byte Spill
> mov     qword ptr [rbp - 48], rdi       # 8-byte Spill
> mov     qword ptr [rbp - 48], r15       # 8-byte Spill
...
```

The actual code quality is equivalent or better:
- Assembly lines: 47736 → 47710 (-26 lines, -0.1%)
- JIT size: -0.5%

The increased spill count just reflects different register allocation decisions, not worse code.
