### PR TITLE
refactor: intern bytecode immediates at parse time

### DIFF
--- a/crates/revmc/src/bytecode/fmt.rs
+++ b/crates/revmc/src/bytecode/fmt.rs
@@ -26,7 +26,7 @@ impl Bytecode<'_> {
             .blocks
             .iter()
             .flat_map(|b| {
-                b.insts().filter(|&i| !self.inst(i).is_dead_code()).map(|i| (i, self.inst(i).pc))
+                b.insts().filter(|&i| !self.inst(i).is_dead_code()).map(|i| (i, self.pc(i)))
             })
             .fold((0u32, 0u32), |(mi, mp), (i, p)| (mi.max(i.index() as u32), mp.max(p)));
         let ic_width = decimal_width(max_ic);
@@ -98,7 +98,7 @@ impl Bytecode<'_> {
 
                 // Instruction text.
                 let mut text = String::from("  ");
-                let opcode = data.to_op_in(self);
+                let opcode = self.opcode(inst);
                 write!(text, "{opcode}").unwrap();
                 if data.flags.contains(InstFlags::INVALID_JUMP) {
                     text.push_str(" %invalid");
@@ -115,7 +115,7 @@ impl Bytecode<'_> {
                         }
                     }
                 } else if data.is_static_jump() {
-                    let target = Inst::from_usize(data.data as usize);
+                    let target = data.static_jump_target();
                     match self.target_block(target) {
                         Some(b) => write!(text, " %{b}").unwrap(),
                         None => write!(text, " %inst{target}").unwrap(),
@@ -127,7 +127,7 @@ impl Bytecode<'_> {
                 // Comment with ic, pc, and flags/behavior.
                 let mut comment = String::new();
                 write!(comment, "ic={:>ic_width$}", inst.index()).unwrap();
-                write!(comment, " pc={:>pc_width$}", data.pc).unwrap();
+                write!(comment, " pc={:>pc_width$}", self.pc(inst)).unwrap();
                 if !data.gas_section.is_empty() {
                     write!(comment, " gas={}", data.gas_section.gas_cost).unwrap();
                 }
@@ -306,7 +306,6 @@ impl fmt::Debug for InstData {
             .field("opcode", &self.to_op())
             .field("flags", &format_args!("{:?}", self.flags))
             .field("data", &self.data)
-            .field("pc", &self.pc)
             .field("gas_section", &self.gas_section)
             .field("stack_section", &self.stack_section)
             .finish()
@@ -419,7 +418,7 @@ impl<'a> Bytecode<'a> {
                         data.stack_section.inputs, data.stack_section.max_growth
                     )?;
                 }
-                let opcode = data.to_op_in(self);
+                let opcode = self.opcode(inst);
                 let mut op_str =
                     abbreviate_hex(&opcode.to_string()).replace('>', "\\>").replace('<', "\\<");
                 if !data.gas_section.is_empty() {

--- a/crates/revmc/src/bytecode/interner.rs
+++ b/crates/revmc/src/bytecode/interner.rs
@@ -19,10 +19,9 @@ impl<I: Idx, T: Hash + Eq, S: BuildHasher + Default> Default for Interner<I, T, 
 
 impl<I: Idx, T: Hash + Eq, S: BuildHasher + Default> Interner<I, T, S> {
     pub(crate) fn new() -> Self {
-        Self { set: IndexSet::default(), _marker: std::marker::PhantomData }
+        Self::with_capacity(0)
     }
 
-    #[allow(dead_code)]
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             set: IndexSet::with_capacity_and_hasher(capacity, S::default()),

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -258,8 +258,7 @@ impl<'a> Bytecode<'a> {
             };
 
             let data = match opcode {
-                op::PUSH0 => U256Imm::new(U256::ZERO, &mut u256_interner).to_raw(),
-                op::PUSH1..=op::PUSH32 | op::DUPN | op::SWAPN | op::EXCHANGE => {
+                op::PUSH0..=op::PUSH32 | op::DUPN | op::SWAPN | op::EXCHANGE => {
                     let imm_len = min_imm_len(opcode) as usize;
                     // `OpcodesIter` returns `None` for truncated EOF immediates; recover
                     // the available bytes directly from `code` and right-pad with zeros
@@ -277,7 +276,11 @@ impl<'a> Bytecode<'a> {
                     };
                     U256Imm::new(value, &mut u256_interner).to_raw()
                 }
-                op::JUMPDEST | op::PC => pc as u32,
+                op::JUMPDEST | op::PC => {
+                    let pc = pc as u32;
+                    debug_assert!(pc & InstData::JUMPDEST_REACHABLE == 0, "pc too large");
+                    pc
+                }
                 _ => 0,
             };
 

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -63,15 +63,7 @@ pub(crate) type U256Interner = Interner<U256Idx, U256, alloy_primitives::map::Fb
 
 /// Compact handle to a `U256` constant.
 ///
-/// Encodes either:
-/// - An inline `u8` value (when the constant fits in `0..=255`), tagged with the high bit: raw =
-///   `INLINE_TAG | value`.
-/// - A reference into a [`U256Interner`], with the high bit clear: raw = `idx`. Up to 2^31 distinct
-///   non-inline constants per [`Bytecode`] are supported.
-///
-/// Distinguishing the two representations is a single bit test against `INLINE_TAG`.
-/// Constructing through [`U256Imm::new`] is canonical: equal values always produce equal
-/// `U256Imm`s, so `Eq`/`Hash` work on the raw bits.
+/// Either a `u32` inline value or a reference into a [`U256Interner`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct U256Imm(u32);
 
@@ -79,11 +71,25 @@ impl U256Imm {
     /// High bit set means the handle is an inline `u8` value.
     const INLINE_TAG: u32 = 1 << 31;
 
+    /// Decodes a handle previously produced by [`Self::to_raw`].
+    #[inline]
+    pub(crate) fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Encodes this handle as a `u32` for storage in [`InstData::data`].
+    #[inline]
+    pub(crate) fn to_raw(self) -> u32 {
+        self.0
+    }
+
     /// Constructs a handle for `value`, inlining `u8`-sized values and otherwise interning.
     #[inline]
     pub(crate) fn new(value: U256, interner: &mut U256Interner) -> Self {
-        if value.bit_len() <= 8 {
-            Self(Self::INLINE_TAG | value.byte(0) as u32)
+        if let Ok(x) = u32::try_from(value)
+            && x & Self::INLINE_TAG == 0
+        {
+            Self(Self::INLINE_TAG | x)
         } else {
             let idx = interner.intern(value).index() as u32;
             debug_assert!(
@@ -98,36 +104,23 @@ impl U256Imm {
     #[inline]
     pub(crate) fn get(self, interner: &U256Interner) -> U256 {
         if self.0 & Self::INLINE_TAG != 0 {
-            U256::from(self.0 as u8)
+            U256::from(self.0 & !Self::INLINE_TAG)
         } else {
             *interner.get(U256Idx::from_usize(self.0 as usize))
         }
     }
 
-    /// Returns the inline `u8` value, if any.
+    /// Returns the inline `u32` value, if any.
     #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn as_u8(self) -> Option<u8> {
-        (self.0 & Self::INLINE_TAG != 0).then_some(self.0 as u8)
-    }
-
-    /// Encodes this handle as a `u32` for storage in [`InstData::data`].
-    #[inline]
-    pub(crate) fn to_raw(self) -> u32 {
-        self.0
-    }
-
-    /// Decodes a handle previously produced by [`Self::to_raw`].
-    #[inline]
-    pub(crate) fn from_raw(raw: u32) -> Self {
-        Self(raw)
+    pub(crate) fn get_inline(self) -> Option<u32> {
+        (self.0 & Self::INLINE_TAG != 0).then_some(self.0 & !Self::INLINE_TAG)
     }
 }
 
 impl std::fmt::Debug for U256Imm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.as_u8() {
-            Some(b) => write!(f, "U256Imm::Inline(0x{b:02x})"),
+        match self.get_inline() {
+            Some(x) => write!(f, "U256Imm::Inline({x})"),
             None => write!(f, "U256Imm::Idx({})", self.0),
         }
     }
@@ -235,10 +228,10 @@ impl<'a> Bytecode<'a> {
     fn new_mono(code: Cow<'a, [u8]>, spec_id: SpecId, gas_params: Option<GasParams>) -> Self {
         let gas_params = gas_params.unwrap_or_else(|| GasParams::new_spec(spec_id));
         let mut insts = IndexVec::with_capacity(code.len() + 8);
-        let mut inst_to_pc: IndexVec<Inst, u32> = IndexVec::with_capacity(code.len() + 8);
+        let mut inst_to_pc = IndexVec::with_capacity(code.len() + 8);
         let mut jumpdests = BitVec::repeat(false, code.len());
         let mut pc_to_inst = FxHashMap::with_capacity_and_hasher(code.len(), Default::default());
-        let mut u256_interner: U256Interner = Interner::new();
+        let mut u256_interner = U256Interner::new();
         let op_infos = op_info_map(spec_id);
         let mut iter = OpcodesIter::new(&code, spec_id).with_pc();
         while let Some((pc, Opcode { opcode, immediate })) = iter.next() {
@@ -264,15 +257,9 @@ impl<'a> Bytecode<'a> {
                 (info.base_gas(), compute_stack_io(opcode, immediate))
             };
 
-            // Pre-compute the immediate so the rest of the compiler never has to access
-            // the raw bytecode. PUSH values are wrapped in `U256Imm`, which inlines
-            // u8-sized values directly and otherwise interns them. DUPN/SWAPN/EXCHANGE
-            // store their immediate byte as an always-inline `U256Imm`. JUMPDEST and PC
-            // store their pc inline so jump dispatch and the PC opcode read it directly
-            // from `data`.
             let data = match opcode {
                 op::PUSH0 => U256Imm::new(U256::ZERO, &mut u256_interner).to_raw(),
-                op::PUSH1..=op::PUSH32 => {
+                op::PUSH1..=op::PUSH32 | op::DUPN | op::SWAPN | op::EXCHANGE => {
                     let imm_len = min_imm_len(opcode) as usize;
                     // `OpcodesIter` returns `None` for truncated EOF immediates; recover
                     // the available bytes directly from `code` and right-pad with zeros
@@ -289,10 +276,6 @@ impl<'a> Bytecode<'a> {
                         _ => U256::ZERO,
                     };
                     U256Imm::new(value, &mut u256_interner).to_raw()
-                }
-                op::DUPN | op::SWAPN | op::EXCHANGE => {
-                    let b = code.get(pc + 1).copied().unwrap_or(0);
-                    U256Imm::new(U256::from(b), &mut u256_interner).to_raw()
                 }
                 op::JUMPDEST | op::PC => pc as u32,
                 _ => 0,
@@ -329,7 +312,6 @@ impl<'a> Bytecode<'a> {
         if insts.last().is_none_or(|last| last.can_fall_through()) {
             trace!("adding STOP padding");
             insts.push(InstData::new(op::STOP));
-            // Synthetic padding lives one past the real bytecode.
             inst_to_pc.push(code.len() as u32);
         }
 
@@ -557,7 +539,7 @@ impl<'a> Bytecode<'a> {
         data.imm().get(&self.u256_interner.borrow())
     }
 
-    /// Returns the length of the original bytecode in bytes (for `CODESIZE`).
+    /// Returns the length of the original bytecode in bytes.
     #[inline]
     pub(crate) fn codesize(&self) -> usize {
         self.code.len()
@@ -617,7 +599,6 @@ impl<'a> Bytecode<'a> {
     ///
     /// Returns `None` if the output is unknown, the instruction has no output, or the
     /// analysis didn't cover this instruction.
-    #[allow(dead_code)]
     pub(crate) fn const_output(&self, inst: Inst) -> Option<U256> {
         let imm = self.snapshots.outputs[inst]?.as_const()?;
         Some(imm.get(&self.u256_interner.borrow()))
@@ -933,7 +914,7 @@ impl InstData {
     pub(crate) fn imm_byte(&self) -> u8 {
         debug_assert!(matches!(self.opcode, op::DUPN | op::SWAPN | op::EXCHANGE));
         // Parse-time encoding for these opcodes always produces an inline `u8`.
-        self.imm().as_u8().unwrap()
+        self.imm().get_inline().unwrap().try_into().unwrap()
     }
 
     /// Returns the program counter stored inline for a `PC` instruction.

--- a/crates/revmc/src/bytecode/mod.rs
+++ b/crates/revmc/src/bytecode/mod.rs
@@ -58,6 +58,81 @@ oxc_index::define_nonmax_u32_index_type! {
 }
 impl_index_display!(U256Idx, "{}");
 
+/// Type alias for the bytecode-level U256 constant interner.
+pub(crate) type U256Interner = Interner<U256Idx, U256, alloy_primitives::map::FbBuildHasher<32>>;
+
+/// Compact handle to a `U256` constant.
+///
+/// Encodes either:
+/// - An inline `u8` value (when the constant fits in `0..=255`), tagged with the high bit: raw =
+///   `INLINE_TAG | value`.
+/// - A reference into a [`U256Interner`], with the high bit clear: raw = `idx`. Up to 2^31 distinct
+///   non-inline constants per [`Bytecode`] are supported.
+///
+/// Distinguishing the two representations is a single bit test against `INLINE_TAG`.
+/// Constructing through [`U256Imm::new`] is canonical: equal values always produce equal
+/// `U256Imm`s, so `Eq`/`Hash` work on the raw bits.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct U256Imm(u32);
+
+impl U256Imm {
+    /// High bit set means the handle is an inline `u8` value.
+    const INLINE_TAG: u32 = 1 << 31;
+
+    /// Constructs a handle for `value`, inlining `u8`-sized values and otherwise interning.
+    #[inline]
+    pub(crate) fn new(value: U256, interner: &mut U256Interner) -> Self {
+        if value.bit_len() <= 8 {
+            Self(Self::INLINE_TAG | value.byte(0) as u32)
+        } else {
+            let idx = interner.intern(value).index() as u32;
+            debug_assert!(
+                idx & Self::INLINE_TAG == 0,
+                "U256 interner exceeded 2^31 entries; bump `U256Imm` encoding",
+            );
+            Self(idx)
+        }
+    }
+
+    /// Returns the underlying `U256` value.
+    #[inline]
+    pub(crate) fn get(self, interner: &U256Interner) -> U256 {
+        if self.0 & Self::INLINE_TAG != 0 {
+            U256::from(self.0 as u8)
+        } else {
+            *interner.get(U256Idx::from_usize(self.0 as usize))
+        }
+    }
+
+    /// Returns the inline `u8` value, if any.
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn as_u8(self) -> Option<u8> {
+        (self.0 & Self::INLINE_TAG != 0).then_some(self.0 as u8)
+    }
+
+    /// Encodes this handle as a `u32` for storage in [`InstData::data`].
+    #[inline]
+    pub(crate) fn to_raw(self) -> u32 {
+        self.0
+    }
+
+    /// Decodes a handle previously produced by [`Self::to_raw`].
+    #[inline]
+    pub(crate) fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+}
+
+impl std::fmt::Debug for U256Imm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.as_u8() {
+            Some(b) => write!(f, "U256Imm::Inline(0x{b:02x})"),
+            None => write!(f, "U256Imm::Idx({})", self.0),
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// Controls which analysis passes run during [`Bytecode::analyze`].
     #[derive(Clone, Copy, Debug)]
@@ -104,9 +179,14 @@ pub struct Bytecode<'a> {
     may_suspend: bool,
     /// Mapping from program counter to instruction.
     pc_to_inst: FxHashMap<u32, Inst>,
+    /// Mapping from instruction index to its program counter (`code[pc]` is the opcode byte).
+    ///
+    /// `JUMPDEST` and `PC` mirror this in `data` for hot codegen access; everything else
+    /// reads it through [`Bytecode::pc`].
+    inst_to_pc: IndexVec<Inst, u32>,
 
     /// Deduplicated constant pool for U256 values.
-    u256_interner: RefCell<Interner<U256Idx, U256, alloy_primitives::map::FbBuildHasher<32>>>,
+    u256_interner: RefCell<U256Interner>,
 
     /// Per-instruction operand snapshots computed by block analysis.
     snapshots: Snapshots,
@@ -155,19 +235,20 @@ impl<'a> Bytecode<'a> {
     fn new_mono(code: Cow<'a, [u8]>, spec_id: SpecId, gas_params: Option<GasParams>) -> Self {
         let gas_params = gas_params.unwrap_or_else(|| GasParams::new_spec(spec_id));
         let mut insts = IndexVec::with_capacity(code.len() + 8);
+        let mut inst_to_pc: IndexVec<Inst, u32> = IndexVec::with_capacity(code.len() + 8);
         let mut jumpdests = BitVec::repeat(false, code.len());
         let mut pc_to_inst = FxHashMap::with_capacity_and_hasher(code.len(), Default::default());
+        let mut u256_interner: U256Interner = Interner::new();
         let op_infos = op_info_map(spec_id);
         let mut iter = OpcodesIter::new(&code, spec_id).with_pc();
         while let Some((pc, Opcode { opcode, immediate })) = iter.next() {
             let inst: Inst = insts.next_idx();
             pc_to_inst.insert(pc as u32, inst);
+            inst_to_pc.push(pc as u32);
 
             if opcode == op::JUMPDEST {
                 jumpdests.set(pc, true)
             }
-
-            let data = 0;
 
             let mut flags = InstFlags::empty();
             let info = op_infos[opcode as usize];
@@ -183,6 +264,40 @@ impl<'a> Bytecode<'a> {
                 (info.base_gas(), compute_stack_io(opcode, immediate))
             };
 
+            // Pre-compute the immediate so the rest of the compiler never has to access
+            // the raw bytecode. PUSH values are wrapped in `U256Imm`, which inlines
+            // u8-sized values directly and otherwise interns them. DUPN/SWAPN/EXCHANGE
+            // store their immediate byte as an always-inline `U256Imm`. JUMPDEST and PC
+            // store their pc inline so jump dispatch and the PC opcode read it directly
+            // from `data`.
+            let data = match opcode {
+                op::PUSH0 => U256Imm::new(U256::ZERO, &mut u256_interner).to_raw(),
+                op::PUSH1..=op::PUSH32 => {
+                    let imm_len = min_imm_len(opcode) as usize;
+                    // `OpcodesIter` returns `None` for truncated EOF immediates; recover
+                    // the available bytes directly from `code` and right-pad with zeros
+                    // per EVM spec.
+                    let start = pc + 1;
+                    let avail = code.get(start..).map(|s| &s[..s.len().min(imm_len)]);
+                    let value = match avail {
+                        Some(slice) if slice.len() == imm_len => U256::from_be_slice(slice),
+                        Some(slice) if !slice.is_empty() => {
+                            let mut padded = [0u8; 32];
+                            padded[..slice.len()].copy_from_slice(slice);
+                            U256::from_be_slice(&padded[..imm_len])
+                        }
+                        _ => U256::ZERO,
+                    };
+                    U256Imm::new(value, &mut u256_interner).to_raw()
+                }
+                op::DUPN | op::SWAPN | op::EXCHANGE => {
+                    let b = code.get(pc + 1).copied().unwrap_or(0);
+                    U256Imm::new(U256::from(b), &mut u256_interner).to_raw()
+                }
+                op::JUMPDEST | op::PC => pc as u32,
+                _ => 0,
+            };
+
             let gas_section = GasSection::default();
             let stack_section = StackSection::default();
 
@@ -192,7 +307,6 @@ impl<'a> Bytecode<'a> {
                 base_gas,
                 stack_io,
                 data,
-                pc: pc as u32,
                 gas_section,
                 stack_section,
             });
@@ -215,6 +329,8 @@ impl<'a> Bytecode<'a> {
         if insts.last().is_none_or(|last| last.can_fall_through()) {
             trace!("adding STOP padding");
             insts.push(InstData::new(op::STOP));
+            // Synthetic padding lives one past the real bytecode.
+            inst_to_pc.push(code.len() as u32);
         }
 
         Self {
@@ -226,9 +342,10 @@ impl<'a> Bytecode<'a> {
             has_dynamic_jumps: false,
             may_suspend: false,
             snapshots: Snapshots::default(),
-            u256_interner: RefCell::new(Interner::new()),
+            u256_interner: RefCell::new(u256_interner),
             multi_jump_targets: FxHashMap::default(),
             pc_to_inst,
+            inst_to_pc,
             inst_lines: RefCell::new(IndexVec::new()),
             redirects: FxHashMap::default(),
             cfg: Cfg::default(),
@@ -270,11 +387,10 @@ impl<'a> Bytecode<'a> {
         &mut self.insts[inst]
     }
 
-    /// Returns the opcode at the given instruction counter.
+    /// Returns the opcode + immediate slice for the given instruction.
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn opcode(&self, inst: Inst) -> Opcode<'_> {
-        self.inst(inst).to_op_in(self)
+        Opcode { opcode: self.inst(inst).opcode, immediate: self.get_imm(inst) }
     }
 
     /// Returns an iterator over the instructions.
@@ -409,16 +525,17 @@ impl<'a> Bytecode<'a> {
         analysis.finish(self);
     }
 
-    /// Returns the immediate value of the given instruction data, if any.
+    /// Returns the immediate value of the given instruction, if any.
     ///
     /// For truncated immediates at EOF, returns the available bytes (which may be shorter than
     /// `imm_len`). Returns `None` only when `imm_len` is 0 or `start` is completely out of bounds.
-    pub(crate) fn get_imm(&self, data: &InstData) -> Option<&[u8]> {
+    pub(crate) fn get_imm(&self, inst: Inst) -> Option<&[u8]> {
+        let data = self.inst(inst);
         let imm_len = data.imm_len() as usize;
         if imm_len == 0 {
             return None;
         }
-        let start = data.pc as usize + 1;
+        let start = self.pc(inst) as usize + 1;
         let end = (start + imm_len).min(self.code.len());
         if start >= end {
             return None;
@@ -426,31 +543,24 @@ impl<'a> Bytecode<'a> {
         Some(&self.code[start..end])
     }
 
-    /// Returns the value of a PUSH instruction, right-padding truncated EOF immediates with zeros
-    /// per EVM spec.
-    pub(crate) fn get_push_value(&self, data: &InstData) -> U256 {
-        match self.get_imm(data) {
-            Some(slice) => {
-                let imm_len = data.imm_len() as usize;
-                if slice.len() == imm_len {
-                    U256::from_be_slice(slice)
-                } else {
-                    let mut padded = [0u8; 32];
-                    padded[..slice.len()].copy_from_slice(slice);
-                    U256::from_be_slice(&padded[..imm_len])
-                }
-            }
-            None => U256::ZERO,
-        }
+    /// Returns the program counter (offset into the original bytecode) of the given instruction.
+    #[inline]
+    pub(crate) fn pc(&self, inst: Inst) -> u32 {
+        self.inst_to_pc[inst]
     }
 
-    /// Returns the first immediate byte, defaulting to `0` if truncated or missing.
-    ///
-    /// This matches upstream `revm-bytecode` legacy analysis which zero-pads incomplete
-    /// trailing immediates.
-    pub(crate) fn get_u8_imm(&self, data: &InstData) -> u8 {
-        let start = data.pc as usize + 1;
-        self.code.get(start).copied().unwrap_or(0)
+    /// Returns the value of a PUSH instruction, right-padding truncated EOF immediates with zeros
+    /// per EVM spec.
+    #[cfg(test)]
+    pub(crate) fn get_push_value(&self, data: &InstData) -> U256 {
+        debug_assert!(matches!(data.opcode, op::PUSH0..=op::PUSH32));
+        data.imm().get(&self.u256_interner.borrow())
+    }
+
+    /// Returns the length of the original bytecode in bytes (for `CODESIZE`).
+    #[inline]
+    pub(crate) fn codesize(&self) -> usize {
+        self.code.len()
     }
 
     /// Returns `true` if the given program counter is a valid jump destination.
@@ -487,11 +597,6 @@ impl<'a> Bytecode<'a> {
         }
     }
 
-    /// Interns a U256 constant, returning its deduplicated index.
-    pub(crate) fn intern_u256(&self, value: U256) -> U256Idx {
-        self.u256_interner.borrow_mut().intern(value)
-    }
-
     /// Returns the multi-target jump table entry for the given instruction, if any.
     pub(crate) fn multi_jump_targets(&self, inst: Inst) -> Option<&[Inst]> {
         self.multi_jump_targets.get(&inst).map(|v| v.as_slice())
@@ -504,8 +609,8 @@ impl<'a> Bytecode<'a> {
     #[allow(dead_code)]
     pub(crate) fn const_operand(&self, inst: Inst, depth: usize) -> Option<U256> {
         let snap = &self.snapshots.inputs[inst];
-        let idx = snap.get(snap.len().checked_sub(1 + depth)?)?.as_const()?;
-        Some(*self.u256_interner.borrow().get(idx))
+        let imm = snap.get(snap.len().checked_sub(1 + depth)?)?.as_const()?;
+        Some(imm.get(&self.u256_interner.borrow()))
     }
 
     /// Returns the known constant output value of the given instruction.
@@ -514,8 +619,8 @@ impl<'a> Bytecode<'a> {
     /// analysis didn't cover this instruction.
     #[allow(dead_code)]
     pub(crate) fn const_output(&self, inst: Inst) -> Option<U256> {
-        let idx = self.snapshots.outputs[inst]?.as_const()?;
-        Some(*self.u256_interner.borrow().get(idx))
+        let imm = self.snapshots.outputs[inst]?.as_const()?;
+        Some(imm.get(&self.u256_interner.borrow()))
     }
 
     /// Logs per-opcode constant-input statistics at trace level.
@@ -680,8 +785,7 @@ impl<'a> Bytecode<'a> {
         let mut buf = String::from("top 5 longest blocks:");
         for (block, len) in &lens {
             let data = &self.cfg.blocks[*block];
-            let first = self.inst(data.insts.start);
-            let _ = write!(buf, "\n  {block} (pc={}, len={len})", first.pc);
+            let _ = write!(buf, "\n  {block} (pc={}, len={len})", self.pc(data.insts.start));
         }
         trace!("{buf}");
     }
@@ -732,16 +836,17 @@ pub(crate) struct InstData {
     ///
     /// This may not be the final/full gas cost of the opcode as it may also have a dynamic cost.
     base_gas: u16,
-    /// Stack inputs and outputs, decoded from the immediate for `DUPN`/`SWAPN`/`EXCHANGE`.
+    /// Stack inputs and outputs.
     stack_io: (u8, u8),
-    /// Instruction-specific data:
-    /// - if the instruction has immediate data, this is a packed offset+length into the bytecode;
-    /// - `JUMP{,I} && STATIC_JUMP in kind`: the jump target, `Instr`;
-    /// - `JUMPDEST`: `1` if the jump destination is reachable, `0` otherwise;
-    /// - otherwise: no meaning.
+    /// Instruction-specific data, populated at parse time and refined by analysis.
+    /// Interpretation depends on `opcode`; access via the typed methods on [`InstData`]:
+    /// - `PUSH0..=PUSH32`, `DUPN | SWAPN | EXCHANGE`: encoded [`U256Imm`].
+    /// - `PC`: program counter of this instruction.
+    /// - `JUMPDEST`: program counter in low 31 bits, reachable flag in high bit
+    ///   ([`InstData::JUMPDEST_REACHABLE`]).
+    /// - `JUMP | JUMPI` with [`InstFlags::STATIC_JUMP`]: target instruction index.
+    /// - otherwise: unused.
     pub(crate) data: u32,
-    /// The program counter, meaning `code[pc]` is this instruction's opcode.
-    pub(crate) pc: u32,
     /// The gas section this instruction belongs to.
     pub(crate) gas_section: GasSection,
     /// The stack section this instruction belongs to.
@@ -788,13 +893,6 @@ impl InstData {
         Opcode { opcode: self.opcode, immediate: None }
     }
 
-    /// Converts this instruction to a raw opcode in the given bytecode.
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn to_op_in<'a>(&self, bytecode: &'a Bytecode<'_>) -> Opcode<'a> {
-        Opcode { opcode: self.opcode, immediate: bytecode.get_imm(self) }
-    }
-
     /// Returns `true` if this instruction is a jump instruction (`JUMP`/`JUMPI`).
     #[inline]
     pub(crate) fn is_jump(&self) -> bool {
@@ -816,8 +914,71 @@ impl InstData {
 
     /// Returns `true` if this instruction is a reachable `JUMPDEST`.
     #[inline]
-    pub(crate) const fn is_reachable_jumpdest(&self, has_dynamic_jumps: bool) -> bool {
-        self.is_jumpdest() && (has_dynamic_jumps || self.data == 1)
+    pub(crate) fn is_reachable_jumpdest(&self, has_dynamic_jumps: bool) -> bool {
+        self.is_jumpdest() && (has_dynamic_jumps || self.is_jumpdest_reachable())
+    }
+
+    /// Returns the [`U256Imm`] of a `PUSH*`/`DUPN`/`SWAPN`/`EXCHANGE` instruction.
+    #[inline]
+    pub(crate) fn imm(&self) -> U256Imm {
+        debug_assert!(matches!(
+            self.opcode,
+            op::PUSH0..=op::PUSH32 | op::DUPN | op::SWAPN | op::EXCHANGE
+        ));
+        U256Imm::from_raw(self.data)
+    }
+
+    /// Returns the inline `u8` immediate of a `DUPN`/`SWAPN`/`EXCHANGE` instruction.
+    #[inline]
+    pub(crate) fn imm_byte(&self) -> u8 {
+        debug_assert!(matches!(self.opcode, op::DUPN | op::SWAPN | op::EXCHANGE));
+        // Parse-time encoding for these opcodes always produces an inline `u8`.
+        self.imm().as_u8().unwrap()
+    }
+
+    /// Returns the program counter stored inline for a `PC` instruction.
+    #[inline]
+    pub(crate) fn pc_imm(&self) -> u32 {
+        debug_assert_eq!(self.opcode, op::PC);
+        self.data
+    }
+
+    /// High bit of `data` set when a `JUMPDEST` is a reachable static jump target.
+    pub(crate) const JUMPDEST_REACHABLE: u32 = 1 << 31;
+
+    /// Returns the program counter of a `JUMPDEST`.
+    #[inline]
+    pub(crate) fn jumpdest_pc(&self) -> u32 {
+        debug_assert_eq!(self.opcode, op::JUMPDEST);
+        self.data & !Self::JUMPDEST_REACHABLE
+    }
+
+    /// Returns `true` if this `JUMPDEST` is the target of a resolved static jump.
+    #[inline]
+    pub(crate) fn is_jumpdest_reachable(&self) -> bool {
+        debug_assert_eq!(self.opcode, op::JUMPDEST);
+        self.data & Self::JUMPDEST_REACHABLE != 0
+    }
+
+    /// Marks this `JUMPDEST` as a reachable static jump target.
+    #[inline]
+    pub(crate) fn set_jumpdest_reachable(&mut self) {
+        debug_assert_eq!(self.opcode, op::JUMPDEST);
+        self.data |= Self::JUMPDEST_REACHABLE;
+    }
+
+    /// Returns the static target of a `JUMP`/`JUMPI` with [`InstFlags::STATIC_JUMP`].
+    #[inline]
+    pub(crate) fn static_jump_target(&self) -> Inst {
+        debug_assert!(self.is_static_jump());
+        Inst::from_usize(self.data as usize)
+    }
+
+    /// Sets the static jump target. Caller must also set [`InstFlags::STATIC_JUMP`].
+    #[inline]
+    pub(crate) fn set_static_jump_target(&mut self, target: Inst) {
+        debug_assert!(self.is_jump());
+        self.data = target.index() as u32;
     }
 
     /// Returns `true` if this instruction starts a new stack section.
@@ -939,22 +1100,25 @@ mod tests {
         // EVM spec: missing bytes are zero, so the value is 0x4200.
         let code = [op::PUSH2, 0x42];
         let bc = Bytecode::test(&code);
-        let data = bc.inst(Inst::from_usize(0));
-        assert_eq!(bc.get_imm(data), Some([0x42].as_slice()));
+        let inst = Inst::from_usize(0);
+        let data = bc.inst(inst);
+        assert_eq!(bc.get_imm(inst), Some([0x42].as_slice()));
         assert_eq!(bc.get_push_value(data), U256::from(0x4200));
 
         // PUSH3 followed by two bytes — truncated at EOF.
         let code = [op::PUSH3, 0xAB, 0xCD];
         let bc = Bytecode::test(&code);
-        let data = bc.inst(Inst::from_usize(0));
-        assert_eq!(bc.get_imm(data), Some([0xAB, 0xCD].as_slice()));
+        let inst = Inst::from_usize(0);
+        let data = bc.inst(inst);
+        assert_eq!(bc.get_imm(inst), Some([0xAB, 0xCD].as_slice()));
         assert_eq!(bc.get_push_value(data), U256::from(0xABCD00));
 
         // PUSH1 with no immediate bytes at all.
         let code = [op::PUSH1];
         let bc = Bytecode::test(&code);
-        let data = bc.inst(Inst::from_usize(0));
-        assert_eq!(bc.get_imm(data), None);
+        let inst = Inst::from_usize(0);
+        let data = bc.inst(inst);
+        assert_eq!(bc.get_imm(inst), None);
         assert_eq!(bc.get_push_value(data), U256::ZERO);
 
         // Non-truncated PUSH2 — full immediate.

--- a/crates/revmc/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc/src/bytecode/passes/block_analysis.rs
@@ -34,8 +34,6 @@ use bitvec::vec::BitVec;
 use either::Either;
 use oxc_index::{IndexVec, index_vec};
 use revm_bytecode::opcode as op;
-#[cfg(test)]
-use revm_primitives::U256;
 use smallvec::SmallVec;
 use std::{cmp::Ordering, collections::VecDeque, ops::Range};
 
@@ -1065,7 +1063,7 @@ impl Bytecode<'_> {
 pub(crate) mod tests {
     use super::*;
     pub(crate) use crate::bytecode::Inst;
-    use revm_primitives::{hardfork::SpecId, hex};
+    pub(crate) use revm_primitives::{U256, hardfork::SpecId, hex};
 
     pub(crate) fn analyze_hex(hex: &str) -> Bytecode<'static> {
         let code = hex::decode(hex.trim()).unwrap();

--- a/crates/revmc/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc/src/bytecode/passes/block_analysis.rs
@@ -13,7 +13,7 @@
 //! ## Abstract domain
 //!
 //! Per-value lattice (ascending order):
-//! - `Const(U256Idx)` — a single known constant.
+//! - `Const(U256Imm)` — a single known constant.
 //! - `ConstSet(ConstSetIdx)` — multiple known constants (interned, sorted, deduplicated).
 //! - `Top` — reachable but unknown.
 //!
@@ -29,11 +29,12 @@
 //! incomplete information, ensuring that only sound jump targets are reported as resolved.
 
 use super::StackSection;
-use crate::bytecode::{Bytecode, Inst, InstFlags, Interner, U256Idx};
+use crate::bytecode::{Bytecode, Inst, InstFlags, Interner, U256Imm};
 use bitvec::vec::BitVec;
 use either::Either;
 use oxc_index::{IndexVec, index_vec};
 use revm_bytecode::opcode as op;
+#[cfg(test)]
 use revm_primitives::U256;
 use smallvec::SmallVec;
 use std::{cmp::Ordering, collections::VecDeque, ops::Range};
@@ -72,7 +73,7 @@ impl Snapshots {
 /// Abstract value on the stack.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum AbsValue {
-    Const(U256Idx),
+    Const(U256Imm),
     /// Multiple known constant values (interned, sorted, deduplicated).
     ConstSet(ConstSetIdx),
     /// Top value (unknown concrete value).
@@ -82,7 +83,7 @@ pub(crate) enum AbsValue {
 
 impl AbsValue {
     /// Returns the single constant if this is `Const`, or `None` otherwise.
-    pub(crate) fn as_const(self) -> Option<U256Idx> {
+    pub(crate) fn as_const(self) -> Option<U256Imm> {
         match self {
             Self::Const(v) => Some(v),
             _ => None,
@@ -92,7 +93,7 @@ impl AbsValue {
 
 /// Constant-set interner used by the abstract interpreter.
 struct ConstSetInterner {
-    interner: Interner<ConstSetIdx, Box<[U256Idx]>>,
+    interner: Interner<ConstSetIdx, Box<[U256Imm]>>,
 }
 
 impl ConstSetInterner {
@@ -101,12 +102,12 @@ impl ConstSetInterner {
     }
 
     /// Returns the constants in the given set.
-    fn get(&self, idx: ConstSetIdx) -> &[U256Idx] {
+    fn get(&self, idx: ConstSetIdx) -> &[U256Imm] {
         self.interner.get(idx)
     }
 
     /// Returns the set of known constants for an abstract value, or `None` if `Top`.
-    fn abs_const_set<'a>(&'a self, val: &'a AbsValue) -> Option<&'a [U256Idx]> {
+    fn abs_const_set<'a>(&'a self, val: &'a AbsValue) -> Option<&'a [U256Imm]> {
         match val {
             AbsValue::Top => None,
             AbsValue::Const(v) => Some(std::slice::from_ref(v)),
@@ -115,7 +116,7 @@ impl ConstSetInterner {
     }
 
     /// Interns a sorted, deduplicated set and returns the corresponding `AbsValue`.
-    fn intern_set(&mut self, set: &[U256Idx]) -> AbsValue {
+    fn intern_set(&mut self, set: &[U256Imm]) -> AbsValue {
         match set.len() {
             0 => unreachable!("empty const set"),
             1 => AbsValue::Const(set[0]),
@@ -132,10 +133,10 @@ impl ConstSetInterner {
                 let a = self.abs_const_set(&a).unwrap();
                 let b = self.abs_const_set(&b).unwrap();
                 // Sorted merge with dedup.
-                let mut merged = SmallVec::<[U256Idx; 8]>::new();
+                let mut merged = SmallVec::<[U256Imm; 8]>::new();
                 let (mut i, mut j) = (0, 0);
                 while i < a.len() && j < b.len() {
-                    match a[i].index().cmp(&b[j].index()) {
+                    match a[i].cmp(&b[j]) {
                         Ordering::Less => {
                             merged.push(a[i]);
                             i += 1;
@@ -384,7 +385,7 @@ impl Bytecode<'_> {
                 })
                 && !is_adjacent
             {
-                trace!(%term_inst, %target_inst, pc = self.insts[term_inst].pc, "resolved non-adjacent jump");
+                trace!(%term_inst, %target_inst, pc = self.pc(term_inst), "resolved non-adjacent jump");
             }
 
             resolved.push((term_inst, target));
@@ -443,11 +444,11 @@ impl Bytecode<'_> {
                             op::JUMPDEST,
                             "block_analysis resolved to non-JUMPDEST"
                         );
-                        self.insts[target_inst].data = 1;
+                        self.insts[target_inst].set_jumpdest_reachable();
                     }
                     if targets.len() == 1 {
                         self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
-                        self.insts[jump_inst].data = targets[0].index() as u32;
+                        self.insts[jump_inst].set_static_jump_target(targets[0]);
                         trace!(%jump_inst, target_inst = %targets[0], "resolved jump");
                     } else {
                         self.insts[jump_inst].flags |=
@@ -592,7 +593,7 @@ impl Bytecode<'_> {
                 }
             } else if term.is_static_jump()
                 && !term.flags.contains(InstFlags::INVALID_JUMP)
-                && let Some(target_block) = resolve(Inst::from_usize(term.data as usize))
+                && let Some(target_block) = resolve(term.static_jump_target())
             {
                 cfg.blocks[target_block].preds.push(bid);
                 cfg.blocks[bid].succs.push(target_block);
@@ -642,7 +643,7 @@ impl Bytecode<'_> {
                 Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
                 None => {
                     // No snapshot means the block was never interpreted (unreachable).
-                    trace!(%jump_inst, pc = self.insts[jump_inst].pc, "jump in unreached block");
+                    trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
                     JumpTarget::Bottom
                 }
             };
@@ -675,8 +676,8 @@ impl Bytecode<'_> {
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
     fn resolve_jump_operand(&self, operand: AbsValue, const_sets: &ConstSetInterner) -> JumpTarget {
         match operand {
-            AbsValue::Const(idx) => {
-                let val = *self.u256_interner.borrow().get(idx);
+            AbsValue::Const(imm) => {
+                let val = imm.get(&self.u256_interner.borrow());
                 match usize::try_from(val) {
                     Ok(target_pc) if self.is_valid_jump(target_pc) => {
                         JumpTarget::single(self.pc_to_inst(target_pc))
@@ -688,8 +689,8 @@ impl Bytecode<'_> {
                 let consts = const_sets.get(set_idx);
                 let interner = self.u256_interner.borrow();
                 let mut targets = SmallVec::new();
-                for &idx in consts {
-                    let val = *interner.get(idx);
+                for &imm in consts {
+                    let val = imm.get(&interner);
                     match usize::try_from(val) {
                         Ok(pc) if self.is_valid_jump(pc) => {
                             targets.push(self.pc_to_inst(pc));
@@ -721,13 +722,13 @@ impl Bytecode<'_> {
         disc_preds: &mut IndexVec<Block, SmallVec<[Block; 4]>>,
     ) {
         let consts = match operand {
-            AbsValue::Const(idx) => Either::Left(std::iter::once(idx)),
+            AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
             AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
             AbsValue::Top => return,
         };
         let interner = self.u256_interner.borrow();
-        for idx in consts {
-            let Ok(target_pc) = usize::try_from(*interner.get(idx)) else { continue };
+        for imm in consts {
+            let Ok(target_pc) = usize::try_from(imm.get(&interner)) else { continue };
             if !self.is_valid_jump(target_pc) {
                 continue;
             }
@@ -918,12 +919,8 @@ impl Bytecode<'_> {
             }
 
             match inst.opcode {
-                op::PUSH0 => {
-                    stack.push(AbsValue::Const(self.intern_u256(U256::ZERO)));
-                }
-                op::PUSH1..=op::PUSH32 => {
-                    let value = self.get_push_value(inst);
-                    stack.push(AbsValue::Const(self.intern_u256(value)));
+                op::PUSH0..=op::PUSH32 => {
+                    stack.push(AbsValue::Const(inst.imm()));
                 }
                 op::POP => {
                     if stack.pop().is_none() {
@@ -946,7 +943,7 @@ impl Bytecode<'_> {
                     stack.swap(len - 1, len - 1 - depth);
                 }
                 op::DUPN => {
-                    let depth = crate::decode_single(self.get_u8_imm(inst));
+                    let depth = crate::decode_single(inst.imm_byte());
                     match depth {
                         Some(n) => {
                             let n = n as usize;
@@ -963,7 +960,7 @@ impl Bytecode<'_> {
                     }
                 }
                 op::SWAPN => {
-                    let depth = crate::decode_single(self.get_u8_imm(inst));
+                    let depth = crate::decode_single(inst.imm_byte());
                     match depth {
                         Some(n) => {
                             let n = n as usize;
@@ -982,7 +979,7 @@ impl Bytecode<'_> {
                     }
                 }
                 op::EXCHANGE => {
-                    let pair = crate::decode_pair(self.get_u8_imm(inst));
+                    let pair = crate::decode_pair(inst.imm_byte());
                     match pair {
                         Some((n, m)) => {
                             let (n, m) = (n as usize, m as usize);
@@ -1403,7 +1400,7 @@ pub(crate) mod tests {
         // The return JUMP at pc=24 should NOT be resolved — the opaque jump at
         // pc=16 can reach fn_entry with any return address. But the current
         // invalidation misses this because fn_entry's block is Known, not Bottom.
-        let return_jump = bytecode.iter_insts().find(|(_, d)| d.pc == 24 && d.is_jump());
+        let return_jump = bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 24 && d.is_jump());
         let (_, rj) = return_jump.unwrap();
         assert!(
             !rj.flags.contains(InstFlags::STATIC_JUMP),
@@ -1526,7 +1523,7 @@ pub(crate) mod tests {
             assert!(
                 !data.flags.contains(InstFlags::INVALID_JUMP),
                 "JUMP inst={inst} pc={} incorrectly marked INVALID_JUMP",
-                data.pc,
+                bytecode.pc(inst),
             );
         }
     }
@@ -1821,7 +1818,7 @@ mod tests_edge_cases {
 
         // The fn return JUMP at pc=32 must NOT be resolved — the trampoline
         // can reach fn_entry with any return address.
-        let return_jump = bytecode.iter_insts().find(|(_, d)| d.pc == 32 && d.is_jump());
+        let return_jump = bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 32 && d.is_jump());
         let (_, rj) = return_jump.unwrap();
         assert!(
             !rj.flags.contains(InstFlags::STATIC_JUMP),
@@ -1870,7 +1867,8 @@ mod tests_edge_cases {
 
         // The JUMPI at pc=27 should NOT be resolved — opaque jump can reach
         // fn_entry with any return address.
-        let return_jumpi = bytecode.iter_insts().find(|(_, d)| d.pc == 27 && d.is_jump());
+        let return_jumpi =
+            bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 27 && d.is_jump());
         let (_, rj) = return_jumpi.unwrap();
         assert!(
             !rj.flags.contains(InstFlags::STATIC_JUMP),
@@ -1923,7 +1921,7 @@ mod tests_edge_cases {
 
         // The return JUMP at pc=30 must NOT be resolved — the opaque caller
         // at pc=25 reaches fn_entry with an arbitrary return address.
-        let return_jump = bytecode.iter_insts().find(|(_, d)| d.pc == 30 && d.is_jump());
+        let return_jump = bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 30 && d.is_jump());
         let (_, rj) = return_jump.unwrap();
         assert!(
             !rj.flags.contains(InstFlags::STATIC_JUMP),
@@ -2107,7 +2105,7 @@ mod tests_edge_cases {
         let lt_inst = bytecode
             .insts
             .iter_enumerated()
-            .find(|(_, inst)| inst.opcode == op::LT && inst.pc == 416)
+            .find(|(i, inst)| inst.opcode == op::LT && bytecode.pc(*i) == 416)
             .map(|(i, _)| i)
             .expect("LT at pc=416 not found");
         assert_eq!(bytecode.const_operand(lt_inst, 0), None);

--- a/crates/revmc/src/bytecode/passes/const_fold.rs
+++ b/crates/revmc/src/bytecode/passes/const_fold.rs
@@ -3,7 +3,7 @@
 use super::block_analysis::AbsValue;
 use crate::{
     InstData,
-    bytecode::{Interner, U256Idx},
+    bytecode::{U256Imm, U256Interner},
 };
 use revm_bytecode::opcode as op;
 use revm_interpreter::instructions::i256::{i256_cmp, i256_div, i256_mod};
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 pub(crate) fn const_fold_gas(
     opcode: u8,
     inputs: &[AbsValue],
-    interner: &Interner<U256Idx, U256, alloy_primitives::map::FbBuildHasher<32>>,
+    interner: &U256Interner,
 ) -> Option<u64> {
     let gas: u64 = match opcode {
         op::CODESIZE | op::PC => 2,
@@ -36,8 +36,8 @@ pub(crate) fn const_fold_gas(
             // EXP: 10 + 50 * byte_size(exponent).
             // The exponent is the second operand (TOS - 1 in EVM stack order, inputs[0] here).
             let exponent_bytes = match inputs.first() {
-                Some(&AbsValue::Const(idx)) => {
-                    let val = interner.get(idx);
+                Some(&AbsValue::Const(imm)) => {
+                    let val = imm.get(interner);
                     (256 - val.leading_zeros()).div_ceil(8)
                 }
                 _ => return None,
@@ -55,21 +55,22 @@ pub(crate) fn const_fold_gas(
 pub(crate) fn try_const_fold(
     inst: &InstData,
     inputs: &[AbsValue],
-    interner: &mut Interner<U256Idx, U256, alloy_primitives::map::FbBuildHasher<32>>,
+    interner: &mut U256Interner,
     code_len: usize,
 ) -> Option<AbsValue> {
     let opcode = inst.opcode;
     let result = match opcode {
         // 0 -> 1
         op::CODESIZE => U256::from(code_len),
-        op::PC => U256::from(inst.pc),
+        // PC stores its program counter inline in `data` at parse time.
+        op::PC => U256::from(inst.pc_imm()),
 
         // 1 -> 1
         op::ISZERO | op::NOT | op::CLZ => {
             let &[AbsValue::Const(ai)] = inputs else {
                 return None;
             };
-            let a = *interner.get(ai);
+            let a = ai.get(interner);
             match opcode {
                 op::ISZERO => U256::from(a.is_zero()),
                 op::NOT => !a,
@@ -103,8 +104,8 @@ pub(crate) fn try_const_fold(
             let &[AbsValue::Const(bi), AbsValue::Const(ai)] = inputs else {
                 return None;
             };
-            let a = *interner.get(ai);
-            let b = *interner.get(bi);
+            let a = ai.get(interner);
+            let b = bi.get(interner);
             match opcode {
                 op::ADD => a.wrapping_add(b),
                 op::MUL => a.wrapping_mul(b),
@@ -176,9 +177,9 @@ pub(crate) fn try_const_fold(
             let &[AbsValue::Const(ci), AbsValue::Const(bi), AbsValue::Const(ai)] = inputs else {
                 return None;
             };
-            let a = *interner.get(ai);
-            let b = *interner.get(bi);
-            let n = *interner.get(ci);
+            let a = ai.get(interner);
+            let b = bi.get(interner);
+            let n = ci.get(interner);
             match opcode {
                 op::ADDMOD => a.add_mod(b, n),
                 op::MULMOD => a.mul_mod(b, n),
@@ -193,7 +194,7 @@ pub(crate) fn try_const_fold(
         "try_const_fold handled opcode {} but const_fold_gas did not",
         inst.opcode,
     );
-    Some(AbsValue::Const(interner.intern(result)))
+    Some(AbsValue::Const(U256Imm::new(result, interner)))
 }
 
 #[cfg(test)]
@@ -569,16 +570,16 @@ mod tests {
     /// must also return `Some`, and vice versa.
     #[test]
     fn const_fold_gas_sync() {
-        let mut interner = crate::bytecode::Interner::new();
-        let one = interner.intern(U256::from(1));
-        let two = interner.intern(U256::from(2));
-        let three = interner.intern(U256::from(3));
+        let mut interner: crate::bytecode::U256Interner = crate::bytecode::Interner::new();
+        let one = U256Imm::new(U256::from(1), &mut interner);
+        let two = U256Imm::new(U256::from(2), &mut interner);
+        let three = U256Imm::new(U256::from(3), &mut interner);
         let c1 = AbsValue::Const(one);
         let c2 = AbsValue::Const(two);
         let c3 = AbsValue::Const(three);
 
         for opcode in 0..=u8::MAX {
-            let inst = crate::InstData { opcode, pc: 0, ..crate::InstData::new(opcode) };
+            let inst = crate::InstData { opcode, ..crate::InstData::new(opcode) };
             let (inp, _) = inst.stack_io();
 
             let inputs: &[AbsValue] = match inp {

--- a/crates/revmc/src/bytecode/passes/const_fold.rs
+++ b/crates/revmc/src/bytecode/passes/const_fold.rs
@@ -62,7 +62,6 @@ pub(crate) fn try_const_fold(
     let result = match opcode {
         // 0 -> 1
         op::CODESIZE => U256::from(code_len),
-        // PC stores its program counter inline in `data` at parse time.
         op::PC => U256::from(inst.pc_imm()),
 
         // 1 -> 1

--- a/crates/revmc/src/bytecode/passes/dead_store_elim.rs
+++ b/crates/revmc/src/bytecode/passes/dead_store_elim.rs
@@ -98,10 +98,11 @@ impl Bytecode<'_> {
                 // Decode immediate for DUPN/SWAPN/EXCHANGE.
                 let imm = match opcode {
                     op::DUPN | op::SWAPN => {
-                        crate::decode_single(self.get_u8_imm(data)).map(DecodedImm::Single)
+                        crate::decode_single(data.imm_byte()).map(DecodedImm::Single)
                     }
-                    op::EXCHANGE => crate::decode_pair(self.get_u8_imm(data))
-                        .map(|(n, m)| DecodedImm::Pair(n, m)),
+                    op::EXCHANGE => {
+                        crate::decode_pair(data.imm_byte()).map(|(n, m)| DecodedImm::Pair(n, m))
+                    }
                     _ => None,
                 };
 

--- a/crates/revmc/src/bytecode/passes/dedup.rs
+++ b/crates/revmc/src/bytecode/passes/dedup.rs
@@ -11,19 +11,25 @@ use oxc_index::IndexVec;
 use revm_bytecode::opcode as op;
 use smallvec::SmallVec;
 
-/// Dedup key: raw bytecode bytes, CFG successor blocks, and terminator jump kind.
+/// Dedup key: instruction-level structural fingerprint, CFG successor blocks, and terminator
+/// jump kind.
 ///
-/// Raw bytes alone are insufficient for JUMP-terminated blocks because block analysis
-/// may resolve byte-identical copies to different static targets depending on incoming
-/// stack context (e.g. different return-address values).
+/// The fingerprint encodes each instruction's opcode plus its (interned) immediate so that
+/// PUSH operations with the same value, and DUPN/SWAPN/EXCHANGE with the same operand, hash
+/// equal across blocks. Raw bytes are intentionally not consulted — all immediate data is
+/// pre-interned at parse time on `InstData`.
 ///
-/// The `is_multi_jump` discriminator prevents MULTI_JUMP dispatcher blocks from
-/// colliding with STATIC_JUMP blocks that happen to share the same bytes and
-/// successor set.
+/// Structural equality alone is insufficient for JUMP-terminated blocks because block
+/// analysis may resolve identical copies to different static targets depending on incoming
+/// stack context (e.g. different return-address values), so successors are part of the key.
+///
+/// The `is_multi_jump` discriminator prevents MULTI_JUMP dispatcher blocks from colliding
+/// with STATIC_JUMP blocks that happen to share the same fingerprint and successor set.
 #[derive(Clone, PartialEq, Eq, Hash)]
-struct DedupKey<'a> {
-    bytes: &'a [u8],
-    /// CFG successors for this block. Two byte-identical blocks are only merged when
+struct DedupKey {
+    /// Instruction fingerprint: per-instruction `(opcode, immediate)` tuples encoded as bytes.
+    fingerprint: SmallVec<[u8; 32]>,
+    /// CFG successors for this block. Two structurally identical blocks are only merged when
     /// their successor sets also match.
     succs: SmallVec<[Block; 4]>,
     /// Whether the block's terminator is a MULTI_JUMP.
@@ -46,14 +52,11 @@ impl<'a> Bytecode<'a> {
     /// and stale once multiple predecessors are merged.
     #[instrument(name = "dedup", level = "debug", skip_all)]
     pub(crate) fn dedup_blocks(&mut self, local_snapshots: &Snapshots) {
-        // Borrow code separately so we can pass `&mut self` to `dedup_blocks_once`.
-        // SAFETY: `self.code` is not modified during dedup.
-        let code: &[u8] = unsafe { &*std::ptr::from_ref::<[u8]>(&self.code) };
-        let mut key_to_blocks = HashMap::<DedupKey<'_>, SmallVec<[Block; 4]>>::default();
+        let mut key_to_blocks = HashMap::<DedupKey, SmallVec<[Block; 4]>>::default();
         let mut total_deduped = 0usize;
         loop {
             key_to_blocks.clear();
-            let deduped = self.dedup_blocks_once(code, &mut key_to_blocks, local_snapshots);
+            let deduped = self.dedup_blocks_once(&mut key_to_blocks, local_snapshots);
             total_deduped += deduped;
             if deduped == 0 {
                 break;
@@ -79,10 +82,9 @@ impl<'a> Bytecode<'a> {
     }
 
     /// Single dedup iteration. Returns the number of blocks deduped.
-    fn dedup_blocks_once<'b>(
+    fn dedup_blocks_once(
         &mut self,
-        code: &'b [u8],
-        key_to_blocks: &mut HashMap<DedupKey<'b>, SmallVec<[Block; 4]>>,
+        key_to_blocks: &mut HashMap<DedupKey, SmallVec<[Block; 4]>>,
         local_snapshots: &Snapshots,
     ) -> usize {
         for bid in self.cfg.blocks.indices() {
@@ -114,14 +116,14 @@ impl<'a> Bytecode<'a> {
                 continue;
             }
 
-            let bytes = block_bytes(code, &self.insts, block);
-            if bytes.is_empty() {
+            let fingerprint = block_fingerprint(&self.insts, block);
+            if fingerprint.is_empty() {
                 continue;
             }
 
             let is_multi_jump = term.flags.contains(InstFlags::MULTI_JUMP);
             key_to_blocks
-                .entry(DedupKey { bytes, succs: block.succs.clone(), is_multi_jump })
+                .entry(DedupKey { fingerprint, succs: block.succs.clone(), is_multi_jump })
                 .or_default()
                 .push(bid);
         }
@@ -155,8 +157,11 @@ impl<'a> Bytecode<'a> {
 
                 // If the duplicate was a reachable JUMPDEST, the canonical must be too
                 // so that sections/gas-checks treat it as a jump target entry point.
-                if self.insts[dup_first_inst].data == 1 {
-                    self.insts[canonical_first_inst].data = 1;
+                if self.insts[dup_first_inst].is_jumpdest()
+                    && self.insts[dup_first_inst].is_jumpdest_reachable()
+                    && self.insts[canonical_first_inst].is_jumpdest()
+                {
+                    self.insts[canonical_first_inst].set_jumpdest_reachable();
                 }
 
                 // Merge multi-jump targets from the duplicate into the canonical block.
@@ -183,9 +188,9 @@ impl<'a> Bytecode<'a> {
                     let is_static = term.is_static_jump()
                         && !term.flags.contains(InstFlags::INVALID_JUMP)
                         && !term.flags.contains(InstFlags::MULTI_JUMP)
-                        && term.data == dup_first_inst.index() as u32;
+                        && term.static_jump_target() == dup_first_inst;
                     if is_static {
-                        self.insts[term_inst].data = canonical_first_inst.index() as u32;
+                        self.insts[term_inst].set_static_jump_target(canonical_first_inst);
                     }
                     // Multi-jump target PCs are not rewritten here: each carries a
                     // distinct PC that callers push as a return address. The targets
@@ -200,17 +205,27 @@ impl<'a> Bytecode<'a> {
     }
 }
 
-/// Returns the raw bytecode bytes for a block's PC range, or empty if the block
-/// extends past the original code (e.g. the synthetic STOP padding).
-fn block_bytes<'a>(
-    code: &'a [u8],
-    insts: &IndexVec<Inst, InstData>,
-    block: &BlockData,
-) -> &'a [u8] {
-    let start_pc = insts[block.insts.start].pc as usize;
-    let end_inst = &insts[block.terminator()];
-    let end_pc = end_inst.pc as usize + 1 + end_inst.imm_len() as usize;
-    code.get(start_pc..end_pc).unwrap_or_default()
+/// Builds a structural fingerprint of a block from instruction data, without consulting the
+/// raw bytecode.
+///
+/// For each non-dead instruction in the block, encodes the opcode followed by the immediate
+/// payload (interned U256Idx for `PUSH*`, immediate byte for `DUPN`/`SWAPN`/`EXCHANGE`).
+/// JUMP/JUMPI carry no immediate and so contribute only their opcode; jump targets are
+/// already factored into the surrounding `DedupKey` via the block's CFG successors.
+fn block_fingerprint(insts: &IndexVec<Inst, InstData>, block: &BlockData) -> SmallVec<[u8; 32]> {
+    let mut buf: SmallVec<[u8; 32]> = SmallVec::new();
+    for i in block.insts() {
+        let data = &insts[i];
+        buf.push(data.opcode);
+        if data.imm_len() > 0 {
+            let mut imm = &data.data.to_ne_bytes()[..];
+            while let [0, rest @ ..] = imm {
+                imm = rest;
+            }
+            buf.extend_from_slice(imm);
+        }
+    }
+    buf
 }
 
 #[cfg(test)]

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -348,8 +348,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         if bytecode.has_dynamic_jumps() {
             fx.bcx.switch_to_block(fx.dynamic_jump_table);
             let jumpdests = bytecode.iter_insts().filter(|(_, data)| data.opcode == op::JUMPDEST);
+            // JUMPDEST stores its pc inline in `data`.
             let targets = jumpdests
-                .map(|(inst, data)| (data.pc as u64, fx.inst_entries[inst]))
+                .map(|(inst, data)| (data.jumpdest_pc() as u64, fx.inst_entries[inst]))
                 .collect::<Vec<_>>();
             let i64_type = fx.bcx.type_int(64);
             let index = fx.bcx.phi(i64_type, &fx.incoming_dynamic_jumps);
@@ -839,7 +840,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::CallDataCopy, &[self.ecx, sp]);
             }
             op::CODESIZE => {
-                let len = self.bcx.iconst(self.word_type, self.bytecode.code.len() as i64);
+                let len = self.bcx.iconst(self.word_type, self.bytecode.codesize() as i64);
                 self.push(len);
             }
             op::CODECOPY => {
@@ -974,7 +975,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let switch_targets: Vec<_> = targets
                             .iter()
                             .map(|&t| {
-                                let pc = self.bytecode.inst(t).pc as u64;
+                                let pc = self.bytecode.inst(t).jumpdest_pc() as u64;
                                 (pc, self.inst_entries[t])
                             })
                             .collect();
@@ -987,7 +988,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                     } else if data.flags.contains(InstFlags::STATIC_JUMP) {
                         // Pop and discard the target; it's always on the stack.
                         self.pop_ignore(1);
-                        let target_inst = Inst::from_usize(data.data as usize);
+                        let target_inst = data.static_jump_target();
                         debug_assert_eq!(
                             *self.bytecode.inst(target_inst),
                             op::JUMPDEST,
@@ -1032,7 +1033,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 goto_return!(no_branch);
             }
             op::PC => {
-                let pc = self.bcx.iconst_256(data.pc);
+                let pc = self.bcx.iconst_256(data.pc_imm());
                 self.push(pc);
             }
             op::MSIZE => {
@@ -1061,29 +1062,23 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::Mcopy, &[self.ecx, sp]);
             }
 
-            op::PUSH0 => {
-                let value = self.bcx.iconst_256(0);
-                self.push(value);
-            }
-            op::PUSH1..=op::PUSH32 => {
-                let value = self.bytecode.get_push_value(data);
-                let value = self.bcx.iconst_256(value);
-                self.push(value);
+            op::PUSH0..=op::PUSH32 => {
+                unreachable!("handled in const_output");
             }
 
             op::DUP1..=op::DUP16 => self.dup((opcode - op::DUP1 + 1) as usize),
-            op::DUPN => match decode_single(self.bytecode.get_u8_imm(data)) {
+            op::DUPN => match decode_single(data.imm_byte()) {
                 Some(n) => self.dup(n as usize),
                 None => goto_return!(fail InstructionResult::InvalidImmediateEncoding),
             },
 
             op::SWAP1..=op::SWAP16 => self.swap((opcode - op::SWAP1 + 1) as usize),
-            op::SWAPN => match decode_single(self.bytecode.get_u8_imm(data)) {
+            op::SWAPN => match decode_single(data.imm_byte()) {
                 Some(n) => self.swap(n as usize),
                 None => goto_return!(fail InstructionResult::InvalidImmediateEncoding),
             },
 
-            op::EXCHANGE => match decode_pair(self.bytecode.get_u8_imm(data)) {
+            op::EXCHANGE => match decode_pair(data.imm_byte()) {
                 Some((n, m)) => self.exchange(n as usize, (m - n) as usize),
                 None => goto_return!(fail InstructionResult::InvalidImmediateEncoding),
             },
@@ -1217,7 +1212,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 let _ = write!(
                     section_dump,
                     "\n  ic{i} pc={} {:?} io={:?} flags={:?} gas={:?} stack={:?}{}{}",
-                    d.pc,
+                    self.bytecode.pc(idx),
                     d.to_op(),
                     d.stack_io(),
                     d.flags,

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -348,7 +348,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         if bytecode.has_dynamic_jumps() {
             fx.bcx.switch_to_block(fx.dynamic_jump_table);
             let jumpdests = bytecode.iter_insts().filter(|(_, data)| data.opcode == op::JUMPDEST);
-            // JUMPDEST stores its pc inline in `data`.
             let targets = jumpdests
                 .map(|(inst, data)| (data.jumpdest_pc() as u64, fx.inst_entries[inst]))
                 .collect::<Vec<_>>();


### PR DESCRIPTION
Pre-computes and stashes all EVM immediates into `InstData::data` at parse time so the rest of the compiler (analysis, dedup, translate) never has to access the raw bytecode again.

PUSH0..=PUSH32 / DUPN / SWAPN / EXCHANGE store a compact `U256Imm` handle: values fitting in a `u8` are inlined directly (tagged via the high bit), larger values are interned in a per-bytecode `U256Interner`. DUPN / SWAPN / EXCHANGE always go through the inline path since their immediate is a single byte.

JUMPDEST stores its program counter in the low 31 bits of `data` with the reachable-jump-target flag packed into the high bit. This removes `InstFlags::REACHABLE_JUMPDEST`, shrinking `InstFlags` back to `u8`. PC mirrors its program counter inline for hot codegen access. JUMP / JUMPI with `STATIC_JUMP` stores the resolved target instruction index.

Per-instruction `pc` was moved to an `inst_to_pc` side-table; `JUMPDEST` and `PC` keep a copy in `data` so jump dispatch and the `PC` opcode read it without an extra indirection.