### PR TITLE
fix(compiler): route all errors through failure

### DIFF
--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -336,8 +336,8 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 .collect::<Vec<_>>();
             let i64_type = fx.bcx.type_int(64);
             let index = fx.bcx.phi(i64_type, &fx.incoming_dynamic_jumps);
-            fx.add_invalid_jump();
-            fx.bcx.switch(index, return_block, &targets, true);
+            let invalid_jump = fx.add_invalid_jump();
+            fx.bcx.switch(index, invalid_jump, &targets, true);
         } else {
             // No dynamic jumps.
             debug_assert!(fx.incoming_dynamic_jumps.is_empty());
@@ -937,7 +937,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         debug_assert_eq!(*data, op::JUMPI);
                         // The jump target is invalid, but we still need to pop it.
                         self.pop_ignore(1);
-                        self.return_block.unwrap()
+                        self.add_invalid_jump()
                     } else if data.flags.contains(InstFlags::MULTI_JUMP) {
                         let target_value = self.pop();
                         let targets = self.bytecode.multi_jump_targets(inst).unwrap();
@@ -961,9 +961,8 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                                 (pc, self.inst_entries[t])
                             })
                             .collect();
-                        self.add_invalid_jump();
-                        let return_block = self.return_block.unwrap();
-                        self.bcx.switch(target_value, return_block, &switch_targets, true);
+                        let invalid_jump = self.add_invalid_jump();
+                        self.bcx.switch(target_value, invalid_jump, &switch_targets, true);
 
                         self.inst_entries[inst] = self.bcx.current_block().unwrap();
                         goto_return!(no_branch);
@@ -1000,9 +999,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         self.materialize_live_stack();
                         let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
                         let next = self.inst_entries[inst + 1];
