### PR TITLE
refactor: inline assert_spec_id builtin

### DIFF
--- a/crates/revmc-builtins/src/ir.rs
+++ b/crates/revmc-builtins/src/ir.rs
@@ -164,7 +164,6 @@ macro_rules! builtins {
                 const _1_0: u8 = POP;
 
                 const PANIC: u8 = _0_0;
-                const ASSERTSPECID: u8 = _0_0;
 
                 const KECCAK256CC: u8 = _0_1;
 
@@ -247,7 +246,6 @@ builtins! {
     }
 
     Panic          = #[Cold] #[NoReturn] __revmc_builtin_panic(ptr, usize) None,
-    AssertSpecId   = __revmc_builtin_assert_spec_id(@[ecx] ptr, u8) None,
 
     Div            = __revmc_builtin_div(@[sp] ptr) None,
     SDiv           = __revmc_builtin_sdiv(@[sp] ptr) None,

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -116,14 +116,6 @@ pub unsafe extern "C" fn __revmc_builtin_panic(data: *const u8, len: usize) -> !
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __revmc_builtin_assert_spec_id(ecx: &EvmContext<'_>, expected: SpecId) {
-    assert_eq!(
-        ecx.spec_id, expected,
-        "revmc panic: runtime spec_id does not match compilation spec_id"
-    );
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn __revmc_builtin_div(rev![a, b]: &mut [EvmWord; 2]) {
     let divisor = b.to_u256();
     *b = if divisor.is_zero() { U256::ZERO } else { a.to_u256().wrapping_div(divisor) }.into();

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -322,8 +322,21 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Add debug assertions for the parameters.
         if config.debug_assertions {
             // Assert that the runtime spec_id matches the compilation spec_id.
-            let compiled_spec = fx.bcx.iconst(fx.i8_type, bytecode.spec_id as i64);
-            let _ = fx.call_builtin(Builtin::AssertSpecId, &[ecx, compiled_spec]);
+            let spec_id_field = get_field(
+                &mut fx.bcx,
+                ecx,
+                mem::offset_of!(EvmContext<'_>, spec_id),
+                "ecx.spec_id.addr",
+            );
+            let runtime_spec = fx.bcx.load(fx.i8_type, spec_id_field, "ecx.spec_id");
+            let cmp = fx.bcx.icmp_imm(IntCC::Equal, runtime_spec, bytecode.spec_id as i64);
+            let current_block = fx.bcx.current_block().unwrap();
+            let fail_block = fx.bcx.create_block_after(current_block, "spec_id.mismatch");
+            let ok_block = fx.bcx.create_block_after(fail_block, "spec_id.ok");
+            fx.bcx.brif_cold(cmp, ok_block, fail_block, true);
+            fx.bcx.switch_to_block(fail_block);
+            fx.call_panic("revmc panic: runtime spec_id does not match compilation spec_id");
+            fx.bcx.switch_to_block(ok_block);
         }
 
         // The bytecode is guaranteed to have at least one instruction.


### PR DESCRIPTION
Removes the `AssertSpecId` builtin and inlines the runtime spec_id check directly in `translate.rs` as IR. The check loads `ecx.spec_id`, compares it against the compilation `spec_id`, and on mismatch branches to a cold panic block.