### PR TITLE
perf: optimize constant-base exp

### DIFF
--- a/crates/revmc-builtins/src/ir.rs
+++ b/crates/revmc-builtins/src/ir.rs
@@ -166,6 +166,7 @@ macro_rules! builtins {
                 const PANIC: u8 = _0_0;
                 const ASSERTSPECID: u8 = _0_0;
 
+                const EXPGAS: u8 = _1_0;
                 const KECCAK256CC: u8 = _0_1;
 
                 const CALLDATALOADC: u8 = _0_1;
@@ -256,6 +257,7 @@ builtins! {
     AddMod         = __revmc_builtin_addmod(@[sp] ptr) None,
     MulMod         = __revmc_builtin_mulmod(@[sp] ptr) None,
     Exp            = __revmc_builtin_exp(@[ecx] ptr, @[sp] ptr) None,
+    ExpGas         = __revmc_builtin_exp_gas(@[ecx] ptr, @[sp] ptr) None,
     Keccak256      = __revmc_builtin_keccak256(@[ecx] ptr, @[sp] ptr) None,
     Keccak256CC    = __revmc_builtin_keccak256_cc(@[ecx] ptr, @[sp] ptr, usize, usize) None,
     Balance        = __revmc_builtin_balance(@[ecx] ptr, @[sp] ptr) None,

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -168,6 +168,15 @@ pub unsafe extern "C" fn __revmc_builtin_exp(
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn __revmc_builtin_exp_gas(
+    ecx: &mut EvmContext<'_>,
+    exponent: &EvmWord,
+) -> BuiltinResult {
+    gas!(ecx, ecx.gas_params.exp_cost(exponent.to_u256()));
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn __revmc_builtin_keccak256(
     ecx: &mut EvmContext<'_>,
     sp: &mut [EvmWord; 2],

--- a/crates/revmc-codegen/src/compiler/translate/peephole.rs
+++ b/crates/revmc-codegen/src/compiler/translate/peephole.rs
@@ -1,7 +1,7 @@
 //! Peephole optimizations applied during translation.
 //!
 //! These fire when abstract interpretation has proven one or more operands are constant,
-//! replacing expensive opaque builtins (DIV, MOD, SDIV, SMOD, ADDMOD, MULMOD) with native
+//! replacing expensive opaque builtins (DIV, MOD, SDIV, SMOD, ADDMOD, MULMOD, EXP) with native
 //! LLVM operations that it can optimize further (e.g. pow2 udiv → lshr, pow2 urem → and).
 
 use super::FunctionCx;
@@ -178,8 +178,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     ///
     /// Dynamic gas is folded into the section gas cost by `SectionsAnalysis` when the
     /// exponent is a compile-time constant, so the section gas check already covers it.
+    /// For constant-base cases with a dynamic exponent, call `ExpGas` to charge only the
+    /// dynamic gas and compute the result inline.
     fn peephole_exp(&mut self) -> bool {
-        let [_base, exponent] = self.const_operands();
+        let [base, exponent] = self.const_operands();
         match exponent {
             // x ** 0 => 1.
             Some(U256::ZERO) => self.fold_const(1),
@@ -194,9 +196,61 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 let r = self.bcx.imul(a, a);
                 self.push(r);
             }
+            Some(_) => return false,
+            None => {}
+        }
+        if exponent.is_some() {
+            return true;
+        }
+        match base {
+            // 0 ** x => x == 0 ? 1 : 0.
+            Some(U256::ZERO) => {
+                self.pay_exp_dynamic_gas();
+                let [_, exponent] = self.popn();
+                let is_zero = self.bcx.icmp_imm(IntCC::Equal, exponent, 0);
+                let one = self.bcx.iconst_256(1);
+                let zero = self.bcx.iconst_256(0);
+                let r = self.bcx.select(is_zero, one, zero);
+                self.push(r);
+            }
+            // 1 ** x => 1.
+            Some(U256::ONE) => {
+                self.pay_exp_dynamic_gas();
+                self.fold_const(1);
+            }
+            // (-1) ** x => x % 2 == 0 ? 1 : -1.
+            Some(U256::MAX) => {
+                self.pay_exp_dynamic_gas();
+                let [_, exponent] = self.popn();
+                let is_odd = self.bcx.bitand_imm(exponent, 1);
+                let is_even = self.bcx.icmp_imm(IntCC::Equal, is_odd, 0);
+                let one = self.bcx.iconst_256(1);
+                let minus_one = self.bcx.iconst_256(U256::MAX);
+                let r = self.bcx.select(is_even, one, minus_one);
+                self.push(r);
+            }
+            // (2 ** k) ** x => x < ceil(256 / k) ? 1 << (k * x) : 0.
+            Some(base) if base.is_power_of_two() => {
+                self.pay_exp_dynamic_gas();
+                let k = base.trailing_zeros();
+                let threshold = i64::from(256_u16.div_ceil(k as u16));
+                let [_, exponent] = self.popn();
+                let in_range = self.bcx.icmp_imm(IntCC::UnsignedLessThan, exponent, threshold);
+                let shift = if k == 1 { exponent } else { self.bcx.imul_imm(exponent, k as i64) };
+                let one = self.bcx.iconst_256(1);
+                let shifted = self.bcx.ishl(one, shift);
+                let zero = self.bcx.iconst_256(0);
+                let r = self.bcx.select(in_range, shifted, zero);
+                self.push(r);
+            }
             _ => return false,
         }
         true
+    }
+
+    fn pay_exp_dynamic_gas(&mut self) {
+        let exponent = self.sp_after_inputs_with(&[1]);
+        self.call_fallible_builtin(Builtin::ExpGas, &[self.ecx, exponent]);
     }
 
     /// SIGNEXTEND ext, x => sign-extend x from (ext+1) bytes.
@@ -319,10 +373,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     fn const_memory_operands(&self, args: [Option<U256>; 2]) -> Option<(u64, u64)> {
         if let [offset, Some(len)] = args
             && let Ok(len) = u64::try_from(len)
-            // For len == 0 offset is ignored.
-            && let Some(offset) = offset
-                .and_then(|offset| u64::try_from(offset).ok())
-                .or_else(|| (len == 0).then_some(0))
+            && let Some(offset) = offset.and_then(|offset| u64::try_from(offset).ok())
         {
             Some((offset, len))
         } else {

--- a/crates/revmc-codegen/src/compiler/translate/peephole.rs
+++ b/crates/revmc-codegen/src/compiler/translate/peephole.rs
@@ -373,7 +373,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     fn const_memory_operands(&self, args: [Option<U256>; 2]) -> Option<(u64, u64)> {
         if let [offset, Some(len)] = args
             && let Ok(len) = u64::try_from(len)
-            && let Some(offset) = offset.and_then(|offset| u64::try_from(offset).ok())
+            // For len == 0 offset is ignored.
+            && let Some(offset) = offset
+                .and_then(|offset| u64::try_from(offset).ok())
+                .or_else(|| (len == 0).then_some(0))
         {
             Some((offset, len))
         } else {

--- a/crates/revmc-codegen/src/tests/macros.rs
+++ b/crates/revmc-codegen/src/tests/macros.rs
@@ -81,12 +81,12 @@ macro_rules! tests {
         )*
     };
 
-    // Generate an `_opaque` companion test for each arity.
-    // Uses MSTORE+MLOAD to make operands invisible to the compiler.
+    // Generate companion tests for every const/dynamic operand combination.
+    // Dynamic operands use MSTORE+MLOAD to make them invisible to the compiler.
     (@maybe_opaque $name:ident(@raw { $($fields:tt)* })) => {};
     (@maybe_opaque $name:ident($op:expr, $a:expr => $($ret:expr),* $(; $($_r1:tt)*)?)) => {
         paste::paste! {
-            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
+            matrix_tests!([<$name _dyn>] = |jit| run_test_case(
                 &TestCase {
                     bytecode: &bytecode_unop_opaque($op, $a),
                     expected_stack: &[$($ret),*],
@@ -100,31 +100,47 @@ macro_rules! tests {
     };
     (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr => $($ret:expr),* $(; $($_r2:tt)*)?)) => {
         paste::paste! {
-            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
-                &TestCase {
-                    bytecode: &bytecode_binop_opaque($op, $a, $b),
-                    expected_stack: &[$($ret),*],
-                    expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
-                    expected_gas: GAS_WHAT_INTERPRETER_SAYS,
-                    ..Default::default()
-                },
-                jit,
-            ));
+            tests!(@mixed_binop [<$name _const_dyn>] $op, $a, $b, true, false => $($ret),*);
+            tests!(@mixed_binop [<$name _dyn_const>] $op, $a, $b, false, true => $($ret),*);
+            tests!(@mixed_binop [<$name _dyn_dyn>] $op, $a, $b, false, false => $($ret),*);
         }
     };
     (@maybe_opaque $name:ident($op:expr, $a:expr, $b:expr, $c:expr => $($ret:expr),* $(; $($_r3:tt)*)?)) => {
         paste::paste! {
-            matrix_tests!([<$name _opaque>] = |jit| run_test_case(
-                &TestCase {
-                    bytecode: &bytecode_ternop_opaque($op, $a, $b, $c),
-                    expected_stack: &[$($ret),*],
-                    expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
-                    expected_gas: GAS_WHAT_INTERPRETER_SAYS,
-                    ..Default::default()
-                },
-                jit,
-            ));
+            tests!(@mixed_ternop [<$name _const_const_dyn>] $op, $a, $b, $c, true, true, false => $($ret),*);
+            tests!(@mixed_ternop [<$name _const_dyn_const>] $op, $a, $b, $c, true, false, true => $($ret),*);
+            tests!(@mixed_ternop [<$name _const_dyn_dyn>] $op, $a, $b, $c, true, false, false => $($ret),*);
+            tests!(@mixed_ternop [<$name _dyn_const_const>] $op, $a, $b, $c, false, true, true => $($ret),*);
+            tests!(@mixed_ternop [<$name _dyn_const_dyn>] $op, $a, $b, $c, false, true, false => $($ret),*);
+            tests!(@mixed_ternop [<$name _dyn_dyn_const>] $op, $a, $b, $c, false, false, true => $($ret),*);
+            tests!(@mixed_ternop [<$name _dyn_dyn_dyn>] $op, $a, $b, $c, false, false, false => $($ret),*);
         }
+    };
+
+    (@mixed_binop $name:ident $op:expr, $a:expr, $b:expr, $a_const:expr, $b_const:expr => $($ret:expr),*) => {
+        matrix_tests!($name = |jit| run_test_case(
+            &TestCase {
+                bytecode: &bytecode_binop_mixed($op, $a, $b, $a_const, $b_const),
+                expected_stack: &[$($ret),*],
+                expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+                expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+                ..Default::default()
+            },
+            jit,
+        ));
+    };
+
+    (@mixed_ternop $name:ident $op:expr, $a:expr, $b:expr, $c:expr, $a_const:expr, $b_const:expr, $c_const:expr => $($ret:expr),*) => {
+        matrix_tests!($name = |jit| run_test_case(
+            &TestCase {
+                bytecode: &bytecode_ternop_mixed($op, $a, $b, $c, $a_const, $b_const, $c_const),
+                expected_stack: &[$($ret),*],
+                expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+                expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+                ..Default::default()
+            },
+            jit,
+        ));
     };
 
     (@case @raw { $($fields:tt)* }) => { &TestCase { $($fields)* ..Default::default() } };

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -824,9 +824,8 @@ tests! {
             expected_gas: 2 + 3 + gas::KECCAK256,
         }),
         keccak256_empty_dynamic_offset(@raw {
-            bytecode: &[op::ADDRESS, op::PUSH0, op::KECCAK256],
-            expected_return: InstructionResult::InvalidOperandOOG,
-            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            bytecode: &[op::PUSH0, op::ADDRESS, op::KECCAK256],
+            expected_stack: &[KECCAK_EMPTY.into()],
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         keccak256_1(@raw {
@@ -1372,9 +1371,8 @@ tests! {
             expected_next_action: ACTION_WHAT_INTERPRETER_SAYS,
         }),
         ret_empty_dynamic_offset(@raw {
-            bytecode: &[op::ADDRESS, op::PUSH0, op::RETURN],
-            expected_return: InstructionResult::InvalidOperandOOG,
-            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            bytecode: &[op::PUSH0, op::ADDRESS, op::RETURN],
+            expected_return: InstructionResult::Return,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         ret(@raw {

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -694,6 +694,14 @@ tests! {
         exp4(op::EXP, 2_U256, 2_U256 => 4_U256; op_gas(60)),
         exp5(op::EXP, 2_U256, 3_U256 => 8_U256; op_gas(60)),
         exp6(op::EXP, 2_U256, 4_U256 => 16_U256; op_gas(60)),
+        exp_zero_base_zero_exp(op::EXP, 0_U256, 0_U256 => 1_U256; op_gas(10)),
+        exp_zero_base_nonzero_exp(op::EXP, 0_U256, 5_U256 => 0_U256; op_gas(60)),
+        exp_one_base_large_exp(op::EXP, 1_U256, U256::MAX => 1_U256; op_gas(1610)),
+        exp_minus_one_base_even_exp(op::EXP, -1_U256, 4_U256 => 1_U256; op_gas(60)),
+        exp_minus_one_base_odd_exp(op::EXP, -1_U256, 5_U256 => -1_U256; op_gas(60)),
+        exp_pow4_base_in_range(op::EXP, 4_U256, 63_U256 => 1_U256 << 126; op_gas(60)),
+        exp_pow4_base_overflow(op::EXP, 4_U256, 128_U256 => 0_U256; op_gas(60)),
+        exp_non_pow2_base(op::EXP, 3_U256, 5_U256 => 243_U256; op_gas(60)),
         exp_overflow(op::EXP, 2_U256, 256_U256 => 0_U256; op_gas(110)),
         // Large exponent spanning multiple bytes.
         exp_large(op::EXP, 2_U256, 0xFFFF_U256 => 2_U256.pow(0xFFFF_U256); op_gas(110)),
@@ -814,6 +822,12 @@ tests! {
             bytecode: &[op::PUSH0, op::PUSH1, 32, op::KECCAK256],
             expected_stack: &[KECCAK_EMPTY.into()],
             expected_gas: 2 + 3 + gas::KECCAK256,
+        }),
+        keccak256_empty_dynamic_offset(@raw {
+            bytecode: &[op::ADDRESS, op::PUSH0, op::KECCAK256],
+            expected_return: InstructionResult::InvalidOperandOOG,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         keccak256_1(@raw {
             bytecode: &[op::PUSH1, 32, op::PUSH0, op::KECCAK256],
@@ -1073,10 +1087,37 @@ tests! {
             expected_stack: &[DEF_ADDR.into_word().into()],
             expected_gas: 5,
         }),
+        mload_const_offset_too_large(@raw {
+            bytecode: &{
+                let mut code = Vec::new();
+                code.push(op::PUSH9);
+                code.extend_from_slice(&0x1_0000_0000_0000_0000_U256.to_be_bytes::<32>()[23..]);
+                code.push(op::MLOAD);
+                code
+            },
+            expected_return: InstructionResult::InvalidOperandOOG,
+            expected_stack: &[0x1_0000_0000_0000_0000_U256],
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
         mstore1(@raw {
             bytecode: &[op::PUSH0, op::PUSH0, op::MSTORE],
             expected_memory: &[0; 32],
             expected_gas: 2 + 2 + (3 + memory_gas_cost(1)),
+        }),
+        mstore_const_offset_dyn_value(@raw {
+            bytecode: &bytecode_binop_mixed(op::MSTORE, 0_U256, 0x69_U256, true, false),
+            expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+        mstore_dyn_offset_const_value(@raw {
+            bytecode: &bytecode_binop_mixed(op::MSTORE, 0_U256, 0x69_U256, false, true),
+            expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+        mstore_dyn_offset_dyn_value(@raw {
+            bytecode: &bytecode_binop_mixed(op::MSTORE, 0_U256, 0x69_U256, false, false),
+            expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         mstore8_1(@raw {
             bytecode: &[op::PUSH0, op::PUSH0, op::MSTORE8],
@@ -1329,6 +1370,12 @@ tests! {
             expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
             expected_next_action: ACTION_WHAT_INTERPRETER_SAYS,
+        }),
+        ret_empty_dynamic_offset(@raw {
+            bytecode: &[op::ADDRESS, op::PUSH0, op::RETURN],
+            expected_return: InstructionResult::InvalidOperandOOG,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
         ret(@raw {
             bytecode: &[op::PUSH1, 0x69, op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::RETURN],
@@ -2078,48 +2125,55 @@ fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
     code
 }
 
-/// Build bytecode: MSTORE(a, 0), MSTORE(b, 32), MLOAD(32), MLOAD(0), `<op>`
-///
-/// The operands pass through MLOAD (an opaque builtin), preventing the compiler
-/// from constant-folding or exploiting UB at compile time.
-fn bytecode_binop_opaque(opcode: u8, a: U256, b: U256) -> Vec<u8> {
-    let mut code = Vec::with_capacity(128);
-    code.push(op::PUSH32);
-    code.extend_from_slice(&a.to_be_bytes::<32>());
-    code.push(op::PUSH1);
-    code.push(0x00);
-    code.push(op::MSTORE);
-    code.push(op::PUSH32);
-    code.extend_from_slice(&b.to_be_bytes::<32>());
-    code.push(op::PUSH1);
-    code.push(0x20);
-    code.push(op::MSTORE);
-    code.push(op::PUSH1);
-    code.push(0x20);
-    code.push(op::MLOAD);
-    code.push(op::PUSH1);
-    code.push(0x00);
-    code.push(op::MLOAD);
-    code.push(opcode);
-    code
-}
-
-/// Build opaque ternop bytecode: MSTORE(a,0), MSTORE(b,32), MSTORE(c,64),
-/// MLOAD(64), MLOAD(32), MLOAD(0), `<op>`.
-fn bytecode_ternop_opaque(opcode: u8, a: U256, b: U256, c: U256) -> Vec<u8> {
-    let mut code = Vec::with_capacity(192);
-    for (val, offset) in [(a, 0u8), (b, 0x20), (c, 0x40)] {
+fn push_const_or_load(code: &mut Vec<u8>, value: U256, is_const: bool, offset: u8) {
+    if is_const {
         code.push(op::PUSH32);
-        code.extend_from_slice(&val.to_be_bytes::<32>());
-        code.push(op::PUSH1);
-        code.push(offset);
-        code.push(op::MSTORE);
-    }
-    for offset in [0x40u8, 0x20, 0x00] {
+        code.extend_from_slice(&value.to_be_bytes::<32>());
+    } else {
         code.push(op::PUSH1);
         code.push(offset);
         code.push(op::MLOAD);
     }
+}
+
+fn store_dynamic_operands(code: &mut Vec<u8>, operands: &[(U256, bool, u8)]) {
+    for &(value, is_const, offset) in operands {
+        if !is_const {
+            code.push(op::PUSH32);
+            code.extend_from_slice(&value.to_be_bytes::<32>());
+            code.push(op::PUSH1);
+            code.push(offset);
+            code.push(op::MSTORE);
+        }
+    }
+}
+
+fn bytecode_binop_mixed(opcode: u8, a: U256, b: U256, a_const: bool, b_const: bool) -> Vec<u8> {
+    let mut code = Vec::with_capacity(128);
+    store_dynamic_operands(&mut code, &[(a, a_const, 0x00), (b, b_const, 0x20)]);
+    push_const_or_load(&mut code, b, b_const, 0x20);
+    push_const_or_load(&mut code, a, a_const, 0x00);
+    code.push(opcode);
+    code
+}
+
+fn bytecode_ternop_mixed(
+    opcode: u8,
+    a: U256,
+    b: U256,
+    c: U256,
+    a_const: bool,
+    b_const: bool,
+    c_const: bool,
+) -> Vec<u8> {
+    let mut code = Vec::with_capacity(192);
+    store_dynamic_operands(
+        &mut code,
+        &[(a, a_const, 0x00), (b, b_const, 0x20), (c, c_const, 0x40)],
+    );
+    push_const_or_load(&mut code, c, c_const, 0x40);
+    push_const_or_load(&mut code, b, b_const, 0x20);
+    push_const_or_load(&mut code, a, a_const, 0x00);
     code.push(opcode);
     code
 }


### PR DESCRIPTION
Adds EXP peepholes for constant bases with dynamic exponents. The optimized cases cover zero, one, minus one, and power-of-two bases while preserving dynamic gas accounting through a new `exp_gas` builtin that only charges the exponent-dependent gas.

The test matrix now generates const/dynamic operand combinations for binary and ternary opcode tests, which covers the new EXP paths and broadens existing peephole coverage. This also fixes constant memory operand handling so zero-length memory operations still require a valid offset when the interpreter would validate it.

Tests: `cargo fmt --all`, `cargo cl -q`, `TMPDIR=$PWD/target/tmp cargo nextest run -p revmc-codegen`.
