### PR TITLE
perf: avoid copying call input

### DIFF
--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -807,9 +807,11 @@ pub unsafe extern "C" fn __revmc_builtin_call(
     let input = if in_len != 0 {
         let in_offset = try_into_usize!(in_offset);
         ensure_memory(ecx, in_offset, in_len)?;
-        Bytes::copy_from_slice(&ecx.memory.slice(in_offset..in_offset + in_len))
+        let local_offset = ecx.memory.local_memory_offset();
+        let start = in_offset.saturating_add(local_offset);
+        start..start.saturating_add(in_len)
     } else {
-        Bytes::new()
+        usize::MAX..usize::MAX
     };
 
     let out_len = try_into_usize!(out_len);
@@ -859,7 +861,7 @@ pub unsafe extern "C" fn __revmc_builtin_call(
 
     *ecx.next_action = Some(InterpreterAction::NewFrame(revm_interpreter::FrameInput::Call(
         Box::new(CallInputs {
-            input: CallInput::Bytes(input),
+            input: CallInput::SharedBuffer(input),
             return_memory_offset: out_offset..out_offset + out_len,
             gas_limit,
             bytecode_address: to,

--- a/crates/revmc/src/tests/runner.rs
+++ b/crates/revmc/src/tests/runner.rs
@@ -718,9 +718,9 @@ fn assert_actions(actual: &InterpreterAction, expected: &InterpreterAction) {
             assert_eq!(actual_call.value, expected_call.value, "value mismatch");
             assert_eq!(actual_call.scheme, expected_call.scheme, "scheme mismatch");
             assert_eq!(actual_call.is_static, expected_call.is_static, "is_static mismatch");
-            // Note: We don't compare `input` directly as JIT uses Bytes, interpreter may use
-            // SharedBuffer Note: We don't compare `known_bytecode` as JIT doesn't
-            // preload
+            // Note: We don't compare `input` directly as it may use different shared-memory
+            // ranges.
+            // Note: We don't compare `known_bytecode` as JIT doesn't preload.
         }
         (
             InterpreterAction::NewFrame(FrameInput::Create(actual_create)),


### PR DESCRIPTION
Use `CallInput::SharedBuffer` for `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL` from compiled code, matching upstream revm's interpreter path. This avoids copying call input memory into a new `Bytes` allocation and instead passes the shared-memory range adjusted by the current local memory offset.

Validated with `cargo fmt --all`, `cargo cl -p revmc-builtins`, and `cargo nextest run -p revmc resume_at_call`.
