### PR TITLE
chore(scripts): improve bench.py output and document workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ Use `cargo r -- run --list` to see available benchmark names.
 `./scripts/bench.py` is the unified benchmarking tool. It collects codegen line
 counts, compile times, jump resolution stats, and constant-input statistics.
 
+The script writes its full markdown output to `<dump_dir>/results.md` in
+addition to printing it to stdout. Summary tables hide changes within a noise
+threshold (1% for codegen, 5% for compile times); the `<details>` tables still
+show every change.
+
 ```bash
 ./scripts/bench.py /tmp/bench --diff main                          # codegen + compile time vs main
 ./scripts/bench.py /tmp/bench --diff main usdc_proxy seaport       # specific benchmarks
@@ -101,9 +106,55 @@ counts, compile times, jump resolution stats, and constant-input statistics.
 ./scripts/bench.py /tmp/bench --codegen-lines --jump-resolution    # combine multiple analyses
 ```
 
+## Bench-and-PR workflow
+
+When the user asks to "bench and open pr", "post results to pr", or whenever
+making a perf change that needs benchmark numbers in the PR description:
+
+1. Run `./scripts/bench.py <dump_dir> --diff <base>` (typically `--diff main`).
+2. Build the PR body **in a single bash command** that inlines
+   `<dump_dir>/results.md` VERBATIM. Do NOT reformat, summarize, drop
+   columns, or rewrite the numbers in the tables — `cat` the file as-is.
+3. Add prose explaining what the PR does ABOVE the inlined results, under a
+   `## Benchmarks` (or similar) heading.
+4. Under `## Benchmarks`, ABOVE the inlined `results.md`, write a short
+   textual summary of the headline numbers (e.g. the `**TOTAL**` row diffs
+   from the codegen + compile-time tables, plus any notable per-bench wins
+   or regressions worth calling out). Keep it to a few sentences or a tight
+   bullet list — this is the at-a-glance summary readers see before the
+   tables. The tables themselves stay verbatim.
+5. Update the PR with `gh pr edit <number> --body-file <body.md>`.
+
+Example — write the body file with prose, summary, and verbatim results in
+one shot:
+
+```bash
+{
+  cat <<'EOF'
+Short description of what this PR does and why.
+
+More prose: motivation, design notes, caveats, anything reviewers need.
+
+## Benchmarks
+
+Headline numbers vs `main`: jit size -7.5%, opt.s +2.9%, total compile time
++0.2%. `counter` regresses on opt.s (+26%); `seaport` is roughly flat.
+
+EOF
+  cat /tmp/bench/results.md
+} > /tmp/pr-body.md
+
+gh pr edit 123 --body-file /tmp/pr-body.md
+```
+
+The heredoc holds whatever prose + summary belongs in the PR; `cat results.md`
+appends the benchmark tables exactly as the script produced them.
+
 ## Important
 
-- NEVER summarize benchmark results. Always post the entire, unedited output.
+- NEVER alter or summarize the benchmark tables themselves — always post them
+  verbatim. A short textual summary of the headline numbers ABOVE the tables
+  (under `## Benchmarks`) is required.
 - NEVER delete or modify `./tmp/` — it contains manually generated IR/asm dumps used for comparison.
 - `tmp/dump/` contains dumps from `main`, `tmp/dump2/` contains dumps from the current branch.
   Use these for manual `diff` comparison of LLVM IR and assembly.

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -105,6 +105,9 @@ pub struct EvmCompiler<B: Backend> {
 
     #[debug(skip)]
     remarks: Remarks,
+    /// Function sizes accumulated across all `jit_function`/`write_object` calls
+    /// in the current finalize cycle. Reset by `clear` / `clear_ir`.
+    compiled_sizes: Vec<(String, usize)>,
     finalized: bool,
 }
 
@@ -132,6 +135,7 @@ impl<B: Backend> EvmCompiler<B> {
             dump_unopt_assembly: false,
             compiler_gas_limit: crate::bytecode::DEFAULT_COMPILER_GAS_LIMIT,
             remarks: Remarks::default(),
+            compiled_sizes: Vec::new(),
             finalized: false,
         }
     }
@@ -467,9 +471,9 @@ impl<B: Backend> EvmCompiler<B> {
             self.backend.jit_function(id)?
         };
         debug_assert!(addr != 0);
+        self.record_compiled_sizes();
         if let Some(dump_dir) = &self.dump_dir() {
             self.dump_remarks(dump_dir)?;
-            self.append_jit_remarks(dump_dir);
         }
         Ok(EvmCompilerFn::new(unsafe { std::mem::transmute::<usize, RawEvmCompilerFn>(addr) }))
     }
