### PR TITLE
perf(llvm): limit expensive live range splitting

### DIFF
--- a/crates/revmc-cli/src/cmd/run.rs
+++ b/crates/revmc-cli/src/cmd/run.rs
@@ -151,7 +151,7 @@ impl RunArgs {
         let is_fixture = bench_entry.is_fixture();
         let default_aot_dir = || std::env::temp_dir().join("revmc-cli").join(&bench_name);
         let mut aot_dir = None;
-        let mut compiled_jit = None;
+        let mut pending_jit = None;
 
         // Compile the entry-point contract: parse, display, dot, dump, aot.
         // For fixture benchmarks, extract the tx-target bytecode.
@@ -234,15 +234,8 @@ impl RunArgs {
                     return Ok(());
                 }
             } else if self.load.is_none() {
-                let fn_ptr = unsafe { compiler.jit_function(f_id)? };
-                let mut functions = B256Map::default();
-                functions.insert(keccak256(&bytecode), fn_ptr.into_inner());
-                compiled_jit = Some((compiler, functions));
+                pending_jit = Some((compiler, vec![(keccak256(&bytecode), f_id)]));
             }
-        }
-
-        if self.n_iters == 0 {
-            return Ok(());
         }
 
         // Unified runtime path for both bytecode, fixture, and loaded benchmarks.
