### PR TITLE
fix(scripts): match bare 'N B' jit size in bench remarks

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -217,7 +217,7 @@ def parse_remarks(dump_dir: str, bench: str) -> dict[str, float]:
     return result
 
 
-JIT_SIZE_RE = re.compile(r"\((\d+) B\)")
+JIT_SIZE_RE = re.compile(r"(?:\(|:\s)(\d+)\s*B\)?")
 
 
 def parse_jit_size(dump_dir: str, bench: str) -> int:


### PR DESCRIPTION
The remarks dump emits sizes under 1 KiB without a parenthesised byte form, e.g. `counter: 900 B` instead of `counter: 1.2 KiB (1278 B)`. The previous regex `\\((\d+) B\\)` only matched the parenthesised form, so small benchmarks (counter, fibonacci-calldata, factorial, push0_proxy, eip4788, eip2935) parsed as 0 and rendered as `-` in the jit size column.

Accept either form.