@@ -520,6 +524,7 @@ impl<B: Backend> EvmCompiler<B> {
     pub fn clear_ir(&mut self) -> Result<()> {
         self.builtins.clear();
         self.remarks.clear();
+        self.compiled_sizes.clear();
         self.finalized = false;
         self.backend.clear_ir()
     }
@@ -535,6 +540,7 @@ impl<B: Backend> EvmCompiler<B> {
     pub unsafe fn clear(&mut self) -> Result<()> {
         self.builtins.clear();
         self.remarks.clear();
+        self.compiled_sizes.clear();
         self.finalized = false;
         unsafe { self.backend.free_all_functions() }
     }
@@ -764,28 +770,33 @@ total:      {total:>11.3?}
             }
         }
 
+        // Cumulative JIT code sizes (across all jit_function calls in this finalize cycle).
+        if !self.compiled_sizes.is_empty() {
+            let total: usize = self.compiled_sizes.iter().map(|(_, s)| *s).sum();
+            writeln!(w)?;
+            writeln!(w, "JIT code sizes (estimated)")?;
+            writeln!(w, "==========================")?;
+            for (name, size) in &self.compiled_sizes {
+                writeln!(w, "{name}: {}", format_bytes(*size))?;
+            }
+            if self.compiled_sizes.len() > 1 {
+                writeln!(w, "total: {}", format_bytes(total))?;
+            }
+        }
+
         w.flush()?;
         Ok(())
     }
 