@@ -261,9 +254,14 @@ impl RunArgs {
                 PreparedBench::load_from_library(&bench_entry, spec_id, load_path, name);
             _compiler = None;
             _lib = Some(lib);
-        } else if let Some((mut compiler, functions)) = compiled_jit {
-            prepared =
-                PreparedBench::load_with_functions(&bench_entry, spec_id, &mut compiler, functions);
+        } else if let Some((mut compiler, pending)) = pending_jit {
+            prepared = PreparedBench::load_with_pending_functions(
+                &bench_entry,
+                spec_id,
+                &mut compiler,
+                B256Map::default(),
+                pending,
+            );
             _compiler = Some(compiler);
             _lib = None;
         } else {
@@ -272,6 +270,10 @@ impl RunArgs {
             _compiler = Some(compiler);
             _lib = None;
         };
+
+        if self.n_iters == 0 {
+            return Ok(());
+        }
 
         prepared.sanity_check();
 

--- a/crates/revmc-cli/src/fixture.rs
+++ b/crates/revmc-cli/src/fixture.rs
@@ -7,7 +7,7 @@ use revm_handler::{ExecuteEvm, MainBuilder, MainnetEvm};
 use revm_primitives::{Address, B256, B256Map, Bytes, StorageKeyMap, StorageValue, TxKind, U256};
 use revm_state::AccountInfo;
 use revmc::{
-    EvmCompiler, EvmLlvmBackend, RawEvmCompilerFn, primitives::hardfork::SpecId,
+    Backend, EvmCompiler, EvmLlvmBackend, RawEvmCompilerFn, primitives::hardfork::SpecId,
     simple_revm_evm::JitEvm,
 };
 use serde::Deserialize;
@@ -148,7 +148,20 @@ impl PreparedBench {
         bench: &Bench,
         default_spec_id: SpecId,
         compiler: &mut EvmCompiler<EvmLlvmBackend>,
+        functions: B256Map<RawEvmCompilerFn>,
+    ) -> Self {
+        Self::load_with_pending_functions(bench, default_spec_id, compiler, functions, Vec::new())
+    }
+
+    /// Load a benchmark, reusing already-translated and already-JIT'd functions.
+    ///
+    /// The caller must keep `compiler` alive as long as the returned `PreparedBench` is used.
+    pub fn load_with_pending_functions(
+        bench: &Bench,
+        default_spec_id: SpecId,
+        compiler: &mut EvmCompiler<EvmLlvmBackend>,
         mut functions: B256Map<RawEvmCompilerFn>,
+        mut pending: Vec<(B256, <EvmLlvmBackend as Backend>::FuncId)>,
     ) -> Self {
         let (accounts, block, cfg, tx) = if bench.is_fixture() {
             Self::parse_fixture(bench)
@@ -159,12 +172,10 @@ impl PreparedBench {
         // JIT compile all contract bytecodes that were not provided by the caller.
         let spec_id = cfg.spec;
         let mut seen = HashSet::new();
-        let mut pending = Vec::new();
+        seen.extend(functions.keys().copied());
+        seen.extend(pending.iter().map(|(hash, _)| *hash));
         for acct in &accounts {
-            if acct.bytecode.is_empty()
-                || functions.contains_key(&acct.code_hash)
-                || !seen.insert(acct.code_hash)
-            {
+            if acct.bytecode.is_empty() || !seen.insert(acct.code_hash) {
                 continue;
             }
             let name = format!("contract_{}", revmc::primitives::hex::encode(acct.code_hash));

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1963,6 +1963,11 @@ fn init_() -> Result<()> {
         // which produce identical codegen at that scale. Small functions still benefit from
         // CGP's address sinking and branch optimizations.
         c"--cgpp-huge-func=1000".as_ptr(),
+        // Greedy register allocation's global live range splitting is superlinear on large
+        // functions with many long-lived values. Treat smaller live ranges as huge so LLVM uses
+        // the cheaper splitting path; this preserves code size on snailtracer while cutting llc
+        // time by ~3x.
+        c"--huge-size-for-split=64".as_ptr(),
     ];
     args.extend(extra.iter().map(|s| s.as_ptr()));
     unsafe {

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -980,7 +980,9 @@ def main():
         action="append",
         default=None,
         help="Extra directory with .bin files to benchmark (can be repeated). "
-        "Defaults to ['tmp/mainnet']; pass any --extra-dir to override.",
+        "Defaults to ['tmp/mainnet'] when running all benchmarks; "
+        "pass any --extra-dir to override or to include extras with explicit "
+        "benchmarks.",
     )
 
     # Analysis selectors. Default: --codegen-lines --compile-times.
@@ -1048,7 +1050,11 @@ def main():
 
     binary = cargo_build(root)
     builtin = args.benches or get_benches(binary)
-    extra_dirs = [] if args.benches else (args.extra_dir if args.extra_dir is not None else ["tmp/mainnet"])
+    extra_dirs = (
+        args.extra_dir
+        if args.extra_dir is not None
+        else ([] if args.benches else ["tmp/mainnet"])
+    )
     extra = find_extra_benches(extra_dirs, root)
     benches = builtin + extra
 

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -129,6 +129,14 @@ def fmt_pct(base: float | int, current: float | int) -> str:
     return f"{pct:+.1f}%{_indicator(pct)}"
 
 
+def fmt_detail(current: str | int, base: str | int, diff: str) -> str:
+    return f"{base}<br>{current}<br>{diff}"
+
+
+def fmt_detail_bold(current: str | int, base: str | int, diff: str) -> str:
+    return f"**{fmt_detail(current, base, diff)}**"
+
+
 def is_noise(base: float | int, current: float | int, noise: float) -> bool:
     """Whether the relative change is within ``noise`` percent (or unmeasurable)."""
     if base == 0:
@@ -489,14 +497,17 @@ class CodegenLines(Analysis):
 
         # Detailed table.
         print("<details><summary>Full details</summary>\n")
-        detail_headers = ["benchmark"]
-        for f in ["unopt.ll", "opt.ll", "opt.s"]:
-            detail_headers += [f"{f} ({base_label})", "diff"]
-        detail_headers += [f"jit size ({base_label})", "diff"]
-        detail_headers += [f"i256 loads ({base_label})", "diff"]
-        detail_headers += [f"i256 stores ({base_label})", "diff"]
-        detail_headers += [f"spills ({base_label})", "diff"]
-        detail_headers += [f"reloads ({base_label})", "diff"]
+        detail_headers = [
+            "benchmark",
+            "unopt.ll",
+            "opt.ll",
+            "opt.s",
+            "jit size",
+            "i256 loads",
+            "i256 stores",
+            "spills",
+            "reloads",
+        ]
         detail_table = []
         for name, counts, jit_size, i256_ld, i256_st, spills, reloads in cur_rows:
             base_counts, base_jit, base_ld, base_st, base_sp, base_rl = base_map.get(
@@ -504,24 +515,29 @@ class CodegenLines(Analysis):
             )
             row = [name]
             for b, c in zip(base_counts, counts):
-                row += [b, fmt_pct(b, c)]
-            row += [fmt_size(base_jit), fmt_pct(base_jit, jit_size)]
-            row += [base_ld, fmt_diff(base_ld, i256_ld)]
-            row += [base_st, fmt_diff(base_st, i256_st)]
-            row += [base_sp, fmt_diff(base_sp, spills)]
-            row += [base_rl, fmt_diff(base_rl, reloads)]
+                row.append(fmt_detail(c, b, fmt_pct(b, c)))
+            row.append(
+                fmt_detail(fmt_size(jit_size), fmt_size(base_jit), fmt_pct(base_jit, jit_size))
+            )
+            row.append(fmt_detail(i256_ld, base_ld, fmt_pct(base_ld, i256_ld)))
+            row.append(fmt_detail(i256_st, base_st, fmt_pct(base_st, i256_st)))
+            row.append(fmt_detail(spills, base_sp, fmt_pct(base_sp, spills)))
+            row.append(fmt_detail(reloads, base_rl, fmt_pct(base_rl, reloads)))
             detail_table.append(row)
         total_row = ["**TOTAL**"]
         for b, c in zip(base_totals, cur_totals):
-            total_row += [f"**{b}**", f"**{fmt_pct(b, c)}**"]
-        total_row += [
-            f"**{fmt_size(base_total_size)}**",
-            f"**{fmt_pct(base_total_size, cur_total_size)}**",
-        ]
-        total_row += [f"**{base_tld}**", f"**{fmt_diff(base_tld, cur_tld)}**"]
-        total_row += [f"**{base_tst}**", f"**{fmt_diff(base_tst, cur_tst)}**"]
-        total_row += [f"**{base_tsp}**", f"**{fmt_diff(base_tsp, cur_tsp)}**"]
-        total_row += [f"**{base_trl}**", f"**{fmt_diff(base_trl, cur_trl)}**"]
+            total_row.append(fmt_detail_bold(c, b, fmt_pct(b, c)))
+        total_row.append(
+            fmt_detail_bold(
+                fmt_size(cur_total_size),
+                fmt_size(base_total_size),
+                fmt_pct(base_total_size, cur_total_size),
+            )
+        )
+        total_row.append(fmt_detail_bold(cur_tld, base_tld, fmt_pct(base_tld, cur_tld)))
+        total_row.append(fmt_detail_bold(cur_tst, base_tst, fmt_pct(base_tst, cur_tst)))
+        total_row.append(fmt_detail_bold(cur_tsp, base_tsp, fmt_pct(base_tsp, cur_tsp)))
+        total_row.append(fmt_detail_bold(cur_trl, base_trl, fmt_pct(base_trl, cur_trl)))
         detail_table.append(total_row)
         print_table(detail_headers, detail_table)
         print("</details>\n")
@@ -601,34 +617,32 @@ class CompileTime(Analysis):
 
         # Detailed table.
         print("<details><summary>Full compile times</summary>\n")
-        detail_headers = ["benchmark", base_label, "branch", "diff"]
-        for phase in PHASES:
-            detail_headers += [
-                f"{phase} ({base_label})",
-                f"{phase} (branch)",
-                f"{phase} diff",
-            ]
+        detail_headers = ["benchmark", "total", *PHASES]
         detail_table = []
         for name, cur in cur_rows:
             base = base_map.get(name, {})
             bt, ct = base.get("total", 0.0), cur.get("total", 0.0)
-            row = [name, fmt_dur(bt), fmt_dur(ct), fmt_pct(bt, ct)]
+            row = [name, fmt_detail(fmt_dur(ct), fmt_dur(bt), fmt_pct(bt, ct))]
             for phase in PHASES:
                 bp, cp = base.get(phase, 0.0), cur.get(phase, 0.0)
-                row += [fmt_dur(bp), fmt_dur(cp), fmt_pct(bp, cp)]
+                row.append(fmt_detail(fmt_dur(cp), fmt_dur(bp), fmt_pct(bp, cp)))
             detail_table.append(row)
         total_row = [
             "**TOTAL**",
-            f"**{fmt_dur(base_totals['total'])}**",
-            f"**{fmt_dur(cur_totals['total'])}**",
-            f"**{fmt_pct(base_totals['total'], cur_totals['total'])}**",
+            fmt_detail_bold(
+                fmt_dur(cur_totals["total"]),
+                fmt_dur(base_totals["total"]),
+                fmt_pct(base_totals["total"], cur_totals["total"]),
+            ),
         ]
         for phase in PHASES:
-            total_row += [
-                f"**{fmt_dur(base_totals[phase])}**",
-                f"**{fmt_dur(cur_totals[phase])}**",
-                f"**{fmt_pct(base_totals[phase], cur_totals[phase])}**",
-            ]
+            total_row.append(
+                fmt_detail_bold(
+                    fmt_dur(cur_totals[phase]),
+                    fmt_dur(base_totals[phase]),
+                    fmt_pct(base_totals[phase], cur_totals[phase]),
+                )
+            )
         detail_table.append(total_row)
         print_table(detail_headers, detail_table)
         print("</details>\n")


### PR DESCRIPTION
This tunes LLVM greedy register allocation for the large single-function modules that revmc generates. Greedy regalloc's global live range splitting can spend seconds on rematerializable values with many live-range segments; lowering `huge-size-for-split` makes LLVM use its cheaper splitting path for those cases.

## Benchmarks

Headline numbers across all benchmarks discovered by `./scripts/bench.py` (21 built-ins plus 9 `tmp/mainnet` contracts): total compile time -27.1%, codegen -32.2%, and total jit size is unchanged. The biggest wins are `snailtracer` (8.315s to 1.580s total, codegen 4.134s to 668ms), `onchain_lm_v2` (4.551s to 1.486s total, codegen 2.060s to 489ms), and `burntpix` (6.157s to 4.841s total, codegen 2.095s to 1.652s).

The full no-argument benchmark set requires a local CLI fix for multi-contract fixtures that defer JIT finalization until all fixture bytecodes are translated. That fix was applied to both sides of this benchmark, so the comparison below isolates the LLVM flag against `main` plus that CLI fix.

### Codegen statistics

| benchmark   |   unopt.ll |   opt.ll |   opt.s |   jit size |   i256 loads |   i256 stores |   spills |   reloads |
|:------------|-----------:|---------:|--------:|-----------:|-------------:|--------------:|---------:|----------:|
| **TOTAL**   |      **=** |    **=** |   **=** |      **=** |        **=** |         **=** |    **=** |     **=** |

<details><summary>Full details</summary>

| benchmark          |                    unopt.ll |                    opt.ll |                       opt.s |                          jit size |              i256 loads |             i256 stores |                spills |                 reloads |
|:-------------------|----------------------------:|--------------------------:|----------------------------:|----------------------------------:|------------------------:|------------------------:|----------------------:|------------------------:|
| fibonacci-calldata |             356<br>356<br>= |           113<br>113<br>= |             306<br>306<br>= |               444 B<br>444 B<br>= |             2<br>2<br>= |             3<br>3<br>= |           5<br>5<br>= |             6<br>6<br>= |
| factorial          |             348<br>348<br>= |           115<br>115<br>= |             348<br>348<br>= |               601 B<br>601 B<br>= |             2<br>2<br>= |             3<br>3<br>= |           8<br>8<br>= |             9<br>9<br>= |
| counter            |           1018<br>1018<br>= |           343<br>343<br>= |             541<br>541<br>= |               876 B<br>876 B<br>= |             8<br>8<br>= |             7<br>7<br>= |           0<br>0<br>- |             0<br>0<br>- |
| snailtracer        |         54487<br>54487<br>= |       20614<br>20614<br>= |         41289<br>41289<br>= |       114.6 KiB<br>114.6 KiB<br>= |       1379<br>1379<br>= |       2245<br>2245<br>= |         96<br>96<br>= |         528<br>528<br>= |
| weth               |         12758<br>12758<br>= |         3743<br>3743<br>= |           6180<br>6180<br>= |         19.0 KiB<br>19.0 KiB<br>= |         256<br>256<br>= |         342<br>342<br>= |         32<br>32<br>= |         106<br>106<br>= |
| hash_10k           |             968<br>968<br>= |           309<br>309<br>= |             557<br>557<br>= |           1.4 KiB<br>1.4 KiB<br>= |           16<br>16<br>= |           23<br>23<br>= |           0<br>0<br>- |             0<br>0<br>- |
| erc20_transfer     |         13888<br>13888<br>= |         4890<br>4890<br>= |           9826<br>9826<br>= |         25.7 KiB<br>25.7 KiB<br>= |         308<br>308<br>= |         441<br>441<br>= |         14<br>14<br>= |           82<br>82<br>= |
| push0_proxy        |             371<br>371<br>= |           183<br>183<br>= |             339<br>339<br>= |               633 B<br>633 B<br>= |             1<br>1<br>= |           15<br>15<br>= |           0<br>0<br>- |             0<br>0<br>- |
| usdc_proxy         |           7162<br>7162<br>= |         2597<br>2597<br>= |           4733<br>4733<br>= |         11.7 KiB<br>11.7 KiB<br>= |         105<br>105<br>= |         196<br>196<br>= |         24<br>24<br>= |           23<br>23<br>= |
| fiat_token         |         77617<br>77617<br>= |       24084<br>24084<br>= |         43709<br>43709<br>= |       144.0 KiB<br>144.0 KiB<br>= |       1773<br>1773<br>= |       2609<br>2609<br>= |       173<br>173<br>= |         748<br>748<br>= |
| uniswap_v2_pair    |         43815<br>43815<br>= |       14124<br>14124<br>= |         24740<br>24740<br>= |         79.2 KiB<br>79.2 KiB<br>= |         888<br>888<br>= |       1373<br>1373<br>= |         80<br>80<br>= |         436<br>436<br>= |
| univ2_router       |         81868<br>81868<br>= |       26146<br>26146<br>= |   46130<br>46087<br>-0.1% 🟢 | 164.9 KiB<br>164.4 KiB<br>-0.3% 🟢 |       2009<br>2009<br>= |       2914<br>2914<br>= |       272<br>272<br>= |         537<br>537<br>= |
| seaport            |       131064<br>131064<br>= |       50577<br>50577<br>= |         94440<br>94440<br>= |       293.2 KiB<br>293.2 KiB<br>= |       4232<br>4232<br>= |       5268<br>5268<br>= |       437<br>437<br>= |       2483<br>2483<br>= |
| airdrop            |         27296<br>27296<br>= |         9377<br>9377<br>= |         17198<br>17198<br>= |         47.2 KiB<br>47.2 KiB<br>= |         560<br>560<br>= |         841<br>841<br>= |         57<br>57<br>= |         340<br>340<br>= |
| bswap64            |           2119<br>2119<br>= |           537<br>537<br>= |           1013<br>1013<br>= |           2.6 KiB<br>2.6 KiB<br>= |           29<br>29<br>= |           53<br>53<br>= |           0<br>0<br>- |             0<br>0<br>- |
| bswap64_opt        |           1807<br>1807<br>= |           490<br>490<br>= |             911<br>911<br>= |           2.5 KiB<br>2.5 KiB<br>= |           33<br>33<br>= |           51<br>51<br>= |           0<br>0<br>- |             0<br>0<br>- |
| eip4788            |             597<br>597<br>= |           224<br>224<br>= |             409<br>409<br>= |               716 B<br>716 B<br>= |             8<br>8<br>= |             9<br>9<br>= |           1<br>1<br>= |             1<br>1<br>= |
| eip2935            |             542<br>542<br>= |           196<br>196<br>= |             398<br>398<br>= |               739 B<br>739 B<br>= |             6<br>6<br>= |             5<br>5<br>= |           0<br>0<br>- |             0<br>0<br>- |
| curve_stableswap   |         23318<br>23318<br>= |         8645<br>8645<br>= |         15632<br>15632<br>= |         28.2 KiB<br>28.2 KiB<br>= |         522<br>522<br>= |         812<br>812<br>= |         25<br>25<br>= |         106<br>106<br>= |
| onchain_lm_v2      |         62942<br>62942<br>= |       21343<br>21343<br>= |         40361<br>40361<br>= |       107.6 KiB<br>107.6 KiB<br>= |       1353<br>1353<br>= |       1692<br>1692<br>= |         67<br>67<br>= |         471<br>471<br>= |
| burntpix           |       209433<br>209433<br>= |       71854<br>71854<br>= |       131782<br>131821<br>= |       221.1 KiB<br>221.1 KiB<br>= |       5298<br>5298<br>= |       6832<br>6832<br>= |       599<br>599<br>= |       2708<br>2709<br>= |
| 0x184e2e0d92…      |       133704<br>133704<br>= |       38862<br>38862<br>= |         69733<br>69733<br>= |       228.9 KiB<br>228.9 KiB<br>= |       2987<br>2987<br>= |       4492<br>4492<br>= |       358<br>358<br>= |       2621<br>2621<br>= |
| 0x26f3fa5857…      |       137618<br>137618<br>= |       36315<br>36315<br>= |         75489<br>75489<br>= |       302.2 KiB<br>302.2 KiB<br>= |       3594<br>3594<br>= |       5343<br>5343<br>= |       619<br>619<br>= |       2204<br>2204<br>= |
| 0x7497bfab49…      |       138128<br>138128<br>= |       36592<br>36592<br>= |         75492<br>75492<br>= |       301.7 KiB<br>301.7 KiB<br>= |       3614<br>3614<br>= |       5337<br>5337<br>= |       622<br>622<br>= |       2099<br>2099<br>= |
| 0x8819f74c38…      |       146858<br>146858<br>= |       41987<br>41987<br>= |   83042<br>83405<br>+0.4% 🔴 | 312.6 KiB<br>313.1 KiB<br>+0.1% 🔴 |       3910<br>3910<br>= |       5108<br>5108<br>= |       755<br>755<br>= |       2334<br>2334<br>= |
| 0x9806ed1505…      |       121219<br>121219<br>= |       38239<br>38239<br>= |         60775<br>60775<br>= |       201.1 KiB<br>201.1 KiB<br>= |       2536<br>2536<br>= |       3463<br>3463<br>= |       462<br>462<br>= |       1365<br>1365<br>= |
| 0xcc74d4c66f…      |       120766<br>120766<br>= |       37192<br>37192<br>= |         65538<br>65538<br>= |       208.3 KiB<br>208.3 KiB<br>= |       2626<br>2626<br>= |       3546<br>3546<br>= |       252<br>252<br>= |       1531<br>1531<br>= |
| 0xd450e90507…      |       130435<br>130435<br>= |       37588<br>37588<br>= |   68319<br>68110<br>-0.3% 🟢 | 236.0 KiB<br>237.1 KiB<br>+0.5% 🔴 |       2884<br>2884<br>= |       4476<br>4476<br>= | 298<br>296<br>-0.7% 🟢 | 1620<br>1616<br>-0.2% 🟢 |
| 0xfbbee2ff80…      |       119343<br>119343<br>= |       36765<br>36765<br>= |         64875<br>64875<br>= |       202.7 KiB<br>202.7 KiB<br>= |       2595<br>2595<br>= |       3507<br>3507<br>= |       249<br>249<br>= |       1519<br>1519<br>= |
| 0xfc5900eac5…      |         96771<br>96771<br>= |       28806<br>28806<br>= |         43735<br>43735<br>= |       140.5 KiB<br>140.5 KiB<br>= |       1874<br>1874<br>= |       2758<br>2758<br>= |       203<br>203<br>= |         888<br>888<br>= |
| **TOTAL**          | **1898616<br>1898616<br>=** | **592850<br>592850<br>=** | **1087840<br>1087990<br>=** |       **3.3 MiB<br>3.3 MiB<br>=** | **45408<br>45408<br>=** | **63764<br>63764<br>=** | **5708<br>5706<br>=** | **24765<br>24762<br>=** |

</details>

### Compile times

| benchmark          |        total |       parse |   translate |     finalize |      codegen |
|:-------------------|-------------:|------------:|------------:|-------------:|-------------:|
| fibonacci-calldata |      +3.6% 🔴 |     +4.5% 🔴 |     -1.1% 🟢 |      +2.1% 🔴 |      +7.2% 🔴 |
| factorial          |      +2.2% 🔴 |     -3.1% 🟢 |     +7.4% 🔴 |      +2.7% 🔴 |      +0.8% 🔴 |
| counter            |      +2.9% 🔴 |     -7.8% 🟢 |     +1.2% 🔴 |      +2.4% 🔴 |      +4.9% 🔴 |
| snailtracer        |     -81.0% 🟢 |     -0.4% 🟢 |     +7.7% 🔴 |     -78.5% 🟢 |     -83.8% 🟢 |
| weth               |      -0.8% 🟢 |     +4.7% 🔴 |     +9.4% 🔴 |      -2.0% 🟢 |      +0.6% 🔴 |
| erc20_transfer     |      -0.3% 🟢 |     -3.6% 🟢 |     -7.0% 🟢 |      -0.9% 🟢 |      +1.0% 🔴 |
| push0_proxy        |      +0.8% 🔴 |     -4.6% 🟢 |     +6.5% 🔴 |      +2.1% 🔴 |      -2.0% 🟢 |
| usdc_proxy         |      -3.9% 🟢 |     -3.5% 🟢 |     -3.9% 🟢 |      -2.7% 🟢 |      -5.8% 🟢 |
| fiat_token         |      +2.7% 🔴 |     -1.0% 🟢 |    +13.4% 🔴 |      +0.2% 🔴 |      +6.4% 🔴 |
| uniswap_v2_pair    |      +2.1% 🔴 |    +10.1% 🔴 |    +11.0% 🔴 |      +1.5% 🔴 |      +2.8% 🔴 |
| seaport            |      -6.6% 🟢 |     +3.5% 🔴 |    +15.8% 🔴 |      -6.4% 🟢 |      -7.9% 🟢 |
| bswap64            |      -4.1% 🟢 |     -5.6% 🟢 |     -6.9% 🟢 |      -3.5% 🟢 |      -4.7% 🟢 |
| bswap64_opt        |      -5.9% 🟢 |     -7.6% 🟢 |     -2.4% 🟢 |      -7.3% 🟢 |      -3.6% 🟢 |
| eip4788            |      -4.6% 🟢 |     -5.4% 🟢 |     -5.6% 🟢 |      -7.6% 🟢 |      +1.2% 🔴 |
| eip2935            |      -9.1% 🟢 |     -3.0% 🟢 |     -9.8% 🟢 |     -11.4% 🟢 |      -5.1% 🟢 |
| curve_stableswap   |      -5.5% 🟢 |     -1.8% 🟢 |     +4.4% 🔴 |      -4.2% 🟢 |      -8.1% 🟢 |
| onchain_lm_v2      |     -67.3% 🟢 |     -4.7% 🟢 |    -12.1% 🟢 |     -66.8% 🟢 |     -76.3% 🟢 |
| burntpix           |     -21.4% 🟢 |     -1.0% 🟢 |    -12.4% 🟢 |     -21.8% 🟢 |     -21.1% 🟢 |
| 0x184e2e0d92…      |      -7.8% 🟢 |     +1.1% 🔴 |     -1.5% 🟢 |      -1.2% 🟢 |     -18.2% 🟢 |
| 0x26f3fa5857…      |      -6.5% 🟢 |     -1.5% 🟢 |     +2.2% 🔴 |     -13.1% 🟢 |      +4.4% 🔴 |
| 0x7497bfab49…      |     -26.5% 🟢 |     +1.3% 🔴 |     -2.9% 🟢 |     -37.5% 🟢 |      -3.0% 🟢 |
| 0x8819f74c38…      |      +3.1% 🔴 |     -2.4% 🟢 |     -6.1% 🟢 |            = |      +8.3% 🔴 |
| 0x9806ed1505…      |      +9.1% 🔴 |     +5.0% 🔴 |     +2.5% 🔴 |     +13.5% 🔴 |      +1.5% 🔴 |
| 0xcc74d4c66f…      |      -0.2% 🟢 |     -4.1% 🟢 |    -10.1% 🟢 |      +0.6% 🔴 |      -1.0% 🟢 |
| 0xd450e90507…      |     -16.2% 🟢 |     -3.3% 🟢 |     -7.7% 🟢 |     -13.3% 🟢 |     -21.0% 🟢 |
| 0xfbbee2ff80…      |     -12.7% 🟢 |     -4.1% 🟢 |     -5.4% 🟢 |     -15.5% 🟢 |      -7.7% 🟢 |
| **TOTAL**          | **-27.1% 🟢** | **-2.3% 🟢** | **-2.2% 🟢** | **-24.5% 🟢** | **-32.2% 🟢** |

<details><summary>Full compile times</summary>

| benchmark          |                              total |                             parse |                         translate |                           finalize |                            codegen |
|:-------------------|-----------------------------------:|----------------------------------:|----------------------------------:|-----------------------------------:|-----------------------------------:|
| fibonacci-calldata |        9.51ms<br>9.85ms<br>+3.6% 🔴 |     195.4µs<br>204.3µs<br>+4.5% 🔴 |     488.1µs<br>482.6µs<br>-1.1% 🟢 |        5.80ms<br>5.92ms<br>+2.1% 🔴 |        3.03ms<br>3.25ms<br>+7.2% 🔴 |
| factorial          |        10.3ms<br>10.6ms<br>+2.2% 🔴 |     186.5µs<br>180.7µs<br>-3.1% 🟢 |     470.2µs<br>505.1µs<br>+7.4% 🔴 |        6.15ms<br>6.32ms<br>+2.7% 🔴 |        3.52ms<br>3.55ms<br>+0.8% 🔴 |
| counter            |        13.6ms<br>14.0ms<br>+2.9% 🔴 |     367.2µs<br>338.5µs<br>-7.8% 🟢 |     611.4µs<br>618.7µs<br>+1.2% 🔴 |        8.13ms<br>8.33ms<br>+2.4% 🔴 |        4.51ms<br>4.73ms<br>+4.9% 🔴 |
| snailtracer        |       8.315s<br>1.580s<br>-81.0% 🟢 |       8.41ms<br>8.37ms<br>-0.4% 🟢 |       10.1ms<br>10.9ms<br>+7.7% 🔴 |      4.162s<br>893.0ms<br>-78.5% 🟢 |      4.134s<br>668.0ms<br>-83.8% 🟢 |
| weth               |      164.1ms<br>162.8ms<br>-0.8% 🟢 |       2.20ms<br>2.30ms<br>+4.7% 🔴 |       2.79ms<br>3.05ms<br>+9.4% 🔴 |        97.9ms<br>95.9ms<br>-2.0% 🟢 |        61.2ms<br>61.5ms<br>+0.6% 🔴 |
| hash_10k           |        14.6ms<br>15.1ms<br>+3.8% 🔴 |     297.7µs<br>308.4µs<br>+3.6% 🔴 |     606.7µs<br>624.1µs<br>+2.9% 🔴 |        8.88ms<br>9.21ms<br>+3.6% 🔴 |        4.79ms<br>5.00ms<br>+4.2% 🔴 |
| erc20_transfer     |      318.6ms<br>317.8ms<br>-0.3% 🟢 |       2.41ms<br>2.33ms<br>-3.6% 🟢 |       3.17ms<br>2.94ms<br>-7.0% 🟢 |      187.3ms<br>185.5ms<br>-0.9% 🟢 |      125.7ms<br>127.0ms<br>+1.0% 🔴 |
| push0_proxy        |        9.65ms<br>9.73ms<br>+0.8% 🔴 |     177.5µs<br>169.3µs<br>-4.6% 🟢 |     460.5µs<br>490.3µs<br>+6.5% 🔴 |        5.76ms<br>5.88ms<br>+2.1% 🔴 |        3.26ms<br>3.19ms<br>-2.0% 🟢 |
| usdc_proxy         |      110.4ms<br>106.1ms<br>-3.9% 🟢 |       1.44ms<br>1.39ms<br>-3.5% 🟢 |       1.90ms<br>1.82ms<br>-3.9% 🟢 |        66.3ms<br>64.5ms<br>-2.7% 🟢 |        40.8ms<br>38.4ms<br>-5.8% 🟢 |
| fiat_token         |        1.238s<br>1.271s<br>+2.7% 🔴 |       15.7ms<br>15.5ms<br>-1.0% 🟢 |      14.5ms<br>16.5ms<br>+13.4% 🔴 |      739.8ms<br>741.3ms<br>+0.2% 🔴 |      467.8ms<br>497.6ms<br>+6.4% 🔴 |
| uniswap_v2_pair    |      721.1ms<br>736.5ms<br>+2.1% 🔴 |      7.24ms<br>7.96ms<br>+10.1% 🔴 |      8.28ms<br>9.19ms<br>+11.0% 🔴 |      463.8ms<br>470.8ms<br>+1.5% 🔴 |      241.8ms<br>248.5ms<br>+2.8% 🔴 |
| univ2_router       |        1.374s<br>1.353s<br>-1.5% 🟢 |       14.3ms<br>14.9ms<br>+4.5% 🔴 |       16.1ms<br>15.8ms<br>-2.1% 🟢 |      819.9ms<br>812.4ms<br>-0.9% 🟢 |      523.8ms<br>509.5ms<br>-2.7% 🟢 |
| seaport            |        3.344s<br>3.122s<br>-6.6% 🟢 |       20.4ms<br>21.2ms<br>+3.5% 🔴 |      24.7ms<br>28.7ms<br>+15.8% 🔴 |        2.190s<br>2.050s<br>-6.4% 🟢 |        1.110s<br>1.022s<br>-7.9% 🟢 |
| airdrop            |      494.7ms<br>483.1ms<br>-2.3% 🟢 |       4.72ms<br>4.61ms<br>-2.5% 🟢 |       5.64ms<br>5.58ms<br>-1.1% 🟢 |      330.1ms<br>324.4ms<br>-1.7% 🟢 |      154.2ms<br>148.5ms<br>-3.7% 🟢 |
| bswap64            |        22.9ms<br>22.0ms<br>-4.1% 🟢 |     532.5µs<br>502.4µs<br>-5.6% 🟢 |     871.9µs<br>811.4µs<br>-6.9% 🟢 |        13.7ms<br>13.2ms<br>-3.5% 🟢 |        7.83ms<br>7.46ms<br>-4.7% 🟢 |
| bswap64_opt        |        21.7ms<br>20.4ms<br>-5.9% 🟢 |     455.6µs<br>421.1µs<br>-7.6% 🟢 |     751.5µs<br>733.3µs<br>-2.4% 🟢 |        13.1ms<br>12.1ms<br>-7.3% 🟢 |        7.42ms<br>7.15ms<br>-3.6% 🟢 |
| eip4788            |        11.6ms<br>11.1ms<br>-4.6% 🟢 |     242.8µs<br>229.7µs<br>-5.4% 🟢 |     547.2µs<br>516.4µs<br>-5.6% 🟢 |        7.06ms<br>6.52ms<br>-7.6% 🟢 |        3.77ms<br>3.81ms<br>+1.2% 🔴 |
| eip2935            |        11.3ms<br>10.2ms<br>-9.1% 🟢 |     227.9µs<br>221.1µs<br>-3.0% 🟢 |     561.4µs<br>506.4µs<br>-9.8% 🟢 |       6.82ms<br>6.04ms<br>-11.4% 🟢 |        3.66ms<br>3.48ms<br>-5.1% 🟢 |
| curve_stableswap   |      397.2ms<br>375.3ms<br>-5.5% 🟢 |       4.03ms<br>3.95ms<br>-1.8% 🟢 |       4.54ms<br>4.74ms<br>+4.4% 🔴 |      244.7ms<br>234.3ms<br>-4.2% 🟢 |      144.0ms<br>132.3ms<br>-8.1% 🟢 |
| onchain_lm_v2      |       4.551s<br>1.486s<br>-67.3% 🟢 |     261.7ms<br>249.4ms<br>-4.7% 🟢 |      15.7ms<br>13.8ms<br>-12.1% 🟢 |      2.214s<br>734.4ms<br>-66.8% 🟢 |      2.060s<br>488.5ms<br>-76.3% 🟢 |
| burntpix           |       6.157s<br>4.841s<br>-21.4% 🟢 |       38.6ms<br>38.2ms<br>-1.0% 🟢 |      47.5ms<br>41.6ms<br>-12.4% 🟢 |       3.976s<br>3.110s<br>-21.8% 🟢 |       2.095s<br>1.652s<br>-21.1% 🟢 |
| 0x184e2e0d92…      |        2.510s<br>2.313s<br>-7.8% 🟢 |       24.5ms<br>24.8ms<br>+1.1% 🔴 |       26.5ms<br>26.1ms<br>-1.5% 🟢 |        1.480s<br>1.462s<br>-1.2% 🟢 |     978.6ms<br>800.1ms<br>-18.2% 🟢 |
| 0x26f3fa5857…      |        2.062s<br>1.929s<br>-6.5% 🟢 |       23.9ms<br>23.5ms<br>-1.5% 🟢 |       26.4ms<br>27.0ms<br>+2.2% 🔴 |       1.269s<br>1.103s<br>-13.1% 🟢 |      742.4ms<br>775.2ms<br>+4.4% 🔴 |
| 0x7497bfab49…      |       2.666s<br>1.960s<br>-26.5% 🟢 |       22.6ms<br>22.9ms<br>+1.3% 🔴 |       26.5ms<br>25.8ms<br>-2.9% 🟢 |       1.821s<br>1.139s<br>-37.5% 🟢 |      796.1ms<br>772.2ms<br>-3.0% 🟢 |
| 0x8819f74c38…      |        2.422s<br>2.496s<br>+3.1% 🔴 |       25.8ms<br>25.2ms<br>-2.4% 🟢 |       28.5ms<br>26.8ms<br>-6.1% 🟢 |              1.452s<br>1.452s<br>= |      916.3ms<br>992.6ms<br>+8.3% 🔴 |
| 0x9806ed1505…      |        2.197s<br>2.397s<br>+9.1% 🔴 |       19.1ms<br>20.1ms<br>+5.0% 🔴 |       22.6ms<br>23.1ms<br>+2.5% 🔴 |       1.387s<br>1.574s<br>+13.5% 🔴 |      768.7ms<br>779.9ms<br>+1.5% 🔴 |
| 0xcc74d4c66f…      |        1.993s<br>1.989s<br>-0.2% 🟢 |       20.7ms<br>19.9ms<br>-4.1% 🟢 |      25.0ms<br>22.5ms<br>-10.1% 🟢 |        1.227s<br>1.234s<br>+0.6% 🔴 |      719.6ms<br>712.2ms<br>-1.0% 🟢 |
| 0xd450e90507…      |       2.371s<br>1.986s<br>-16.2% 🟢 |       21.3ms<br>20.6ms<br>-3.3% 🟢 |       25.9ms<br>23.9ms<br>-7.7% 🟢 |       1.379s<br>1.196s<br>-13.3% 🟢 |     943.9ms<br>746.0ms<br>-21.0% 🟢 |
| 0xfbbee2ff80…      |       2.306s<br>2.014s<br>-12.7% 🟢 |       20.5ms<br>19.7ms<br>-4.1% 🟢 |       23.6ms<br>22.3ms<br>-5.4% 🟢 |       1.486s<br>1.255s<br>-15.5% 🟢 |      776.7ms<br>717.2ms<br>-7.7% 🟢 |
| 0xfc5900eac5…      |        1.532s<br>1.512s<br>-1.3% 🟢 |       16.9ms<br>16.5ms<br>-2.2% 🟢 |       21.0ms<br>20.8ms<br>-1.1% 🟢 |      954.3ms<br>941.6ms<br>-1.3% 🟢 |      540.0ms<br>532.8ms<br>-1.3% 🟢 |
| **TOTAL**          | **47.369s<br>34.554s<br>-27.1% 🟢** | **579.0ms<br>565.7ms<br>-2.3% 🟢** | **386.4ms<br>378.0ms<br>-2.2% 🟢** | **28.022s<br>21.147s<br>-24.5% 🟢** | **18.382s<br>12.463s<br>-32.2% 🟢** |

</details>

