### PR TITLE
perf: assume non-null pointers in JIT'd function signature

### DIFF
--- a/crates/revmc-context/src/arch/aarch64.rs
+++ b/crates/revmc-context/src/arch/aarch64.rs
@@ -1,5 +1,6 @@
 use super::{EXIT_RESULT_OFFSET, EXIT_SP_OFFSET};
 use crate::{EvmContext, EvmStack, RawEvmCompilerFn};
+use core::ptr::NonNull;
 use revm_interpreter::InstructionResult;
 
 /// Entry trampoline: saves callee-saved registers, stores SP into
@@ -10,9 +11,9 @@ use revm_interpreter::InstructionResult;
 /// returns the `exit_result` stored in `EvmContext`.
 #[unsafe(naked)]
 pub(crate) unsafe extern "C" fn revmc_entry(
-    ecx: *mut EvmContext<'_>,
-    stack: *mut EvmStack,
-    stack_len: *mut usize,
+    ecx: NonNull<EvmContext<'_>>,
+    stack: NonNull<EvmStack>,
+    stack_len: NonNull<usize>,
     f: RawEvmCompilerFn,
 ) -> InstructionResult {
     // AAPCS64: x0=ecx, x1=stack, x2=stack_len, x3=f

--- a/crates/revmc-context/src/arch/x86_64.rs
+++ b/crates/revmc-context/src/arch/x86_64.rs
@@ -1,5 +1,6 @@
 use super::{EXIT_RESULT_OFFSET, EXIT_SP_OFFSET};
 use crate::{EvmContext, EvmStack, RawEvmCompilerFn};
+use core::ptr::NonNull;
 use revm_interpreter::InstructionResult;
 
 /// Entry trampoline: saves callee-saved registers, stores RSP into
@@ -10,9 +11,9 @@ use revm_interpreter::InstructionResult;
 /// returns the `exit_result` stored in `EvmContext`.
 #[unsafe(naked)]
 pub(crate) unsafe extern "C" fn revmc_entry(
-    ecx: *mut EvmContext<'_>,
-    stack: *mut EvmStack,
-    stack_len: *mut usize,
+    ecx: NonNull<EvmContext<'_>>,
+    stack: NonNull<EvmStack>,
+    stack_len: NonNull<usize>,
     f: RawEvmCompilerFn,
 ) -> InstructionResult {
     // System V AMD64: rdi=ecx, rsi=stack, rdx=stack_len, rcx=f

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -6,7 +6,11 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::{fmt, mem::MaybeUninit, ptr};
+use core::{
+    fmt,
+    mem::MaybeUninit,
+    ptr::{self, NonNull},
+};
 use revm_interpreter::{
     Gas, Host, InputsImpl, InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
     SharedMemory,
@@ -192,9 +196,9 @@ macro_rules! extern_revmc {
             $(
                 $(#[$attr])*
                 $vis fn $name(
-                    ecx: *mut $crate::EvmContext<'_>,
-                    stack: *mut $crate::EvmStack,
-                    stack_len: *mut usize,
+                    ecx: ::core::ptr::NonNull<$crate::EvmContext<'_>>,
+                    stack: ::core::ptr::NonNull<$crate::EvmStack>,
+                    stack_len: ::core::ptr::NonNull<usize>,
                 ) -> $crate::private::revm_interpreter::InstructionResult;
             )+
         }
@@ -207,9 +211,9 @@ macro_rules! extern_revmc {
 /// information.
 // When changing the signature, also update the corresponding declarations in `fn translate`.
 pub type RawEvmCompilerFn = unsafe extern "C" fn(
-    ecx: *mut EvmContext<'_>,
-    stack: *mut EvmStack,
-    stack_len: *mut usize,
+    ecx: NonNull<EvmContext<'_>>,
+    stack: NonNull<EvmStack>,
+    stack_len: NonNull<usize>,
 ) -> InstructionResult;
 
 /// An EVM bytecode function.
@@ -289,7 +293,7 @@ impl EvmCompilerFn {
         let (mut ecx, stack, stack_len) =
             EvmContext::from_interpreter_with_stack(interpreter, host);
         configure(&mut ecx);
-        let result = self.call(Some(stack), Some(stack_len), &mut ecx);
+        let result = self.call(stack, stack_len, &mut ecx);
 
         let resume_at = ecx.resume_at;
 
@@ -321,13 +325,9 @@ impl EvmCompilerFn {
     /// Calls the function.
     ///
     /// Arguments:
-    /// - `stack`: Pointer to the stack. Must be `Some` if `local_stack` is set to `false`, or if
-    ///   the bytecode may suspend (contains `CALL`/`CREATE`-family opcodes).
-    /// - `stack_len`: Pointer to the stack length. Must be `Some` if `inspect_stack` is set to
-    ///   `true`, or if the bytecode may suspend.
+    /// - `stack`: The stack buffer.
+    /// - `stack_len`: The stack length.
     /// - `ecx`: The context object.
-    ///
-    /// These conditions are enforced at runtime if `debug_assertions` is set to `true`.
     ///
     /// Use of this method is discouraged, as setup and cleanup need to be done manually.
     ///
@@ -337,11 +337,11 @@ impl EvmCompilerFn {
     #[inline]
     pub unsafe fn call(
         self,
-        stack: Option<&mut EvmStack>,
-        stack_len: Option<&mut usize>,
+        stack: &mut EvmStack,
+        stack_len: &mut usize,
         ecx: &mut EvmContext<'_>,
     ) -> InstructionResult {
-        revmc_entry(ecx, option_as_mut_ptr(stack), option_as_mut_ptr(stack_len), self.0)
+        revmc_entry(NonNull::from(ecx), NonNull::from(stack), NonNull::from(stack_len), self.0)
     }
 
     /// Same as [`call`](Self::call) but with `#[inline(never)]`.
@@ -354,8 +354,8 @@ impl EvmCompilerFn {
     #[inline(never)]
     pub unsafe fn call_noinline(
         self,
-        stack: Option<&mut EvmStack>,
-        stack_len: Option<&mut usize>,
+        stack: &mut EvmStack,
+        stack_len: &mut usize,
         ecx: &mut EvmContext<'_>,
     ) -> InstructionResult {
         self.call(stack, stack_len, ecx)
@@ -795,14 +795,6 @@ impl EvmWord {
     }
 }
 
-#[inline(always)]
-fn option_as_mut_ptr<T>(opt: Option<&mut T>) -> *mut T {
-    match opt {
-        Some(ref_) => ref_,
-        None => ptr::null_mut(),
-    }
-}
-
 // Macro re-exports.
 // Not public API.
 #[doc(hidden)]
@@ -830,9 +822,9 @@ mod tests {
 
     #[unsafe(no_mangle)]
     extern "C" fn __test_fn(
-        _ecx: *mut EvmContext<'_>,
-        _stack: *mut EvmStack,
-        _stack_len: *mut usize,
+        _ecx: NonNull<EvmContext<'_>>,
+        _stack: NonNull<EvmStack>,
+        _stack_len: NonNull<usize>,
     ) -> InstructionResult {
         InstructionResult::Stop
     }

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -668,9 +668,10 @@ impl<B: Backend> EvmCompiler<B> {
             bcx.add_function_attribute(None, attr, FunctionAttributeLocation::Function);
         }
 
-        // Pointer argument attributes.
+        // Pointer argument attributes. All pointers are non-null (the function signature uses
+        // `NonNull<T>`).
         for &(i, size, align) in ptr_attrs {
-            let attrs = default_attrs::for_sized_ptr((size, align));
+            let attrs = default_attrs::for_sized_ptr((size, align)).chain([Attribute::NonNull]);
             for attr in attrs {
                 let loc = FunctionAttributeLocation::Param(i as _);
                 bcx.add_function_attribute(None, attr, loc);

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -12,7 +12,7 @@ use revm_interpreter::{InputsImpl, InstructionResult};
 use revm_primitives::U256;
 use revmc_backend::{Attribute, BackendTypes, FunctionAttributeLocation, Pointer, TypeMethods};
 use revmc_builtins::{Builtin, Builtins, CallKind, CreateKind};
-use std::{fmt::Write, mem};
+use std::mem;
 
 mod peephole;
 
@@ -216,7 +216,8 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Use a local alloca for the stack to allow the backend to eliminate dead stores to
         // stack slots above `stack_len` at function exit (e.g. `PUSH0 POP`).
         // Disabled when `inspect_stack` is set because the caller observes every store.
-        let local_stack = !config.inspect_stack;
+        // TODO: temporarily disabled to evaluate `dead_on_return` on the stack argument.
+        let local_stack = false;
         let stack = if local_stack {
             let stack_type = bcx.type_array(word_type, STACK_CAP as u32);
             bcx.new_stack_slot(stack_type, "stack.addr")
@@ -312,30 +313,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             builtins,
         };
 
-        // Add debug assertions for the parameters.
+        // Pointers are always non-null per the function signature; LLVM elides redundant
+        // null checks via the `nonnull` attribute, so no debug assertions are needed.
         if config.debug_assertions {
-            fx.pointer_panic_with_bool(true, ecx, "EVM context pointer", "");
-            fx.pointer_panic_with_bool(
-                !local_stack || bytecode.may_suspend(),
-                sp_arg,
-                "stack pointer",
-                if !local_stack {
-                    "local stack is disabled"
-                } else {
-                    "bytecode suspends execution"
-                },
-            );
-            fx.pointer_panic_with_bool(
-                config.inspect_stack || bytecode.may_suspend(),
-                stack_len_arg,
-                "stack length pointer",
-                if config.inspect_stack {
-                    "stack inspection is enabled"
-                } else {
-                    "bytecode suspends execution"
-                },
-            );
-
             // Assert that the runtime spec_id matches the compilation spec_id.
             let compiled_spec = fx.bcx.iconst(fx.i8_type, bytecode.spec_id as i64);
             let _ = fx.call_builtin(Builtin::AssertSpecId, &[ecx, compiled_spec]);
@@ -1580,36 +1560,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         ));
     }
 
-    // Pointer must not be null if `must_be_set` is true.
-    fn pointer_panic_with_bool(
-        &mut self,
-        must_be_set: bool,
-        ptr: B::Value,
-        name: &str,
-        extra: &str,
-    ) {
-        if !must_be_set {
-            return;
-        }
-        let panic_cond = self.bcx.is_null(ptr);
-        let mut msg = format!("revmc panic: {name} must not be null");
-        if !extra.is_empty() {
-            write!(msg, " ({extra})").unwrap();
-        }
-        self.build_assertion(panic_cond, &msg);
-    }
-
-    fn build_assertion(&mut self, cond: B::Value, msg: &str) {
-        let failure = self.create_block_after_current("panic");
-        let target = self.create_block_after(failure, "contd");
-        self.bcx.brif(cond, failure, target);
-
-        self.bcx.switch_to_block(failure);
-        self.call_panic(msg);
-
-        self.bcx.switch_to_block(target);
-    }
-
     /// Build a call to the panic builtin.
     fn call_panic(&mut self, msg: &str) {
         let function = self.builtin_function(Builtin::Panic);
@@ -1682,12 +1632,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     fn create_block_after(&mut self, after: B::BasicBlock, name: &str) -> B::BasicBlock {
         let name = self.op_block_name(name);
         self.bcx.create_block_after(after, &name)
-    }
-
-    /// Creates a named block after the current block.
-    fn create_block_after_current(&mut self, name: &str) -> B::BasicBlock {
-        let after = self.current_block();
-        self.create_block_after(after, name)
     }
 
     /// Returns the block name for the current opcode with the given suffix.

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -12,7 +12,7 @@ use revm_interpreter::{InputsImpl, InstructionResult};
 use revm_primitives::U256;
 use revmc_backend::{Attribute, BackendTypes, FunctionAttributeLocation, Pointer, TypeMethods};
 use revmc_builtins::{Builtin, Builtins, CallKind, CreateKind};
-use std::mem;
+use std::{fmt::Write, mem};
 
 mod peephole;
 
@@ -216,8 +216,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Use a local alloca for the stack to allow the backend to eliminate dead stores to
         // stack slots above `stack_len` at function exit (e.g. `PUSH0 POP`).
         // Disabled when `inspect_stack` is set because the caller observes every store.
-        // TODO: temporarily disabled to evaluate `dead_on_return` on the stack argument.
-        let local_stack = false;
+        let local_stack = !config.inspect_stack;
         let stack = if local_stack {
             let stack_type = bcx.type_array(word_type, STACK_CAP as u32);
             bcx.new_stack_slot(stack_type, "stack.addr")
@@ -313,9 +312,30 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             builtins,
         };
 
-        // Pointers are always non-null per the function signature; LLVM elides redundant
-        // null checks via the `nonnull` attribute, so no debug assertions are needed.
+        // Add debug assertions for the parameters.
         if config.debug_assertions {
+            fx.pointer_panic_with_bool(true, ecx, "EVM context pointer", "");
+            fx.pointer_panic_with_bool(
+                !local_stack || bytecode.may_suspend(),
+                sp_arg,
+                "stack pointer",
+                if !local_stack {
+                    "local stack is disabled"
+                } else {
+                    "bytecode suspends execution"
+                },
+            );
+            fx.pointer_panic_with_bool(
+                config.inspect_stack || bytecode.may_suspend(),
+                stack_len_arg,
+                "stack length pointer",
+                if config.inspect_stack {
+                    "stack inspection is enabled"
+                } else {
+                    "bytecode suspends execution"
+                },
+            );
+
             // Assert that the runtime spec_id matches the compilation spec_id.
             let compiled_spec = fx.bcx.iconst(fx.i8_type, bytecode.spec_id as i64);
             let _ = fx.call_builtin(Builtin::AssertSpecId, &[ecx, compiled_spec]);
@@ -1560,6 +1580,36 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         ));
     }
 
+    // Pointer must not be null if `must_be_set` is true.
+    fn pointer_panic_with_bool(
+        &mut self,
+        must_be_set: bool,
+        ptr: B::Value,
+        name: &str,
+        extra: &str,
+    ) {
+        if !must_be_set {
+            return;
+        }
+        let panic_cond = self.bcx.is_null(ptr);
+        let mut msg = format!("revmc panic: {name} must not be null");
+        if !extra.is_empty() {
+            write!(msg, " ({extra})").unwrap();
+        }
+        self.build_assertion(panic_cond, &msg);
+    }
+
+    fn build_assertion(&mut self, cond: B::Value, msg: &str) {
+        let failure = self.create_block_after_current("panic");
+        let target = self.create_block_after(failure, "contd");
+        self.bcx.brif(cond, failure, target);
+
+        self.bcx.switch_to_block(failure);
+        self.call_panic(msg);
+
+        self.bcx.switch_to_block(target);
+    }
+
     /// Build a call to the panic builtin.
     fn call_panic(&mut self, msg: &str) {
         let function = self.builtin_function(Builtin::Panic);
@@ -1632,6 +1682,12 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     fn create_block_after(&mut self, after: B::BasicBlock, name: &str) -> B::BasicBlock {
         let name = self.op_block_name(name);
         self.bcx.create_block_after(after, &name)
+    }
+
+    /// Creates a named block after the current block.
+    fn create_block_after_current(&mut self, name: &str) -> B::BasicBlock {
+        let after = self.current_block();
+        self.create_block_after(after, name)
     }
 
     /// Returns the block name for the current opcode with the given suffix.

--- a/crates/revmc/src/tests/fibonacci.rs
+++ b/crates/revmc/src/tests/fibonacci.rs
@@ -28,7 +28,7 @@ fn run_fibonacci_test<B: Backend>(compiler: &mut EvmCompiler<B>, input: u16, dyn
             stack.set(0, U256::from(input).into());
             *stack_len = 1;
         }
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         // Apparently the code does `fibonacci(input + 1)`.
         assert_eq!(*stack_len, 1);

--- a/crates/revmc/src/tests/meta.rs
+++ b/crates/revmc/src/tests/meta.rs
@@ -16,9 +16,9 @@ matrix_tests!(
         let gas_fn = unsafe { compiler.jit_function(gas_id) }.unwrap();
         let no_gas_fn = unsafe { compiler.jit_function(no_gas_id) }.unwrap();
         with_evm_context(bytecode, spec_id, |ecx, stack, stack_len| {
-            let r = unsafe { gas_fn.call(Some(stack), Some(stack_len), ecx) };
+            let r = unsafe { gas_fn.call(stack, stack_len, ecx) };
             assert_eq!(r, InstructionResult::Stop);
-            let r = unsafe { no_gas_fn.call(Some(stack), Some(stack_len), ecx) };
+            let r = unsafe { no_gas_fn.call(stack, stack_len, ecx) };
             assert_eq!(r, InstructionResult::Stop);
         });
     }
@@ -47,7 +47,7 @@ matrix_tests!(
 
         // First function still works after clear_ir + second compilation.
         with_evm_context(bytecode1, spec_id, |ecx, stack, stack_len| {
-            let r = unsafe { f1.call(Some(stack), Some(stack_len), ecx) };
+            let r = unsafe { f1.call(stack, stack_len, ecx) };
             assert_eq!(r, InstructionResult::Stop);
             assert_eq!(*stack_len, 1);
             assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(42));
@@ -55,7 +55,7 @@ matrix_tests!(
 
         // Second function works.
         with_evm_context(bytecode2, spec_id, |ecx, stack, stack_len| {
-            let r = unsafe { f2.call(Some(stack), Some(stack_len), ecx) };
+            let r = unsafe { f2.call(stack, stack_len, ecx) };
             assert_eq!(r, InstructionResult::Stop);
             assert_eq!(*stack_len, 1);
             assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(3));
@@ -80,7 +80,7 @@ fn jit_and_verify<B: Backend>(
     let f = unsafe { compiler.jit_function(id) }.unwrap();
 
     with_evm_context(code, super::DEF_SPEC, |ecx, stack, stack_len| {
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop, "{name}: unexpected return");
         assert_eq!(*stack_len, 1, "{name}: expected 1 stack element");
         assert_eq!(

--- a/crates/revmc/src/tests/resume.rs
+++ b/crates/revmc/src/tests/resume.rs
@@ -35,7 +35,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         // (as opposed to reaching an actual STOP opcode).
 
         // op::PUSH1, 0x42,
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42));
@@ -43,7 +43,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(resume_1.get(), 1);
 
         // op::PUSH1, 0x69,
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 2);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42));
@@ -52,7 +52,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(resume_2.get(), 2);
 
         // op::ADD,
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42 + 0x69));
@@ -60,7 +60,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(resume_3.get(), 3);
 
         // stop
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42 + 0x69));
@@ -68,7 +68,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
 
         // op::ADD,
         ecx.resume_at = resume_2;
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::StackUnderflow);
         assert_eq!(*stack_len, 1);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42 + 0x69));
@@ -79,7 +79,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
 
         // op::ADD,
         ecx.resume_at = resume_2;
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42 + 0x69 + 2));
@@ -87,7 +87,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
 
         // op::PUSH1, 0x69,
         ecx.resume_at = resume_1;
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 2);
         assert_eq!(unsafe { stack.as_slice(*stack_len) }[0].to_u256(), U256::from(0x42 + 0x69 + 2));
@@ -95,7 +95,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(ecx.resume_at, resume_2);
 
         // op::ADD,
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(
@@ -105,7 +105,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(ecx.resume_at, resume_3);
 
         // stop
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(
@@ -115,7 +115,7 @@ fn run<B: Backend>(compiler: &mut EvmCompiler<B>, code: &[u8], spec_id: SpecId) 
         assert_eq!(ecx.resume_at, resume_3);
 
         // stop
-        let r = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let r = unsafe { f.call(stack, stack_len, ecx) };
         assert_eq!(r, InstructionResult::Stop);
         assert_eq!(*stack_len, 1);
         assert_eq!(

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -614,7 +614,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
             assert_host(&int_host);
         }
 
-        let actual_return = unsafe { f.call(Some(stack), Some(stack_len), ecx) };
+        let actual_return = unsafe { f.call(stack, stack_len, ecx) };
 
         if matches!(
             actual_return,


### PR DESCRIPTION
Make the JIT'd function signature use `NonNull<T>` for all three pointer arguments (`ecx`, `stack`, `stack_len`) and require non-Option arguments in `EvmCompilerFn::call`. `NonNull<T>` is layout-compatible with `*mut T`, so the C ABI is unchanged.

The LLVM `nonnull` parameter attribute is now applied unconditionally to all three pointer parameters, matching the new signature.