-    fn append_jit_remarks(&self, dump_dir: &Path) {
-        let sizes = self.backend.function_sizes();
-        if sizes.is_empty() {
-            return;
-        }
-        let remarks_path = dump_dir.join("remarks.txt");
-        let Ok(mut file) = fs::OpenOptions::new().append(true).open(&remarks_path) else {
-            return;
-        };
-        let total: usize = sizes.iter().map(|(_, s)| *s).sum();
-        let _ = writeln!(file);
-        let _ = writeln!(file, "JIT code sizes (estimated)");
-        let _ = writeln!(file, "==========================");
-        for (name, size) in &sizes {
-            let _ = writeln!(file, "{name}: {}", format_bytes(*size));
-        }
-        if sizes.len() > 1 {
-            let _ = writeln!(file, "total: {}", format_bytes(total));
+    /// Pull the latest compiled function sizes from the backend and merge them into
+    /// `compiled_sizes`, deduplicating by name (later entries overwrite earlier ones).
+    fn record_compiled_sizes(&mut self) {
+        for (name, size) in self.backend.function_sizes() {
+            if let Some(slot) = self.compiled_sizes.iter_mut().find(|(n, _)| *n == name) {
+                slot.1 = size;
+            } else {
+                self.compiled_sizes.push((name, size));
+            }
         }
     }
 

--- a/crates/revmc/src/compiler/mod.rs
+++ b/crates/revmc/src/compiler/mod.rs
@@ -468,6 +468,7 @@ impl<B: Backend> EvmCompiler<B> {
         };
         debug_assert!(addr != 0);
         if let Some(dump_dir) = &self.dump_dir() {
+            self.dump_remarks(dump_dir)?;
             self.append_jit_remarks(dump_dir);
         }
         Ok(EvmCompilerFn::new(unsafe { std::mem::transmute::<usize, RawEvmCompilerFn>(addr) }))
@@ -486,7 +487,14 @@ impl<B: Backend> EvmCompiler<B> {
     pub fn write_object<W: io::Write>(&mut self, w: W) -> Result<()> {
         ensure!(self.is_aot(), "cannot write AOT object during JIT compilation");
         self.finalize()?;
-        self.backend.write_object(w)
+        {
+            let _t = self.remarks.time(|r| &r.codegen);
+            self.backend.write_object(w)?;
+        }
+        if let Some(dump_dir) = &self.dump_dir() {
+            self.dump_remarks(dump_dir)?;
+        }
+        Ok(())
     }
 
     /// (JIT) Frees the memory associated with a single function.
@@ -631,10 +639,6 @@ impl<B: Backend> EvmCompiler<B> {
 
         let finalize_total = &self.remarks.finalize_total;
         finalize_total.set(finalize_total.get() + finalize_start.elapsed());
-
-        if let Some(dump_dir) = &dump_dir {
-            self.dump_remarks(dump_dir)?;
-        }
 
         Ok(())
     }

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -33,6 +33,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from abc import ABC, abstractmethod
 
@@ -128,6 +129,21 @@ def fmt_pct(base: float | int, current: float | int) -> str:
     return f"{pct:+.1f}%{_indicator(pct)}"
 
 
+def is_noise(base: float | int, current: float | int, noise: float) -> bool:
+    """Whether the relative change is within ``noise`` percent (or unmeasurable)."""
+    if base == 0:
+        return current == 0
+    pct = (current - base) / base * 100
+    return abs(pct) <= noise
+
+
+# Noise thresholds for skipping rows in the always-visible summary tables.
+# Rows where every change is within the threshold are dropped from the summary
+# (the `<details>` table still shows them).
+NOISE_CODEGEN = 1.0  # codegen line counts, jit size, spills, reloads
+NOISE_TIME = 5.0  # compile times (high run-to-run variance)
+
+
 def fmt_dur(s: float) -> str:
     if s == 0:
         return "-"
@@ -200,6 +216,24 @@ def parse_duration(s: str) -> float:
     if not m:
         return 0.0
     return float(m.group(1)) * DURATION_UNITS[m.group(2)]
+
+
+class _Tee:
+    """Write to multiple streams simultaneously (e.g. stdout + a file)."""
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, s):
+        for st in self._streams:
+            st.write(s)
+
+    def flush(self):
+        for st in self._streams:
+            st.flush()
+
+    def isatty(self):
+        return False
 
 
 def print_table(headers: list[str], rows: list[list], right_cols: int | None = None):
@@ -376,21 +410,22 @@ class CodegenLines(Analysis):
         print("### Codegen statistics\n")
         headers = ["benchmark", "unopt.ll", "opt.ll", "opt.s", "jit size", "i256 loads", "i256 stores", "spills", "reloads"]
         table = []
+        n = NOISE_CODEGEN
         for name, counts, jit_size, i256_ld, i256_st, spills, reloads in cur_rows:
             base_counts, base_jit, base_ld, base_st, base_sp, base_rl = base_map.get(
                 name, ([0] * 3, 0, 0, 0, 0, 0)
             )
-            table.append(
-                [
-                    name,
-                    *[fmt_pct(b, c) for b, c in zip(base_counts, counts)],
-                    fmt_pct(base_jit, jit_size),
-                    fmt_pct(base_ld, i256_ld),
-                    fmt_pct(base_st, i256_st),
-                    fmt_pct(base_sp, spills),
-                    fmt_pct(base_rl, reloads),
-                ]
-            )
+            pairs = [
+                *list(zip(base_counts, counts)),
+                (base_jit, jit_size),
+                (base_ld, i256_ld),
+                (base_st, i256_st),
+                (base_sp, spills),
+                (base_rl, reloads),
+            ]
+            if all(is_noise(b, c, n) for b, c in pairs):
+                continue
+            table.append([name, *[fmt_pct(b, c) for b, c in pairs]])
         table.append(
             [
                 "**TOTAL**",
@@ -497,11 +532,13 @@ class CompileTime(Analysis):
         # Summary table.
         print("### Compile times\n")
         table = []
+        n = NOISE_TIME
         for name, cur in cur_rows:
             base = base_map.get(name, {})
-            table.append(
-                [name, *[fmt_pct(base.get(p, 0.0), cur.get(p, 0.0)) for p in keys]]
-            )
+            pairs = [(base.get(p, 0.0), cur.get(p, 0.0)) for p in keys]
+            if all(is_noise(b, c, n) for b, c in pairs):
+                continue
+            table.append([name, *[fmt_pct(b, c) for b, c in pairs]])
         table.append(
             [
                 "**TOTAL**",
@@ -1009,18 +1046,31 @@ def main():
                 if os.path.isdir(base_worktree):
                     shutil.rmtree(base_worktree)
 
-            for a in analyses:
-                a.report_diff(
-                    benches,
-                    args.dump_dir,
-                    outputs,
-                    base_dump,
-                    base_outputs,
-                    args.base_rev,
-                )
+            def run_reports():
+                for a in analyses:
+                    a.report_diff(
+                        benches,
+                        args.dump_dir,
+                        outputs,
+                        base_dump,
+                        base_outputs,
+                        args.base_rev,
+                    )
         else:
-            for a in analyses:
-                a.report(benches, args.dump_dir, outputs)
+            def run_reports():
+                for a in analyses:
+                    a.report(benches, args.dump_dir, outputs)
+
+        os.makedirs(args.dump_dir, exist_ok=True)
+        results_path = os.path.join(args.dump_dir, "results.md")
+        with open(results_path, "w") as md:
+            old_stdout = sys.stdout
+            sys.stdout = _Tee(old_stdout, md)
+            try:
+                run_reports()
+            finally:
+                sys.stdout = old_stdout
+        eprint(f"Wrote {results_path}")
 
     finally:
         shutil.rmtree(link_dir, ignore_errors=True)


### PR DESCRIPTION
Two related changes to the bench tooling:

1. \`scripts/bench.py\` now writes its full markdown report to \`<dump_dir>/results.md\` in addition to printing it to stdout, so the file can be inlined verbatim into PR descriptions.
2. The always-visible summary tables skip rows where every change is within a noise threshold (1% for codegen, 5% for compile times). The \`<details>\` tables still show every value, so nothing is lost — the summary just highlights the rows that actually moved.

\`AGENTS.md\` documents the bench-and-PR workflow: build the PR body in a single bash command that pipes a heredoc of prose + headline summary followed by \`cat <dump_dir>/results.md\`, then \`gh pr edit --body-file\`. Tables stay verbatim; a short textual summary above them is required.