-                        if target == self.return_block.unwrap() {
-                            self.add_invalid_jump();
-                        }
                         self.bcx.brif(cond, target, next);
                     } else {
                         // Flush virtual values before leaving the section.
@@ -1692,18 +1688,27 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let current_block = self.current_block();
         let target = self.create_block_after(current_block, "contd");
 
-        let return_block = if let Some(return_block) = self.return_block {
+        let exit_block = if is_failure {
+            if let Some(failure_block) = self.failure_block {
+                self.incoming_failures.push((ret, current_block));
+                failure_block
+            } else {
+                self.create_block_after(target, "failure")
+            }
+        } else if let Some(return_block) = self.return_block {
             self.incoming_returns.push((ret, current_block));
             return_block
         } else {
             self.create_block_after(target, "return")
         };
-        let then_block = if is_failure { return_block } else { target };
-        let else_block = if is_failure { target } else { return_block };
+        let then_block = if is_failure { exit_block } else { target };
+        let else_block = if is_failure { target } else { exit_block };
         self.bcx.brif_cold(cond, then_block, else_block, is_failure);
 
-        if self.return_block.is_none() {
-            self.bcx.switch_to_block(return_block);
+        if (is_failure && self.failure_block.is_none())
+            || (!is_failure && self.return_block.is_none())
+        {
+            self.bcx.switch_to_block(exit_block);
             self.bcx.ret(&[ret]);
         }
 
@@ -1754,11 +1759,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         }
     }
 
-    fn add_invalid_jump(&mut self) {
-        self.incoming_returns.push((
+    fn add_invalid_jump(&mut self) -> B::BasicBlock {
+        let block = self.failure_block.unwrap();
+        self.incoming_failures.push((
             self.bcx.iconst(self.i8_type, InstructionResult::InvalidJump as i64),
             self.bcx.current_block().unwrap(),
         ));
+        block
     }
 
     /// Build a call to the panic builtin.


### PR DESCRIPTION
Routes compiler errors through the failure path so generated execution handles them consistently.

## Benchmarks

Headline numbers vs `main`: jit size is unchanged, opt.ll is +0.1%, opt.s is +1.6%, and total compile time is +6.2%. The largest codegen movement is `burntpix` opt.s at +23.4% while its jit size improves by -1.2%; compile-time changes are mostly in finalize (+6.6%) and codegen (+5.8%).

### Codegen statistics

| benchmark          |   unopt.ll |      opt.ll |       opt.s |   jit size |   i256 loads |   i256 stores |      spills |     reloads |
|:-------------------|-----------:|------------:|------------:|-----------:|-------------:|--------------:|------------:|------------:|
| fibonacci-calldata |    +2.0% 🔴 |           = |           = |          = |            = |             = |           = |           = |
| factorial          |    +2.0% 🔴 |           = |           = |          = |            = |             = |           = |           = |
| weth               |    +0.1% 🔴 |           = |     +0.2% 🔴 |    +0.4% 🔴 |            = |             = |    +21.0% 🔴 |           = |
| push0_proxy        |    +1.9% 🔴 |           = |           = |          = |            = |             = |           - |           - |
| uniswap_v2_pair    |          = |           = |     -0.1% 🟢 |    -0.1% 🟢 |            = |             = |     -2.0% 🟢 |           = |
| eip4788            |    +1.2% 🔴 |           = |           = |          = |            = |             = |           = |           = |
| eip2935            |    +1.3% 🔴 |           = |           = |          = |            = |             = |           - |           - |
| burntpix           |          = |     +0.5% 🔴 |    +23.4% 🔴 |    -1.2% 🟢 |            = |             = |     +2.5% 🔴 |     -0.8% 🟢 |
| 0x184e2e0d92…      |          = |           = |     -0.2% 🟢 |    -0.1% 🟢 |            = |             = |     -1.5% 🟢 |           = |
| 0xfc5900eac5…      |          = |     +0.2% 🔴 |     -1.0% 🟢 |    +0.3% 🔴 |            = |             = |     -0.5% 🟢 |     -5.9% 🟢 |
| **TOTAL**          |      **=** | **+0.1% 🔴** | **+1.6% 🔴** |      **=** |        **=** |         **=** | **-0.1% 🟢** | **-0.2% 🟢** |

<details><summary>Full details</summary>

| benchmark          |   unopt.ll (main) |    diff |   opt.ll (main) |        diff |   opt.s (main) |        diff |   jit size (main) |    diff |   i256 loads (main) |   diff |   i256 stores (main) |   diff |   spills (main) |   diff |   reloads (main) |    diff |
|:-------------------|------------------:|--------:|----------------:|------------:|---------------:|------------:|------------------:|--------:|--------------------:|-------:|---------------------:|-------:|----------------:|-------:|-----------------:|--------:|
| fibonacci-calldata |               350 | +2.0% 🔴 |             113 |           = |            306 |           = |             444 B |       = |                   2 |      = |                    3 |      = |               5 |      = |                6 |       = |
| factorial          |               342 | +2.0% 🔴 |             115 |           = |            348 |           = |             601 B |       = |                   2 |      = |                    3 |      = |               8 |      = |                9 |       = |
| counter            |              1012 | +0.7% 🔴 |             343 |           = |            541 |           = |             876 B |       = |                   8 |      = |                    7 |      = |               0 |      = |                0 |       = |
| snailtracer        |             54481 |       = |           22389 |           = |          38914 |           = |         112.3 KiB |       = |                1379 |      = |                 2245 |      = |              89 |      = |              842 |       = |
| weth               |             12752 | +0.1% 🔴 |            3941 |           = |           6103 |     +0.2% 🔴 |          19.5 KiB | +0.4% 🔴 |                 256 |      = |                  342 |      = |              81 |    +17 |               81 |       = |
| hash_10k           |               962 | +0.7% 🔴 |             308 |           = |            557 |           = |           1.4 KiB |       = |                  16 |      = |                   23 |      = |               0 |      = |                0 |       = |
| erc20_transfer     |             13882 | +0.1% 🔴 |            5436 |           = |           9274 |           = |          25.7 KiB |       = |                 308 |      = |                  441 |      = |              15 |      = |              145 |       = |
| push0_proxy        |               365 | +1.9% 🔴 |             186 |           = |            339 |           = |             627 B |       = |                   1 |      = |                   15 |      = |               0 |      = |                0 |       = |
| usdc_proxy         |              7156 | +0.1% 🔴 |            2817 |           = |           4324 |           = |          11.6 KiB |       = |                 105 |      = |                  196 |      = |              28 |      = |               26 |       = |
| fiat_token         |             77618 |       = |           25535 |           = |          41646 |           = |         145.3 KiB |       = |                1773 |      = |                 2609 |      = |             482 |      = |              470 |       = |
| uniswap_v2_pair    |             43816 |       = |           15031 |           = |          24437 |     -0.1% 🟢 |          80.1 KiB | -0.1% 🟢 |                 888 |      = |                 1373 |      = |             305 |     -6 |              436 |       = |
| univ2_router       |             81869 |       = |           27854 |           = |          43965 |           = |         163.5 KiB |       = |                2009 |      = |                 2914 |      = |             301 |      = |              855 |       = |
| seaport            |            131058 |       = |           54467 |           = |          88619 |           = |         294.1 KiB |       = |                4232 |      = |                 5268 |      = |            1038 |     -3 |             2579 |       = |
| airdrop            |             27290 |       = |           10202 |           = |          16259 |           = |          48.6 KiB |       = |                 560 |      = |                  841 |      = |             253 |      = |              438 |       = |
| bswap64            |              2113 | +0.3% 🔴 |             537 |           = |           1013 |           = |           2.6 KiB |       = |                  29 |      = |                   53 |      = |               0 |      = |                0 |       = |
| bswap64_opt        |              1801 | +0.4% 🔴 |             490 |           = |            911 |           = |           2.5 KiB |       = |                  33 |      = |                   51 |      = |               0 |      = |                0 |       = |
| eip4788            |               591 | +1.2% 🔴 |             224 |           = |            409 |           = |             716 B |       = |                   8 |      = |                    9 |      = |               1 |      = |                1 |       = |
| eip2935            |               536 | +1.3% 🔴 |             196 |           = |            398 |           = |             739 B |       = |                   6 |      = |                    5 |      = |               0 |      = |                0 |       = |
| curve_stableswap   |             17291 |       = |            7457 |           = |          10575 |           = |          27.5 KiB |       = |                 403 |      = |                  614 |      = |              19 |      = |               86 |       = |
| onchain_lm_v2      |             56639 |       = |           22641 |           = |          34901 |           = |         101.3 KiB |       = |                1353 |      = |                 1692 |      = |              75 |      = |              169 |       = |
| burntpix           |            126792 |       = |           46434 |     +0.5% 🔴 |          66476 |    +23.4% 🔴 |         217.4 KiB | -1.2% 🟢 |                2704 |      = |                 3664 |      = |             323 |     +8 |             1814 |     -14 |
| 0x184e2e0d92…      |            133705 |       = |           40694 |           = |          73307 |     -0.2% 🟢 |         242.7 KiB | -0.1% 🟢 |                2987 |      = |                 4492 |      = |            1691 |    -26 |             1269 |       = |
| 0x26f3fa5857…      |            137619 |       = |           37949 |           = |          73939 |           = |         307.9 KiB | +0.1% 🔴 |                3594 |      = |                 5343 |      = |            1077 |      = |             1990 |       = |
| 0x7497bfab49…      |            138129 |       = |           38236 |           = |          73484 |           = |         299.9 KiB | -0.1% 🟢 |                3614 |      = |                 5337 |      = |             675 |      = |             1796 |       = |
| 0x8819f74c38…      |            146859 |       = |           44338 |     -0.1% 🟢 |          81581 |     +0.3% 🔴 |         320.0 KiB |       = |                3910 |      = |                 5108 |      = |            1252 |     +1 |             2086 |       = |
| 0x9806ed1505…      |            121220 |       = |           41097 |     +0.1% 🔴 |          60821 |     +0.5% 🔴 |         206.4 KiB | +0.2% 🔴 |                2547 |      = |                 3463 |      = |             940 |     +2 |             1425 |      -1 |
| 0xcc74d4c66f…      |            120767 |       = |           39489 |           = |          63328 |           = |         215.9 KiB |       = |                2626 |      = |                 3546 |      = |             702 |     +1 |             1382 |       = |
| 0xd450e90507…      |            130436 |       = |           39789 |           = |          67328 |           = |         239.6 KiB |       = |                2884 |      = |                 4476 |      = |            1001 |     +2 |             1320 |       = |
| 0xfbbee2ff80…      |            119344 |       = |           39034 |           = |          62693 |           = |         210.6 KiB |       = |                2595 |      = |                 3507 |      = |             690 |      = |             1373 |       = |
| 0xfc5900eac5…      |             96772 |       = |           31786 |     +0.2% 🔴 |          43023 |     -1.0% 🟢 |         143.0 KiB | +0.3% 🔴 |                1941 |      = |                 2758 |      = |             569 |     -3 |              595 |     -35 |
| **TOTAL**          |       **1803567** |   **=** |      **599128** | **+0.1% 🔴** |     **989819** | **+1.6% 🔴** |       **3.4 MiB** |   **=** |           **42773** |  **=** |            **60398** |  **=** |       **11620** | **-7** |        **21193** | **-50** |

</details>

### Compile times

| benchmark          |       total |       parse |   translate |    finalize |     codegen |
|:-------------------|------------:|------------:|------------:|------------:|------------:|
| fibonacci-calldata |     +0.3% 🔴 |    -13.4% 🟢 |     -2.6% 🟢 |     -4.3% 🟢 |    +10.2% 🔴 |
| factorial          |     +1.9% 🔴 |     -0.5% 🟢 |    +26.8% 🔴 |     +0.1% 🔴 |     +2.0% 🔴 |
| counter            |     -7.8% 🟢 |     +0.4% 🔴 |    +10.9% 🔴 |    -10.9% 🟢 |     -5.0% 🟢 |
| snailtracer        |     +6.2% 🔴 |     +3.8% 🔴 |     -4.4% 🟢 |     +7.8% 🔴 |     +4.5% 🔴 |
| weth               |     +2.7% 🔴 |     +7.3% 🔴 |    +11.6% 🔴 |     +2.6% 🔴 |     +2.3% 🔴 |
| hash_10k           |     +0.9% 🔴 |     +1.9% 🔴 |     +1.4% 🔴 |     -3.9% 🟢 |    +10.6% 🔴 |
| erc20_transfer     |     -1.7% 🟢 |    -18.4% 🟢 |     -5.4% 🟢 |     -2.7% 🟢 |     +0.3% 🔴 |
| push0_proxy        |     +6.7% 🔴 |     +4.4% 🔴 |     +9.3% 🔴 |     +8.7% 🔴 |     +2.9% 🔴 |
| usdc_proxy         |     +0.9% 🔴 |     -0.2% 🟢 |     -5.6% 🟢 |     -0.5% 🟢 |     +3.5% 🔴 |
| fiat_token         |     +2.1% 🔴 |     +3.4% 🔴 |     +6.7% 🔴 |     +2.3% 🔴 |     +1.5% 🔴 |
| bswap64_opt        |     -3.4% 🟢 |     -4.4% 🟢 |     -6.6% 🟢 |     -5.2% 🟢 |     +0.1% 🔴 |
| eip4788            |    +17.4% 🔴 |     -1.6% 🟢 |    +14.4% 🔴 |    +18.0% 🔴 |    +17.8% 🔴 |
| curve_stableswap   |     +2.3% 🔴 |     +8.6% 🔴 |     +6.5% 🔴 |     +2.9% 🔴 |     +0.7% 🔴 |
| burntpix           |    +10.4% 🔴 |     -0.8% 🟢 |     +5.9% 🔴 |     +9.5% 🔴 |    +12.5% 🔴 |
| 0x184e2e0d92…      |    +12.4% 🔴 |     +5.2% 🔴 |    +16.5% 🔴 |    +15.6% 🔴 |     +7.1% 🔴 |
| 0x26f3fa5857…      |     +8.6% 🔴 |     -4.5% 🟢 |     +0.5% 🔴 |     +7.4% 🔴 |    +11.0% 🔴 |
| 0x7497bfab49…      |     +7.5% 🔴 |     +2.3% 🔴 |     +9.7% 🔴 |     +6.7% 🔴 |     +8.9% 🔴 |
| 0x8819f74c38…      |    +13.0% 🔴 |     +0.7% 🔴 |    +26.1% 🔴 |    +16.7% 🔴 |     +7.5% 🔴 |
| 0x9806ed1505…      |     +2.0% 🔴 |     -1.8% 🟢 |    -18.4% 🟢 |     +1.8% 🔴 |     +3.0% 🔴 |
| 0xcc74d4c66f…      |     +7.1% 🔴 |     +3.2% 🔴 |     +4.6% 🔴 |     +7.7% 🔴 |     +6.1% 🔴 |
| 0xd450e90507…      |     +2.3% 🔴 |     -5.8% 🟢 |     -8.1% 🟢 |     +2.8% 🔴 |     +1.9% 🔴 |
| 0xfbbee2ff80…      |     +5.9% 🔴 |     +0.5% 🔴 |     -0.9% 🟢 |     +5.3% 🔴 |     +7.1% 🔴 |
| 0xfc5900eac5…      |    +12.3% 🔴 |     +3.1% 🔴 |     -1.6% 🟢 |    +13.4% 🔴 |    +11.1% 🔴 |
| **TOTAL**          | **+6.2% 🔴** | **-0.1% 🟢** | **+2.6% 🔴** | **+6.6% 🔴** | **+5.8% 🔴** |

<details><summary>Full compile times</summary>

| benchmark          |        main |      branch |        diff |   parse (main) |   parse (branch) |   parse diff |   translate (main) |   translate (branch) |   translate diff |   finalize (main) |   finalize (branch) |   finalize diff |   codegen (main) |   codegen (branch) |   codegen diff |
|:-------------------|------------:|------------:|------------:|---------------:|-----------------:|-------------:|-------------------:|---------------------:|-----------------:|------------------:|--------------------:|----------------:|-----------------:|-------------------:|---------------:|
| fibonacci-calldata |      9.52ms |      9.55ms |     +0.3% 🔴 |        179.5µs |          155.4µs |     -13.4% 🟢 |            474.8µs |              462.6µs |          -2.6% 🟢 |            5.77ms |              5.52ms |         -4.3% 🟢 |           3.10ms |             3.42ms |       +10.2% 🔴 |
| factorial          |      9.96ms |      10.2ms |     +1.9% 🔴 |        164.6µs |          163.9µs |      -0.5% 🟢 |            432.4µs |              548.2µs |         +26.8% 🔴 |            5.85ms |              5.86ms |         +0.1% 🔴 |           3.51ms |             3.58ms |        +2.0% 🔴 |
| counter            |      14.0ms |      12.9ms |     -7.8% 🟢 |        304.6µs |          305.7µs |      +0.4% 🔴 |            575.9µs |              638.5µs |         +10.9% 🔴 |            8.45ms |              7.53ms |        -10.9% 🟢 |           4.62ms |             4.39ms |        -5.0% 🟢 |
| snailtracer        |      4.186s |      4.445s |     +6.2% 🔴 |         7.64ms |           7.93ms |      +3.8% 🔴 |             10.8ms |               10.3ms |          -4.4% 🟢 |            2.162s |              2.330s |         +7.8% 🔴 |           2.005s |             2.096s |        +4.5% 🔴 |
| weth               |     157.6ms |     161.8ms |     +2.7% 🔴 |         1.97ms |           2.11ms |      +7.3% 🔴 |             2.83ms |               3.16ms |         +11.6% 🔴 |            92.6ms |              95.0ms |         +2.6% 🔴 |           60.2ms |             61.6ms |        +2.3% 🔴 |
| hash_10k           |      15.9ms |      16.1ms |     +0.9% 🔴 |        268.9µs |          274.0µs |      +1.9% 🔴 |            600.9µs |              609.4µs |          +1.4% 🔴 |            10.1ms |              9.67ms |         -3.9% 🟢 |           4.97ms |             5.50ms |       +10.6% 🔴 |
| erc20_transfer     |     316.5ms |     311.3ms |     -1.7% 🟢 |         2.53ms |           2.07ms |     -18.4% 🟢 |             3.10ms |               2.93ms |          -5.4% 🟢 |           186.9ms |             181.9ms |         -2.7% 🟢 |          124.0ms |            124.4ms |        +0.3% 🔴 |
| push0_proxy        |      9.42ms |      10.1ms |     +6.7% 🔴 |        154.4µs |          161.2µs |      +4.4% 🔴 |            478.4µs |              522.8µs |          +9.3% 🔴 |            5.59ms |              6.08ms |         +8.7% 🔴 |           3.20ms |             3.29ms |        +2.9% 🔴 |
| usdc_proxy         |     105.1ms |     106.0ms |     +0.9% 🔴 |         1.32ms |           1.32ms |      -0.2% 🟢 |             1.93ms |               1.82ms |          -5.6% 🟢 |            63.8ms |              63.5ms |         -0.5% 🟢 |           38.0ms |             39.3ms |        +3.5% 🔴 |
| fiat_token         |      1.268s |      1.294s |     +2.1% 🔴 |         14.1ms |           14.5ms |      +3.4% 🔴 |             13.9ms |               14.8ms |          +6.7% 🔴 |           749.5ms |             766.4ms |         +2.3% 🔴 |          490.9ms |            498.1ms |        +1.5% 🔴 |
| uniswap_v2_pair    |     640.4ms |     649.0ms |     +1.3% 🔴 |         6.81ms |           6.68ms |      -1.8% 🟢 |             8.36ms |               8.32ms |          -0.6% 🟢 |           375.3ms |             372.2ms |         -0.8% 🟢 |          250.0ms |            261.8ms |        +4.7% 🔴 |
| univ2_router       |      1.355s |      1.357s |     +0.1% 🔴 |         14.4ms |           13.8ms |      -3.7% 🟢 |             14.8ms |               14.9ms |          +0.6% 🔴 |           802.2ms |             794.9ms |         -0.9% 🟢 |          523.7ms |            533.2ms |        +1.8% 🔴 |
| seaport            |      3.220s |      3.299s |     +2.5% 🔴 |         19.1ms |           18.7ms |      -2.1% 🟢 |             25.0ms |               25.1ms |          +0.6% 🔴 |            2.040s |              2.083s |         +2.1% 🔴 |           1.135s |             1.172s |        +3.3% 🔴 |
| airdrop            |     483.9ms |     488.6ms |     +1.0% 🔴 |         4.68ms |           4.54ms |      -3.0% 🟢 |             5.90ms |               6.17ms |          +4.5% 🔴 |           317.1ms |             320.8ms |         +1.2% 🔴 |          156.2ms |            157.1ms |        +0.6% 🔴 |
| bswap64            |      21.5ms |      21.3ms |     -1.1% 🟢 |        459.5µs |          467.8µs |      +1.8% 🔴 |            804.5µs |              804.9µs |          +0.1% 🔴 |            12.6ms |              12.5ms |         -0.8% 🟢 |           7.66ms |             7.53ms |        -1.7% 🟢 |
| bswap64_opt        |      21.4ms |      20.7ms |     -3.4% 🟢 |        426.9µs |          408.3µs |      -4.4% 🟢 |            796.1µs |              743.3µs |          -6.6% 🟢 |            12.8ms |              12.2ms |         -5.2% 🟢 |           7.34ms |             7.35ms |        +0.1% 🔴 |
| eip4788            |      11.1ms |      13.0ms |    +17.4% 🔴 |        209.7µs |          206.3µs |      -1.6% 🟢 |            532.6µs |              609.3µs |         +14.4% 🔴 |            6.58ms |              7.76ms |        +18.0% 🔴 |           3.77ms |             4.44ms |       +17.8% 🔴 |
| eip2935            |      10.7ms |      10.8ms |     +0.7% 🔴 |        197.5µs |          200.3µs |      +1.4% 🔴 |            545.2µs |              531.2µs |          -2.6% 🟢 |            6.42ms |              6.54ms |         +1.9% 🔴 |           3.58ms |             3.55ms |        -0.9% 🟢 |
| curve_stableswap   |     300.7ms |     307.6ms |     +2.3% 🔴 |         2.81ms |           3.05ms |      +8.6% 🔴 |             3.85ms |               4.10ms |          +6.5% 🔴 |           195.1ms |             200.8ms |         +2.9% 🔴 |           99.0ms |             99.7ms |        +0.7% 🔴 |
| onchain_lm_v2      |      2.435s |      2.538s |     +4.2% 🔴 |         8.50ms |           8.40ms |      -1.2% 🟢 |             11.1ms |               11.1ms |          -0.4% 🟢 |            1.277s |              1.337s |         +4.7% 🔴 |           1.138s |             1.182s |        +3.9% 🔴 |
| burntpix           |      3.089s |      3.411s |    +10.4% 🔴 |         19.9ms |           19.7ms |      -0.8% 🟢 |             23.1ms |               24.5ms |          +5.9% 🔴 |            1.970s |              2.157s |         +9.5% 🔴 |           1.076s |             1.210s |       +12.5% 🔴 |
| 0x184e2e0d92…      |      2.224s |      2.499s |    +12.4% 🔴 |         22.8ms |           24.0ms |      +5.2% 🔴 |             24.4ms |               28.4ms |         +16.5% 🔴 |            1.340s |              1.549s |        +15.6% 🔴 |          837.3ms |            897.0ms |        +7.1% 🔴 |
| 0x26f3fa5857…      |      1.917s |      2.082s |     +8.6% 🔴 |         22.1ms |           21.1ms |      -4.5% 🟢 |             24.9ms |               25.0ms |          +0.5% 🔴 |            1.099s |              1.180s |         +7.4% 🔴 |          770.7ms |            855.4ms |       +11.0% 🔴 |
| 0x7497bfab49…      |      1.925s |      2.069s |     +7.5% 🔴 |         21.2ms |           21.7ms |      +2.3% 🔴 |             24.9ms |               27.3ms |          +9.7% 🔴 |            1.127s |              1.202s |         +6.7% 🔴 |          751.6ms |            818.3ms |        +8.9% 🔴 |
| 0x8819f74c38…      |      2.572s |      2.906s |    +13.0% 🔴 |         23.6ms |           23.7ms |      +0.7% 🔴 |             26.0ms |               32.8ms |         +26.1% 🔴 |            1.475s |              1.722s |        +16.7% 🔴 |           1.048s |             1.127s |        +7.5% 🔴 |
| 0x9806ed1505…      |      2.494s |      2.544s |     +2.0% 🔴 |         19.0ms |           18.7ms |      -1.8% 🟢 |             28.7ms |               23.4ms |         -18.4% 🟢 |            1.540s |              1.568s |         +1.8% 🔴 |          906.8ms |            933.7ms |        +3.0% 🔴 |
| 0xcc74d4c66f…      |      2.084s |      2.231s |     +7.1% 🔴 |         18.5ms |           19.1ms |      +3.2% 🔴 |             22.1ms |               23.1ms |          +4.6% 🔴 |            1.266s |              1.363s |         +7.7% 🔴 |          777.8ms |            825.4ms |        +6.1% 🔴 |
| 0xd450e90507…      |      2.348s |      2.401s |     +2.3% 🔴 |         20.6ms |           19.4ms |      -5.8% 🟢 |             26.1ms |               24.0ms |          -8.1% 🟢 |            1.366s |              1.404s |         +2.8% 🔴 |          935.1ms |            953.3ms |        +1.9% 🔴 |
| 0xfbbee2ff80…      |      2.098s |      2.221s |     +5.9% 🔴 |         19.0ms |           19.1ms |      +0.5% 🔴 |             23.3ms |               23.1ms |          -0.9% 🟢 |            1.268s |              1.335s |         +5.3% 🔴 |          787.7ms |            843.3ms |        +7.1% 🔴 |
| 0xfc5900eac5…      |      1.688s |      1.895s |    +12.3% 🔴 |         14.8ms |           15.2ms |      +3.1% 🔴 |             18.7ms |               18.4ms |          -1.6% 🟢 |            1.033s |              1.171s |        +13.4% 🔴 |          621.4ms |            690.2ms |       +11.1% 🔴 |
| **TOTAL**          | **37.031s** | **39.341s** | **+6.2% 🔴** |    **287.8ms** |      **287.4ms** |  **-0.1% 🟢** |        **348.8ms** |          **358.0ms** |      **+2.6% 🔴** |       **21.820s** |         **23.270s** |     **+6.6% 🔴** |      **14.574s** |        **15.422s** |    **+5.8% 🔴** |

</details>

