### PR TITLE
fix(builtins): call host.log before on_log callback

### DIFF
--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -692,10 +692,10 @@ pub unsafe extern "C" fn __revmc_builtin_log(
         address: ecx.input.target_address,
         data: LogData::new(topics, data).expect("too many topics"),
     };
+    ecx.host.log(log.clone());
     if let Some(on_log) = &mut ecx.on_log {
         on_log(&log);
     }
-    ecx.host.log(log);
     Ok(())
 }
 

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -692,9 +692,11 @@ pub unsafe extern "C" fn __revmc_builtin_log(
         address: ecx.input.target_address,
         data: LogData::new(topics, data).expect("too many topics"),
     };
-    ecx.host.log(log.clone());
     if let Some(on_log) = &mut ecx.on_log {
+        ecx.host.log(log.clone());
         on_log(&log);
+    } else {
+        ecx.host.log(log);
     }
     Ok(())
 }


### PR DESCRIPTION
fix(builtins): call host.log before on_log callback

Emit the log through Host before optional on_log hooks so observers run after state is updated, matching interpreter ordering.