### PR TITLE
perf(context): store Gas inline in EvmContext

### DIFF
--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -904,7 +904,7 @@ pub unsafe extern "C" fn __revmc_builtin_do_return(
         Bytes::new()
     };
     *ecx.next_action =
-        Some(InterpreterAction::Return(InterpreterResult { output, gas: *ecx.gas, result }));
+        Some(InterpreterAction::Return(InterpreterResult { output, gas: ecx.gas, result }));
     Err(result.into())
 }
 
@@ -924,7 +924,7 @@ pub unsafe extern "C" fn __revmc_builtin_do_return_cc(
         Bytes::new()
     };
     *ecx.next_action =
-        Some(InterpreterAction::Return(InterpreterResult { output, gas: *ecx.gas, result }));
+        Some(InterpreterAction::Return(InterpreterResult { output, gas: ecx.gas, result }));
     Err(result.into())
 }
 

--- a/crates/revmc-builtins/src/utils.rs
+++ b/crates/revmc-builtins/src/utils.rs
@@ -83,8 +83,14 @@ pub(crate) unsafe fn read_words_rev<'a, const N: usize>(sp: *mut EvmWord) -> &'a
 
 #[inline]
 pub(crate) fn ensure_memory(ecx: &mut EvmContext<'_>, offset: usize, len: usize) -> BuiltinResult {
-    revm_interpreter::interpreter::resize_memory(ecx.gas, ecx.memory, &ecx.gas_params, offset, len)
-        .map_err(Into::into)
+    revm_interpreter::interpreter::resize_memory(
+        &mut ecx.gas,
+        ecx.memory,
+        &ecx.gas_params,
+        offset,
+        len,
+    )
+    .map_err(Into::into)
 }
 
 pub(crate) unsafe fn copy_operation(

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -88,8 +88,14 @@ pub struct EvmContext<'a> {
     pub memory: &'a mut SharedMemory,
     /// Input information (target address, caller, input data, call value).
     pub input: &'a mut InputsImpl,
-    /// The gas.
-    pub gas: &'a mut Gas,
+    /// The gas, stored inline to avoid an extra pointer indirection in JIT code.
+    ///
+    /// Mirrors the interpreter's [`Gas`] for the duration of the JIT call, and is written back
+    /// to [`Self::gas_ptr`] on exit.
+    pub gas: Gas,
+    /// Pointer to the original interpreter [`Gas`], used to write [`Self::gas`] back on exit.
+    #[doc(hidden)]
+    pub gas_ptr: &'a mut Gas,
     /// The host.
     pub host: &'a mut dyn Host,
     /// The return action.
@@ -129,9 +135,9 @@ const _: () = {
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
-    assert!(offset_of!(EvmContext<'_>, spec_id) == 65);
-    assert!(offset_of!(EvmContext<'_>, resume_at) == 72);
-    assert!(offset_of!(EvmContext<'_>, calldatasize) == 112);
+    assert!(offset_of!(EvmContext<'_>, spec_id) == 121);
+    assert!(offset_of!(EvmContext<'_>, resume_at) == 128);
+    assert!(offset_of!(EvmContext<'_>, calldatasize) == 168);
 };
 
 impl fmt::Debug for EvmContext<'_> {
@@ -158,10 +164,12 @@ impl<'a> EvmContext<'a> {
         let bytecode = interpreter.bytecode.bytecode_slice() as *const [u8];
         let calldatasize = interpreter.input.input.len();
         let gas_params = host.gas_params().clone();
+        let gas_ptr: *mut Gas = &mut interpreter.gas;
         let this = Self {
             memory: &mut interpreter.memory,
             input: &mut interpreter.input,
-            gas: &mut interpreter.gas,
+            gas: interpreter.gas,
+            gas_ptr,
             host,
             next_action: &mut interpreter.bytecode.action,
             return_data: interpreter.return_data.buffer(),
@@ -306,6 +314,13 @@ impl EvmCompilerFn {
         // as it might have overflown inside of the function.
         if result == InstructionResult::OutOfGas {
             ecx.gas.spend_all();
+        }
+
+        // Write the inline gas back to the original interpreter `Gas` location.
+        // SAFETY: `gas_ptr` was constructed from `&mut interpreter.gas` and stays valid
+        // for the lifetime of `interpreter`.
+        unsafe {
+            *ecx.gas_ptr = ecx.gas;
         }
 
         let return_data_is_empty = ecx.return_data.is_empty();

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -164,12 +164,11 @@ impl<'a> EvmContext<'a> {
         let bytecode = interpreter.bytecode.bytecode_slice() as *const [u8];
         let calldatasize = interpreter.input.input.len();
         let gas_params = host.gas_params().clone();
-        let gas_ptr: *mut Gas = &mut interpreter.gas;
         let this = Self {
             memory: &mut interpreter.memory,
             input: &mut interpreter.input,
             gas: interpreter.gas,
-            gas_ptr,
+            gas_ptr: &mut interpreter.gas,
             host,
             next_action: &mut interpreter.bytecode.action,
             return_data: interpreter.return_data.buffer(),
@@ -317,11 +316,7 @@ impl EvmCompilerFn {
         }
 
         // Write the inline gas back to the original interpreter `Gas` location.
-        // SAFETY: `gas_ptr` was constructed from `&mut interpreter.gas` and stays valid
-        // for the lifetime of `interpreter`.
-        unsafe {
-            *ecx.gas_ptr = ecx.gas;
-        }
+        *ecx.gas_ptr = ecx.gas;
 
         let return_data_is_empty = ecx.return_data.is_empty();
 

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -90,9 +90,6 @@ pub struct EvmContext<'a> {
     pub input: &'a mut InputsImpl,
     /// The gas.
     pub gas: Gas,
-    /// Pointer to the original interpreter gas, written back on exit.
-    #[doc(hidden)]
-    pub gas_ptr: &'a mut Gas,
     /// The host.
     pub host: &'a mut dyn Host,
     /// The return action.
@@ -132,9 +129,9 @@ const _: () = {
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
-    assert!(offset_of!(EvmContext<'_>, spec_id) == 121);
-    assert!(offset_of!(EvmContext<'_>, resume_at) == 128);
-    assert!(offset_of!(EvmContext<'_>, calldatasize) == 168);
+    assert!(offset_of!(EvmContext<'_>, spec_id) == 113);
+    assert!(offset_of!(EvmContext<'_>, resume_at) == 120);
+    assert!(offset_of!(EvmContext<'_>, calldatasize) == 160);
 };
 
 impl fmt::Debug for EvmContext<'_> {
@@ -165,7 +162,6 @@ impl<'a> EvmContext<'a> {
             memory: &mut interpreter.memory,
             input: &mut interpreter.input,
             gas: interpreter.gas,
-            gas_ptr: &mut interpreter.gas,
             host,
             next_action: &mut interpreter.bytecode.action,
             return_data: interpreter.return_data.buffer(),
@@ -312,9 +308,8 @@ impl EvmCompilerFn {
             ecx.gas.spend_all();
         }
 
-        *ecx.gas_ptr = ecx.gas;
-
         let return_data_is_empty = ecx.return_data.is_empty();
+        interpreter.gas = ecx.gas;
 
         if return_data_is_empty {
             interpreter.return_data.0.clear();

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -88,12 +88,9 @@ pub struct EvmContext<'a> {
     pub memory: &'a mut SharedMemory,
     /// Input information (target address, caller, input data, call value).
     pub input: &'a mut InputsImpl,
-    /// The gas, stored inline to avoid an extra pointer indirection in JIT code.
-    ///
-    /// Mirrors the interpreter's [`Gas`] for the duration of the JIT call, and is written back
-    /// to [`Self::gas_ptr`] on exit.
+    /// The gas.
     pub gas: Gas,
-    /// Pointer to the original interpreter [`Gas`], used to write [`Self::gas`] back on exit.
+    /// Pointer to the original interpreter gas, written back on exit.
     #[doc(hidden)]
     pub gas_ptr: &'a mut Gas,
     /// The host.
@@ -315,7 +312,6 @@ impl EvmCompilerFn {
             ecx.gas.spend_all();
         }
 
-        // Write the inline gas back to the original interpreter `Gas` location.
         *ecx.gas_ptr = ecx.gas;
 
         let return_data_is_empty = ecx.return_data.is_empty();

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -1024,7 +1024,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.push(msize);
             }
             op::GAS => {
-                let remaining = self.load_gas_remaining();
+                let addr = self.gas_remaining_addr();
+                let i64_type = self.bcx.type_int(64);
+                let remaining = self.bcx.load(i64_type, addr, "gas.remaining");
                 let remaining = self.bcx.zext(self.word_type, remaining);
                 self.push(remaining);
             }
@@ -1402,19 +1404,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         self.bcx.gep(self.i8_type, self.ecx, &[offset], "gas.remaining.addr")
     }
 
-    /// Loads the gas used.
-    fn load_gas_remaining(&mut self) -> B::Value {
-        let addr = self.gas_remaining_addr();
-        let i64_type = self.bcx.type_int(64);
-        self.bcx.load(i64_type, addr, "gas.remaining")
-    }
-
-    /// Stores the gas used.
-    fn store_gas_remaining(&mut self, value: B::Value) {
-        let addr = self.gas_remaining_addr();
-        self.bcx.store(value, addr);
-    }
-
     /// Saves the local `stack_len` to `stack_len_arg`.
     fn save_stack_len(&mut self) {
         let len = self.stack_len.load(&mut self.bcx, "stack_len");
@@ -1621,9 +1610,11 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
         // Modified from `Gas::record_cost`.
         // This can overflow the gas counters, which has to be adjusted for after the call.
-        let gas_remaining = self.load_gas_remaining();
+        let addr = self.gas_remaining_addr();
+        let i64_type = self.bcx.type_int(64);
+        let gas_remaining = self.bcx.load(i64_type, addr, "gas.remaining");
         let (res, overflow) = self.bcx.usub_overflow(gas_remaining, cost);
-        self.store_gas_remaining(res);
+        self.bcx.store(res, addr);
         self.build_check(overflow, InstructionResult::OutOfGas);
     }
 

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -76,8 +76,6 @@ pub(super) struct FunctionCx<'a, B: Backend> {
     /// The stack argument pointer. Only used when `local_stack` is enabled and the stack needs
     /// to be copied in/out at entry/exit boundaries.
     sp_arg: Option<B::Value>,
-    /// The amount of gas remaining. `i64`. See `Gas`.
-    gas_remaining: Pointer<B::Builder<'a>>,
     /// The EVM context. Opaque pointer, only passed to builtins.
     ecx: B::Value,
     /// Stack length before the current instruction.
@@ -210,7 +208,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // Get common types.
         let isize_type = bcx.type_ptr_sized_int();
         let i8_type = bcx.type_int(8);
-        let i64_type = bcx.type_int(64);
         let word_type = bcx.type_int(256);
         let address_type = bcx.type_int(160);
 
@@ -232,15 +229,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let stack_len_arg = bcx.fn_param(2);
         // This is initialized later in `post_entry_block`.
         let stack_len = bcx.new_stack_slot(isize_type, "len.addr");
-
-        // `gas` is stored inline in `ecx`; the gas pointer is just `ecx + offset_of(gas)`.
-        let gas_ptr =
-            get_field(&mut bcx, ecx, mem::offset_of!(EvmContext<'_>, gas), "ecx.gas.addr");
-        let gas_remaining = {
-            let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, tracker.remaining) as i64);
-            let name = "gas.remaining.addr";
-            Pointer::new_address(i64_type, bcx.gep(i8_type, gas_ptr, &[offset], name))
-        };
 
         // Create all instruction entry blocks.
         // Dead-code instructions map to `unreachable_block`, except when block deduplication
@@ -283,7 +271,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             stack_len,
             stack,
             sp_arg: local_stack.then_some(sp_arg),
-            gas_remaining,
             ecx,
             len_before: zero,
             len_offset: 0,
@@ -1408,14 +1395,24 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         self.bcx.store(value, slot);
     }
 
+    fn gas_remaining_addr(&mut self) -> B::Value {
+        const OFFSET: usize =
+            mem::offset_of!(EvmContext<'_>, gas) + mem::offset_of!(pf::Gas, tracker.remaining);
+        let offset = self.bcx.iconst(self.isize_type, OFFSET as i64);
+        self.bcx.gep(self.i8_type, self.ecx, &[offset], "gas.remaining.addr")
+    }
+
     /// Loads the gas used.
     fn load_gas_remaining(&mut self) -> B::Value {
-        self.gas_remaining.load(&mut self.bcx, "gas.remaining")
+        let addr = self.gas_remaining_addr();
+        let i64_type = self.bcx.type_int(64);
+        self.bcx.load(i64_type, addr, "gas.remaining")
     }
 
     /// Stores the gas used.
     fn store_gas_remaining(&mut self, value: B::Value) {
-        self.gas_remaining.store(&mut self.bcx, value);
+        let addr = self.gas_remaining_addr();
+        self.bcx.store(value, addr);
     }
 
     /// Saves the local `stack_len` to `stack_len_arg`.

--- a/crates/revmc/src/compiler/translate/mod.rs
+++ b/crates/revmc/src/compiler/translate/mod.rs
@@ -233,13 +233,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // This is initialized later in `post_entry_block`.
         let stack_len = bcx.new_stack_slot(isize_type, "len.addr");
 
-        // Load gas pointer from ecx.
-        let ptr_type = bcx.type_ptr();
-        let gas_ptr = {
-            let gas_field =
-                get_field(&mut bcx, ecx, mem::offset_of!(EvmContext<'_>, gas), "ecx.gas.addr");
-            bcx.load(ptr_type, gas_field, "ecx.gas")
-        };
+        // `gas` is stored inline in `ecx`; the gas pointer is just `ecx + offset_of(gas)`.
+        let gas_ptr =
+            get_field(&mut bcx, ecx, mem::offset_of!(EvmContext<'_>, gas), "ecx.gas.addr");
         let gas_remaining = {
             let offset = bcx.iconst(i64_type, mem::offset_of!(pf::Gas, tracker.remaining) as i64);
             let name = "gas.remaining.addr";

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -497,7 +497,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
             ecx.is_static = true;
         }
         if gas_limit != DEF_GAS_LIMIT {
-            *ecx.gas = Gas::new(gas_limit);
+            ecx.gas = Gas::new(gas_limit);
         }
         if let Some(modify_ecx) = modify_ecx {
             modify_ecx(ecx);


### PR DESCRIPTION
Stores `Gas` directly inside `EvmContext` instead of holding `&mut Gas`. The
JIT computes the `gas.remaining` address as `ecx + offset_of(gas) +
offset_of(remaining)` on each gas pay, removing the entry-block pointer load
and the cached `gas_remaining` pointer in `FunctionCx`. On exit,
`call_with_interpreter_inner` writes `ecx.gas` back to `interpreter.gas`.

## Benchmarks

Headline diffs vs `main`: jit size -0.7%, opt.s -0.8%, opt.ll +1.0%, unopt.ll
+2.1%, total compile time -4.4%. Largest opt.s wins are `usdc_proxy` (-6.5%)
and `univ2_router` (-2.8%); `airdrop` regresses (+1.9%). Compile-time wins are
broad (e.g. `push0_proxy` -16.8%, `bswap64_opt` -12.0%, `curve_stableswap`
-10.1%).

### Codegen statistics

| benchmark          |    unopt.ll |      opt.ll |       opt.s |    jit size |   i256 loads |   i256 stores |      spills |      reloads |
|:-------------------|------------:|------------:|------------:|------------:|-------------:|--------------:|------------:|-------------:|
| fibonacci-calldata |     +1.4% 🔴 |     -1.7% 🟢 |     -1.0% 🟢 |     -0.9% 🟢 |            = |             = |    -16.7% 🟢 |     -14.3% 🟢 |
| factorial          |     +1.5% 🔴 |     -1.7% 🟢 |     -0.9% 🟢 |     -0.7% 🟢 |            = |             = |    -11.1% 🟢 |     -10.0% 🟢 |
| counter            |     +3.1% 🔴 |     -0.6% 🟢 |     -0.7% 🟢 |     -1.8% 🟢 |            = |             = |           - |            - |
| snailtracer        |     +2.4% 🔴 |     +0.1% 🔴 |     +0.8% 🔴 |     +2.0% 🔴 |            = |       +0.3% 🔴 |     +2.3% 🔴 |     -17.0% 🟢 |
| weth               |     +1.5% 🔴 |     +0.7% 🔴 |     -2.5% 🟢 |     -2.6% 🟢 |            = |             = |           = |     -46.0% 🟢 |
| hash_10k           |     +2.0% 🔴 |     -0.6% 🟢 |     -1.8% 🟢 |     -2.3% 🟢 |            = |             = |   -100.0% 🟢 |    -100.0% 🟢 |
| erc20_transfer     |     +2.2% 🔴 |     +0.1% 🔴 |     +0.1% 🔴 |     +0.2% 🔴 |      +0.3% 🔴 |       +0.7% 🔴 |           = |      -2.0% 🟢 |
| push0_proxy        |     +1.7% 🔴 |     -0.5% 🟢 |     -1.2% 🟢 |     -0.9% 🟢 |            = |             = |           - |            - |
| usdc_proxy         |     +2.6% 🔴 |     -0.5% 🟢 |     -6.5% 🟢 |     -6.8% 🟢 |            = |             = |    +12.0% 🔴 |     -75.2% 🟢 |
| fiat_token         |     +1.6% 🔴 |     +0.8% 🔴 |     -2.1% 🟢 |     -2.5% 🟢 |      +0.1% 🔴 |       +0.1% 🔴 |     -5.5% 🟢 |     -41.0% 🟢 |
| uniswap_v2_pair    |     +1.9% 🔴 |     +1.0% 🔴 |     -0.2% 🟢 |     -0.3% 🟢 |            = |       +0.1% 🔴 |     -8.7% 🟢 |     -18.7% 🟢 |
| univ2_router       |     +1.6% 🔴 |     +1.6% 🔴 |     -2.8% 🟢 |     -2.2% 🟢 |            = |       +0.4% 🔴 |     +7.5% 🔴 |     -29.6% 🟢 |
| seaport            |     +2.1% 🔴 |     +1.3% 🔴 |     -0.6% 🟢 |     -1.0% 🟢 |      +0.1% 🔴 |       +0.3% 🔴 |     +0.5% 🔴 |      -2.3% 🟢 |
| airdrop            |     +2.3% 🔴 |     -0.7% 🟢 |     +1.9% 🔴 |     +2.3% 🔴 |            = |       +0.2% 🔴 |     +1.6% 🔴 |     +39.5% 🔴 |
| bswap64            |     +1.7% 🔴 |     -0.4% 🟢 |           = |     +0.2% 🔴 |            = |             = |           - |            - |
| bswap64_opt        |     +1.4% 🔴 |     -0.4% 🟢 |     +0.1% 🔴 |     -0.7% 🟢 |            = |             = |   -100.0% 🟢 |    -100.0% 🟢 |
| eip4788            |     +2.6% 🔴 |     -0.9% 🟢 |     -1.0% 🟢 |     -2.6% 🟢 |            = |             = |    -50.0% 🟢 |     -50.0% 🟢 |
| eip2935            |     +2.1% 🔴 |     -1.0% 🟢 |     -1.5% 🟢 |     -1.9% 🟢 |            = |             = |   -100.0% 🟢 |    -100.0% 🟢 |
| curve_stableswap   |     +2.5% 🔴 |     -0.4% 🟢 |     -1.5% 🟢 |     -0.9% 🟢 |            = |       +1.0% 🔴 |    +11.8% 🔴 |     +87.0% 🔴 |
| onchain_lm_v2      |     +2.5% 🔴 |     +0.2% 🔴 |     +0.1% 🔴 |     +0.2% 🔴 |      +0.1% 🔴 |       +0.5% 🔴 |           = |            = |
| burntpix           |     +2.5% 🔴 |     +2.0% 🔴 |     -0.4% 🟢 |     -0.1% 🟢 |      +0.1% 🔴 |       +0.2% 🔴 |     +2.9% 🔴 |      -8.4% 🟢 |
| **TOTAL**          | **+2.1% 🔴** | **+1.0% 🔴** | **-0.8% 🟢** | **-0.7% 🟢** |  **+0.1% 🔴** |   **+0.3% 🔴** | **-0.6% 🟢** | **-12.9% 🟢** |

<details><summary>Full details</summary>

| benchmark          |   unopt.ll (main) |        diff |   opt.ll (main) |        diff |   opt.s (main) |        diff |   jit size (main) |        diff |   i256 loads (main) |    diff |   i256 stores (main) |    diff |   spills (main) |    diff |   reloads (main) |      diff |
|:-------------------|------------------:|------------:|----------------:|------------:|---------------:|------------:|------------------:|------------:|--------------------:|--------:|---------------------:|--------:|----------------:|--------:|-----------------:|----------:|
| fibonacci-calldata |               349 |     +1.4% 🔴 |             115 |     -1.7% 🟢 |            309 |     -1.0% 🟢 |             448 B |     -0.9% 🟢 |                   2 |       = |                    3 |       = |               6 |      -1 |                7 |        -1 |
| factorial          |               341 |     +1.5% 🔴 |             117 |     -1.7% 🟢 |            351 |     -0.9% 🟢 |             605 B |     -0.7% 🟢 |                   2 |       = |                    3 |       = |               9 |      -1 |               10 |        -1 |
| counter            |               998 |     +3.1% 🔴 |             345 |     -0.6% 🟢 |            545 |     -0.7% 🟢 |             892 B |     -1.8% 🟢 |                   8 |       = |                    7 |       = |               0 |       = |                0 |         = |
| snailtracer        |             53833 |     +2.4% 🔴 |           22359 |     +0.1% 🔴 |          38613 |     +0.8% 🔴 |         110.1 KiB |     +2.0% 🔴 |                1379 |       = |                 2239 |      +6 |              87 |      +2 |             1015 |      -173 |
| weth               |             12659 |     +1.5% 🔴 |            3915 |     +0.7% 🔴 |           6258 |     -2.5% 🟢 |          20.0 KiB |     -2.6% 🟢 |                 256 |       = |                  342 |       = |              81 |       = |              150 |       -69 |
| hash_10k           |               954 |     +2.0% 🔴 |             310 |     -0.6% 🟢 |            567 |     -1.8% 🟢 |           1.4 KiB |     -2.3% 🟢 |                  16 |       = |                   23 |       = |               2 |      -2 |                3 |        -3 |
| erc20_transfer     |             13733 |     +2.2% 🔴 |            5429 |     +0.1% 🔴 |           9268 |     +0.1% 🔴 |          25.7 KiB |     +0.2% 🔴 |                 307 |      +1 |                  438 |      +3 |              15 |       = |              148 |        -3 |
| push0_proxy        |               363 |     +1.7% 🔴 |             187 |     -0.5% 🟢 |            343 |     -1.2% 🟢 |             633 B |     -0.9% 🟢 |                   1 |       = |                   15 |       = |               0 |       = |                0 |         = |
| usdc_proxy         |              7066 |     +2.6% 🔴 |            2832 |     -0.5% 🟢 |           4625 |     -6.5% 🟢 |          12.5 KiB |     -6.8% 🟢 |                 105 |       = |                  196 |       = |              25 |      +3 |              105 |       -79 |
| fiat_token         |             76996 |     +1.6% 🔴 |           25325 |     +0.8% 🔴 |          42554 |     -2.1% 🟢 |         149.1 KiB |     -2.5% 🟢 |                1771 |      +2 |                 2606 |      +3 |             510 |     -28 |              796 |      -326 |
| uniswap_v2_pair    |             43407 |     +1.9% 🔴 |           14885 |     +1.0% 🔴 |          24495 |     -0.2% 🟢 |          80.4 KiB |     -0.3% 🟢 |                 888 |       = |                 1371 |      +2 |             334 |     -29 |              536 |      -100 |
| univ2_router       |             81214 |     +1.6% 🔴 |           27417 |     +1.6% 🔴 |          45226 |     -2.8% 🟢 |         167.2 KiB |     -2.2% 🟢 |                2009 |       = |                 2902 |     +12 |             280 |     +21 |             1214 |      -359 |
| seaport            |            129667 |     +2.1% 🔴 |           53753 |     +1.3% 🔴 |          89167 |     -0.6% 🟢 |         296.9 KiB |     -1.0% 🟢 |                4226 |      +6 |                 5250 |     +18 |            1033 |      +5 |             2639 |       -60 |
| airdrop            |             26985 |     +2.3% 🔴 |           10270 |     -0.7% 🟢 |          15949 |     +1.9% 🔴 |          47.5 KiB |     +2.3% 🔴 |                 560 |       = |                  839 |      +2 |             249 |      +4 |              314 |      +124 |
| bswap64            |              2097 |     +1.7% 🔴 |             539 |     -0.4% 🟢 |           1013 |           = |           2.6 KiB |     +0.2% 🔴 |                  29 |       = |                   53 |       = |               0 |       = |                0 |         = |
| bswap64_opt        |              1790 |     +1.4% 🔴 |             492 |     -0.4% 🟢 |            910 |     +0.1% 🔴 |           2.6 KiB |     -0.7% 🟢 |                  33 |       = |                   51 |       = |               1 |      -1 |                1 |        -1 |
| eip4788            |               585 |     +2.6% 🔴 |             226 |     -0.9% 🟢 |            413 |     -1.0% 🟢 |             735 B |     -2.6% 🟢 |                   8 |       = |                    9 |       = |               2 |      -1 |                2 |        -1 |
| eip2935            |               532 |     +2.1% 🔴 |             198 |     -1.0% 🟢 |            404 |     -1.5% 🟢 |             753 B |     -1.9% 🟢 |                   6 |       = |                    5 |       = |               2 |      -2 |                2 |        -2 |
| curve_stableswap   |             17078 |     +2.5% 🔴 |            7486 |     -0.4% 🟢 |          10737 |     -1.5% 🟢 |          27.8 KiB |     -0.9% 🟢 |                 403 |       = |                  608 |      +6 |              17 |      +2 |               46 |       +40 |
| onchain_lm_v2      |             55934 |     +2.5% 🔴 |           22603 |     +0.2% 🔴 |          34872 |     +0.1% 🔴 |         101.1 KiB |     +0.2% 🔴 |                1352 |      +1 |                 1683 |      +9 |              75 |       = |              169 |         = |
| burntpix           |            125243 |     +2.5% 🔴 |           45520 |     +2.0% 🔴 |          66773 |     -0.4% 🟢 |         217.7 KiB |     -0.1% 🟢 |                2702 |      +2 |                 3657 |      +7 |             314 |      +9 |             1981 |      -167 |
| **TOTAL**          |        **651824** | **+2.1% 🔴** |      **244323** | **+1.0% 🔴** |     **393392** | **-0.8% 🟢** |       **1.2 MiB** | **-0.7% 🟢** |           **16063** | **+12** |            **22300** | **+68** |        **3042** | **-19** |         **9138** | **-1181** |

</details>

### Compile times

| benchmark          |       total |       parse |   translate |    finalize |     codegen |
|:-------------------|------------:|------------:|------------:|------------:|------------:|
| fibonacci-calldata |    -10.1% 🟢 |     -7.7% 🟢 |     -6.8% 🟢 |     -5.3% 🟢 |    -18.6% 🟢 |
| factorial          |     +1.1% 🔴 |     -1.3% 🟢 |     +8.9% 🔴 |     +4.0% 🔴 |     -5.1% 🟢 |
| counter            |     -6.4% 🟢 |     -5.5% 🟢 |     +1.3% 🔴 |     -7.4% 🟢 |     -5.7% 🟢 |
| snailtracer        |     -3.9% 🟢 |     -0.5% 🟢 |     -4.9% 🟢 |     -5.7% 🟢 |     -2.0% 🟢 |
| weth               |     -4.7% 🟢 |     +1.5% 🔴 |     +4.6% 🔴 |     -4.5% 🟢 |     -5.8% 🟢 |
| hash_10k           |     -9.8% 🟢 |    -10.5% 🟢 |     -9.9% 🟢 |    -10.2% 🟢 |     -8.9% 🟢 |
| erc20_transfer     |     -5.5% 🟢 |     +5.1% 🔴 |     -2.8% 🟢 |     -5.8% 🟢 |     -5.4% 🟢 |
| push0_proxy        |    -16.8% 🟢 |    -17.1% 🟢 |    -16.0% 🟢 |    -19.1% 🟢 |    -12.7% 🟢 |
| usdc_proxy         |     -8.1% 🟢 |     -4.0% 🟢 |     -6.9% 🟢 |     -9.6% 🟢 |     -5.8% 🟢 |
| fiat_token         |     -8.0% 🟢 |     +0.3% 🔴 |     +2.8% 🔴 |     -4.3% 🟢 |    -13.4% 🟢 |
| univ2_router       |     -3.5% 🟢 |     +2.8% 🔴 |     +6.7% 🔴 |     -1.6% 🟢 |     -6.6% 🟢 |
| seaport            |     -6.0% 🟢 |     +2.2% 🔴 |     -2.9% 🟢 |     -5.0% 🟢 |     -8.0% 🟢 |
| bswap64            |     -1.1% 🟢 |     -1.1% 🟢 |     +6.5% 🔴 |     -3.6% 🟢 |     +2.4% 🔴 |
| bswap64_opt        |    -12.0% 🟢 |     -2.9% 🟢 |     -3.2% 🟢 |    -14.4% 🟢 |     -9.0% 🟢 |
| eip4788            |           = |     -7.7% 🟢 |     +0.7% 🔴 |     +7.0% 🔴 |    -10.8% 🟢 |
| eip2935            |     -7.6% 🟢 |     -9.5% 🟢 |    -14.2% 🟢 |     -5.9% 🟢 |     -9.3% 🟢 |
| curve_stableswap   |    -10.1% 🟢 |     -1.2% 🟢 |     +2.9% 🔴 |     -8.2% 🟢 |    -14.3% 🟢 |
| onchain_lm_v2      |     -5.2% 🟢 |     +2.5% 🔴 |     +5.4% 🔴 |     -5.8% 🟢 |     -4.7% 🟢 |
| **TOTAL**          | **-4.4% 🟢** | **+0.2% 🔴** | **+0.5% 🔴** | **-4.2% 🟢** | **-4.7% 🟢** |

<details><summary>Full compile times</summary>

| benchmark          |        main |      branch |        diff |   parse (main) |   parse (branch) |   parse diff |   translate (main) |   translate (branch) |   translate diff |   finalize (main) |   finalize (branch) |   finalize diff |   codegen (main) |   codegen (branch) |   codegen diff |
|:-------------------|------------:|------------:|------------:|---------------:|-----------------:|-------------:|-------------------:|---------------------:|-----------------:|------------------:|--------------------:|----------------:|-----------------:|-------------------:|---------------:|
| fibonacci-calldata |      10.4ms |      9.37ms |    -10.1% 🟢 |        172.4µs |          159.1µs |      -7.7% 🟢 |            513.4µs |              478.4µs |          -6.8% 🟢 |            6.07ms |              5.75ms |         -5.3% 🟢 |           3.65ms |             2.97ms |       -18.6% 🟢 |
| factorial          |      10.8ms |      10.9ms |     +1.1% 🔴 |        169.3µs |          167.1µs |      -1.3% 🟢 |            481.5µs |              524.5µs |          +8.9% 🔴 |            6.46ms |              6.72ms |         +4.0% 🔴 |           3.65ms |             3.46ms |        -5.1% 🟢 |
| counter            |      14.1ms |      13.2ms |     -6.4% 🟢 |        309.3µs |          292.2µs |      -5.5% 🟢 |            634.6µs |              642.8µs |          +1.3% 🔴 |            8.54ms |              7.91ms |         -7.4% 🟢 |           4.62ms |             4.36ms |        -5.7% 🟢 |
| snailtracer        |      4.467s |      4.292s |     -3.9% 🟢 |         7.81ms |           7.78ms |      -0.5% 🟢 |             10.8ms |               10.2ms |          -4.9% 🟢 |            2.304s |              2.172s |         -5.7% 🟢 |           2.145s |             2.102s |        -2.0% 🟢 |
| weth               |     171.1ms |     163.0ms |     -4.7% 🟢 |         2.07ms |           2.10ms |      +1.5% 🔴 |             2.82ms |               2.95ms |          +4.6% 🔴 |           101.6ms |              97.0ms |         -4.5% 🟢 |           64.6ms |             60.9ms |        -5.8% 🟢 |
| hash_10k           |      16.0ms |      14.4ms |     -9.8% 🟢 |        297.7µs |          266.4µs |     -10.5% 🟢 |            660.5µs |              595.0µs |          -9.9% 🟢 |            9.80ms |              8.80ms |        -10.2% 🟢 |           5.25ms |             4.79ms |        -8.9% 🟢 |
| erc20_transfer     |     325.9ms |     307.9ms |     -5.5% 🟢 |         2.23ms |           2.35ms |      +5.1% 🔴 |             3.19ms |               3.10ms |          -2.8% 🟢 |           191.7ms |             180.6ms |         -5.8% 🟢 |          128.8ms |            121.8ms |        -5.4% 🟢 |
| push0_proxy        |      11.5ms |      9.56ms |    -16.8% 🟢 |        183.4µs |          152.1µs |     -17.1% 🟢 |            557.9µs |              468.7µs |         -16.0% 🟢 |            7.00ms |              5.66ms |        -19.1% 🟢 |           3.75ms |             3.27ms |       -12.7% 🟢 |
| usdc_proxy         |     113.3ms |     104.1ms |     -8.1% 🟢 |         1.36ms |           1.31ms |      -4.0% 🟢 |             1.94ms |               1.80ms |          -6.9% 🟢 |            70.0ms |              63.3ms |         -9.6% 🟢 |           40.0ms |             37.7ms |        -5.8% 🟢 |
| fiat_token         |      1.392s |      1.281s |     -8.0% 🟢 |         13.9ms |           13.9ms |      +0.3% 🔴 |             14.2ms |               14.6ms |          +2.8% 🔴 |           786.8ms |             752.5ms |         -4.3% 🟢 |          577.4ms |            500.0ms |       -13.4% 🟢 |
| uniswap_v2_pair    |     691.3ms |     678.9ms |     -1.8% 🟢 |         7.15ms |           7.04ms |      -1.6% 🟢 |             10.1ms |               9.79ms |          -3.1% 🟢 |           396.2ms |             397.9ms |         +0.4% 🔴 |          277.8ms |            264.2ms |        -4.9% 🟢 |
| univ2_router       |      1.527s |      1.473s |     -3.5% 🟢 |         13.8ms |           14.2ms |      +2.8% 🔴 |             16.7ms |               17.8ms |          +6.7% 🔴 |           887.7ms |             873.1ms |         -1.6% 🟢 |          608.6ms |            568.2ms |        -6.6% 🟢 |
| seaport            |      3.651s |      3.431s |     -6.0% 🟢 |         19.5ms |           19.9ms |      +2.2% 🔴 |             26.6ms |               25.8ms |          -2.9% 🟢 |            2.263s |              2.150s |         -5.0% 🟢 |           1.342s |             1.235s |        -8.0% 🟢 |
| airdrop            |     516.6ms |     507.9ms |     -1.7% 🟢 |         4.60ms |           4.70ms |      +2.2% 🔴 |             6.07ms |               5.97ms |          -1.7% 🟢 |           341.9ms |             333.3ms |         -2.5% 🟢 |          164.0ms |            164.0ms |              = |
| bswap64            |      23.8ms |      23.5ms |     -1.1% 🟢 |        488.7µs |          483.2µs |      -1.1% 🟢 |            879.5µs |              936.3µs |          +6.5% 🔴 |            14.1ms |              13.6ms |         -3.6% 🟢 |           8.28ms |             8.47ms |        +2.4% 🔴 |
| bswap64_opt        |      24.3ms |      21.4ms |    -12.0% 🟢 |        423.3µs |          411.0µs |      -2.9% 🟢 |            820.0µs |              794.0µs |          -3.2% 🟢 |            14.9ms |              12.8ms |        -14.4% 🟢 |           8.17ms |             7.43ms |        -9.0% 🟢 |
| eip4788            |      12.4ms |      12.4ms |           = |        244.5µs |          225.8µs |      -7.7% 🟢 |            612.0µs |              616.2µs |          +0.7% 🔴 |            7.05ms |              7.54ms |         +7.0% 🔴 |           4.47ms |             3.99ms |       -10.8% 🟢 |
| eip2935            |      11.5ms |      10.7ms |     -7.6% 🟢 |        208.3µs |          188.4µs |      -9.5% 🟢 |            608.6µs |              521.9µs |         -14.2% 🟢 |            6.72ms |              6.33ms |         -5.9% 🟢 |           4.00ms |             3.63ms |        -9.3% 🟢 |
| curve_stableswap   |     344.7ms |     309.9ms |    -10.1% 🟢 |         2.91ms |           2.88ms |      -1.2% 🟢 |             3.69ms |               3.80ms |          +2.9% 🔴 |           220.8ms |             202.7ms |         -8.2% 🟢 |          117.3ms |            100.5ms |       -14.3% 🟢 |
| onchain_lm_v2      |      2.784s |      2.639s |     -5.2% 🟢 |         8.63ms |           8.84ms |      +2.5% 🔴 |             11.8ms |               12.4ms |          +5.4% 🔴 |            1.461s |              1.376s |         -5.8% 🟢 |           1.302s |             1.241s |        -4.7% 🟢 |
| burntpix           |      3.366s |      3.319s |     -1.4% 🟢 |         20.4ms |           19.7ms |      -3.4% 🟢 |             25.3ms |               25.7ms |          +1.7% 🔴 |            2.151s |              2.105s |         -2.1% 🟢 |           1.170s |             1.169s |        -0.1% 🟢 |
| **TOTAL**          | **19.485s** | **18.632s** | **-4.4% 🟢** |    **106.9ms** |      **107.1ms** |  **+0.2% 🔴** |        **138.8ms** |          **139.5ms** |      **+0.5% 🔴** |       **11.256s** |         **10.779s** |     **-4.2% 🟢** |       **7.983s** |         **7.607s** |    **-4.7% 🟢** |

</details>

