### PR TITLE
perf: inline calldataload

### DIFF
--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -336,6 +336,16 @@ pub trait Builder: BackendTypes + TypeMethods {
         align: usize,
         name: &str,
     ) -> Self::Value;
+    /// Loads a value from a pointer whose contents are invariant for the current invocation.
+    fn load_invariant_aligned(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        align: usize,
+        name: &str,
+    ) -> Self::Value {
+        self.load_aligned(ty, ptr, align, name)
+    }
     /// Stores a value to a pointer, assuming natural alignment.
     fn store(&mut self, value: Self::Value, ptr: Self::Value);
     /// Stores a value to a pointer with an explicit alignment override.

--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -393,13 +393,6 @@ pub trait Builder: BackendTypes + TypeMethods {
         then_value: Self::Value,
         else_value: Self::Value,
     ) -> Self::Value;
-    fn lazy_select(
-        &mut self,
-        cond: Self::Value,
-        ty: Self::Type,
-        then_value: impl FnOnce(&mut Self) -> Self::Value,
-        else_value: impl FnOnce(&mut Self) -> Self::Value,
-    ) -> Self::Value;
 
     fn iadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn isub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;

--- a/crates/revmc-builtins/src/ir.rs
+++ b/crates/revmc-builtins/src/ir.rs
@@ -187,7 +187,6 @@ macro_rules! builtins {
                 const EXPGAS: u8 = _1_0;
                 const KECCAK256CC: u8 = _0_1;
 
-                const CALLDATALOADC: u8 = _0_1;
                 const SLOADC: u8 = _0_1;
 
                 const MRESIZE: u8 = _0_0;
@@ -277,8 +276,6 @@ builtins! {
     Keccak256CC    = __revmc_builtin_keccak256_cc(@[ecx] ptr, @[sp] ptr, usize, usize) None,
     Balance        = __revmc_builtin_balance(@[ecx] ptr, @[sp] ptr) None,
     Origin         = __revmc_builtin_origin(@[ecx_ro] ptr, @[sp] ptr) None,
-    CallDataLoad   = __revmc_builtin_calldataload(@[ecx_ro] ptr, @[sp] ptr) None,
-    CallDataLoadC  = __revmc_builtin_calldataload_c(@[ecx_ro] ptr, @[sp] ptr, usize) None,
     CallDataCopy   = __revmc_builtin_calldatacopy(@[ecx] ptr, @[sp] ptr) None,
     CodeCopy       = __revmc_builtin_codecopy(@[ecx] ptr, @[sp] ptr) None,
     GasPrice       = __revmc_builtin_gas_price(@[ecx_ro] ptr, @[sp] ptr) None,

--- a/crates/revmc-builtins/src/lib.rs
+++ b/crates/revmc-builtins/src/lib.rs
@@ -16,7 +16,7 @@ use revm_interpreter::{
     InstructionResult, InterpreterAction, InterpreterResult, as_u64_saturated, as_usize_saturated,
     interpreter_types::{InputsTr, MemoryTr},
 };
-use revm_primitives::{B256, Bytes, KECCAK_EMPTY, Log, LogData, U256, hardfork::SpecId};
+use revm_primitives::{Bytes, KECCAK_EMPTY, Log, LogData, U256, hardfork::SpecId};
 use revmc_context::{EvmContext, EvmWord};
 
 pub mod gas;
@@ -227,41 +227,6 @@ pub unsafe extern "C" fn __revmc_builtin_balance(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __revmc_builtin_origin(ecx: &EvmContext<'_>, slot: &mut EvmWord) {
     *slot = EvmWord::from_be_bytes(ecx.host.caller().into_word());
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn __revmc_builtin_calldataload(
-    ecx: &EvmContext<'_>,
-    offset_ptr: &mut EvmWord,
-) {
-    do_calldataload(ecx, offset_ptr, as_usize_saturated!(offset_ptr.to_u256()));
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn __revmc_builtin_calldataload_c(
-    ecx: &EvmContext<'_>,
-    offset_ptr: &mut EvmWord,
-    offset: u64,
-) {
-    do_calldataload(ecx, offset_ptr, offset as usize);
-}
-
-fn do_calldataload(ecx: &EvmContext<'_>, out: &mut EvmWord, offset: usize) {
-    let mut word = B256::ZERO;
-    let input = ecx.input.input();
-    let input_len = input.len();
-    if offset < input_len {
-        let count = 32.min(input_len - offset);
-        let input = ecx.input.input().as_bytes_memory(ecx.memory);
-        // SAFETY: `count` is bounded by the calldata length.
-        // This is `word[..count].copy_from_slice(input[offset..offset + count])`, written using
-        // raw pointers as apparently the compiler cannot optimize the slice version, and using
-        // `get_unchecked` twice is uglier.
-        unsafe {
-            core::ptr::copy_nonoverlapping(input.as_ptr().add(offset), word.as_mut_ptr(), count)
-        };
-    }
-    *out = EvmWord::from_be_bytes(word);
 }
 
 #[unsafe(no_mangle)]

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -821,8 +821,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 field!(@push self.word_type, input, InputsImpl; call_value);
             }
             op::CALLDATALOAD => {
-                let sp = self.sp_after_inputs();
-                let _ = self.call_builtin(Builtin::CallDataLoad, &[self.ecx, sp]);
+                self.calldataload();
             }
             op::CALLDATASIZE => {
                 field!(@push self.isize_type, self.ecx, EvmContext<'_>; calldatasize);
@@ -1333,6 +1332,50 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let ir_const = self.bcx.iconst(self.i8_type, ir as i64);
         let _ = self.call_builtin(Builtin::DoReturn, &[self.ecx, sp, ir_const]);
         self.bcx.unreachable();
+    }
+
+    /// Builds a `CALLDATALOAD` instruction.
+    fn calldataload(&mut self) {
+        let offset_word = self.pop();
+        let offset = self.bcx.ireduce(self.isize_type, offset_word);
+
+        let calldatasize_field = self.get_field(
+            self.ecx,
+            mem::offset_of!(EvmContext<'_>, calldatasize),
+            "ecx.calldatasize.addr",
+        );
+        let calldatasize = self.bcx.load(self.isize_type, calldatasize_field, "ecx.calldatasize");
+        let calldata_base_field = self.get_field(
+            self.ecx,
+            mem::offset_of!(EvmContext<'_>, calldata_base),
+            "ecx.calldata_base.addr",
+        );
+        let calldata_base =
+            self.bcx.load(self.bcx.type_ptr(), calldata_base_field, "ecx.calldata_base");
+
+        let extended = self.bcx.zext(self.word_type, offset);
+        let fits = self.bcx.icmp(IntCC::Equal, offset_word, extended);
+        let in_bounds = self.bcx.icmp(IntCC::UnsignedLessThan, offset, calldatasize);
+        let valid = self.bcx.bitand(fits, in_bounds);
+
+        let remaining = self.bcx.isub(calldatasize, offset);
+        let src = self.bcx.gep(self.i8_type, calldata_base, &[offset], "calldata.src");
+
+        let full_avail = self.bcx.icmp_imm(IntCC::UnsignedGreaterThanOrEqual, remaining, 32);
+        let fast = self.bcx.bitand(valid, full_avail);
+
+        let result = self.lazy_select(
+            fast,
+            self.word_type,
+            |this| this.bcx.load_aligned(this.word_type, src, 1, "calldataload.full"),
+            |this| {
+                let zero_isize = this.bcx.iconst(this.isize_type, 0);
+                let safe_remaining = this.bcx.select(valid, remaining, zero_isize);
+                this.call_calldataload_slow(src, safe_remaining)
+            },
+        );
+        let result = if self.little_endian() { self.bcx.bswap(result) } else { result };
+        self.push(result);
     }
 
     /// Builds a `CREATE` or `CREATE2` instruction.
@@ -1879,6 +1922,34 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         self.bytecode.inst(self.current_inst.unwrap())
     }
 
+    fn lazy_select(
+        &mut self,
+        cond: B::Value,
+        ty: B::Type,
+        then_value: impl FnOnce(&mut Self) -> B::Value,
+        else_value: impl FnOnce(&mut Self) -> B::Value,
+    ) -> B::Value {
+        let current_block = self.current_block();
+        let then_block = self.create_block_after(current_block, "then");
+        let else_block = self.create_block_after(then_block, "else");
+        let done_block = self.create_block_after(else_block, "contd");
+
+        self.bcx.brif(cond, then_block, else_block);
+
+        self.bcx.switch_to_block(then_block);
+        let then_value = then_value(self);
+        self.bcx.br(done_block);
+        let then_block = self.current_block();
+
+        self.bcx.switch_to_block(else_block);
+        let else_value = else_value(self);
+        self.bcx.br(done_block);
+        let else_block = self.current_block();
+
+        self.bcx.switch_to_block(done_block);
+        self.bcx.phi(ty, &[(then_value, then_block), (else_value, else_block)])
+    }
+
     /// Returns the current block.
     fn current_block(&mut self) -> B::BasicBlock {
         // There always is a block present.
@@ -1926,6 +1997,44 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
 /// IR builtins.
 impl<B: Backend> FunctionCx<'_, B> {
+    /// Calls the cold calldataload slow path: `fn(src: *const u8, remaining: isize) -> i256`.
+    fn call_calldataload_slow(&mut self, src: B::Value, remaining: B::Value) -> B::Value {
+        let ptr_type = self.bcx.type_ptr();
+        let isize_type = self.isize_type;
+        let word_type = self.word_type;
+        self.call_ir_builtin(
+            "calldataload_slow",
+            &[src, remaining],
+            &[ptr_type, isize_type],
+            Some(word_type),
+            Self::build_calldataload_slow,
+        )
+        .unwrap()
+    }
+
+    fn build_calldataload_slow(&mut self) {
+        self.bcx.add_function_attribute(None, Attribute::Cold, FunctionAttributeLocation::Function);
+
+        let src = self.bcx.fn_param(0);
+        let remaining = self.bcx.fn_param(1);
+        let zero = self.bcx.iconst_256(U256::ZERO);
+
+        let has_data = self.bcx.icmp_imm(IntCC::SignedGreaterThan, remaining, 0);
+        let r = self.lazy_select(
+            has_data,
+            self.word_type,
+            |this| {
+                let slot = this.bcx.new_stack_slot_raw(this.word_type, "tmp");
+                let slot_ptr = this.bcx.stack_addr(this.word_type, slot);
+                this.bcx.store(zero, slot_ptr);
+                this.bcx.memcpy(slot_ptr, src, remaining);
+                this.bcx.load(this.word_type, slot_ptr, "partial")
+            },
+            |_this| zero,
+        );
+        self.bcx.ret(&[r]);
+    }
+
     #[allow(dead_code)]
     #[must_use]
     fn call_ir_builtin(

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -1367,7 +1367,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let full_avail = self.bcx.icmp_imm(IntCC::UnsignedGreaterThanOrEqual, remaining, 32);
         let fast = self.bcx.bitand(valid, full_avail);
 
-        let result = self.lazy_select(
+        let result = self.if_else(
             fast,
             self.word_type,
             |this| this.bcx.load_aligned(this.word_type, src, 1, "calldataload.full"),
@@ -1700,11 +1700,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             return self.build_memory_addr(offset);
         }
 
-        let current_block = self.current_block();
-        let resize_block = self.create_block_after(current_block, "mresize");
-        let contd_block = self.create_block_after(resize_block, "mresize.contd");
-
-        // Otherwise emit the normal checked-resize diamond.
+        // Otherwise emit the normal checked-resize branch.
         // Fast path: offset + len <= mem_len (no overflow).
         let mem_len_field =
             self.get_field(self.ecx, mem::offset_of!(EvmContext<'_>, mem_len), "ecx.mem_len.addr");
@@ -1712,15 +1708,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let exceeds = self.bcx.icmp(IntCC::UnsignedGreaterThan, min_size, mem_len);
         self.cached_mem_base = None;
 
-        self.bcx.brif(exceeds, resize_block, contd_block);
-
-        // Cold path: call mresize builtin.
-        self.bcx.switch_to_block(resize_block);
-        self.bcx.set_current_block_cold();
-        self.call_fallible_builtin(Builtin::Mresize, &[self.ecx, min_size]);
-        self.bcx.br(contd_block);
-
-        self.bcx.switch_to_block(contd_block);
+        self.if_then(exceeds, |this| {
+            this.bcx.set_current_block_cold();
+            this.call_fallible_builtin(Builtin::Mresize, &[this.ecx, min_size]);
+        });
         self.build_memory_addr(offset)
     }
 
@@ -1969,7 +1960,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         self.bytecode.inst(self.current_inst.unwrap())
     }
 
-    fn lazy_select(
+    fn if_else(
         &mut self,
         cond: B::Value,
         ty: B::Type,
@@ -1995,6 +1986,20 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
         self.bcx.switch_to_block(done_block);
         self.bcx.phi(ty, &[(then_value, then_block), (else_value, else_block)])
+    }
+
+    fn if_then(&mut self, cond: B::Value, then: impl FnOnce(&mut Self)) {
+        let current_block = self.current_block();
+        let then_block = self.create_block_after(current_block, "then");
+        let done_block = self.create_block_after(then_block, "contd");
+
+        self.bcx.brif(cond, then_block, done_block);
+
+        self.bcx.switch_to_block(then_block);
+        then(self);
+        self.bcx.br(done_block);
+
+        self.bcx.switch_to_block(done_block);
     }
 
     /// Returns the current block.
@@ -2061,13 +2066,18 @@ impl<B: Backend> FunctionCx<'_, B> {
 
     fn build_calldataload_slow(&mut self) {
         self.bcx.add_function_attribute(None, Attribute::Cold, FunctionAttributeLocation::Function);
+        self.bcx.add_function_attribute(
+            None,
+            Attribute::NoInline,
+            FunctionAttributeLocation::Function,
+        );
 
         let src = self.bcx.fn_param(0);
         let remaining = self.bcx.fn_param(1);
         let zero = self.bcx.iconst_256(U256::ZERO);
 
         let has_data = self.bcx.icmp_imm(IntCC::SignedGreaterThan, remaining, 0);
-        let r = self.lazy_select(
+        let r = self.if_else(
             has_data,
             self.word_type,
             |this| {

--- a/crates/revmc-codegen/src/compiler/translate/peephole.rs
+++ b/crates/revmc-codegen/src/compiler/translate/peephole.rs
@@ -31,7 +31,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             op::SIGNEXTEND => self.peephole_signextend(),
             op::BYTE => self.peephole_byte(),
 
-            op::CALLDATALOAD | op::SLOAD => self.peephole_load(data.opcode),
+            op::SLOAD => self.peephole_load(data.opcode),
 
             op::KECCAK256 => self.peephole_keccak256(),
             op::RETURN | op::REVERT => self.peephole_return(data.opcode),
@@ -283,17 +283,12 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         {
             let builtin = match op {
                 op::SLOAD => Builtin::SloadC,
-                op::CALLDATALOAD => Builtin::CallDataLoadC,
                 _ => unreachable!(),
             };
             let sp = self.sp_from_top(1);
             let offset = self.bcx.iconst(self.isize_type, offset as i64);
             let args = &[self.ecx, sp, offset];
-            if op == op::CALLDATALOAD {
-                let _ = self.call_builtin(builtin, args);
-            } else {
-                self.call_fallible_builtin(builtin, args);
-            }
+            self.call_fallible_builtin(builtin, args);
             // Builtin wrote output to sp; reload into virtual stack.
             let off = self.section_len_offset - 1;
             let value = self.load_word(sp, "builtin.out");

--- a/crates/revmc-codegen/src/tests/runner.rs
+++ b/crates/revmc-codegen/src/tests/runner.rs
@@ -501,6 +501,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
         }
         if let Some(modify_ecx) = modify_ecx {
             modify_ecx(ecx);
+            ecx.refresh_memory_cache();
         }
 
         // Interpreter - run via instruction table

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -111,8 +111,10 @@ pub struct EvmContext<'a> {
     /// Set to `None` when no inspector is active.
     #[doc(hidden)]
     pub on_log: Option<&'a mut (dyn FnMut(&Log) + 'a)>,
-    /// The size of the call input data, cached for CALLDATASIZE.
+    /// The size of the call input data.
     pub calldatasize: usize,
+    /// Cached base pointer for the current call input data.
+    pub calldata_base: *const u8,
     /// The result set by a builtin before exiting via [`revmc_exit`].
     pub exit_result: InstructionResult,
     /// Saved RSP from the entry trampoline, used by [`revmc_exit`] to unwind.
@@ -177,6 +179,7 @@ impl<'a> EvmContext<'a> {
             resume_at,
             bytecode,
             on_log: None,
+            calldata_base: ptr::null(),
             calldatasize,
             exit_result: InstructionResult::Stop,
             exit_sp: ptr::null_mut(),
@@ -193,9 +196,18 @@ impl<'a> EvmContext<'a> {
     /// Must be called after any operation that may resize memory.
     #[inline]
     pub fn refresh_memory_cache(&mut self) {
-        let mut slice = self.memory.context_memory_mut();
-        self.mem_base = slice.as_mut_ptr();
-        self.mem_len = slice.len();
+        {
+            let mut slice = self.memory.context_memory_mut();
+            self.mem_base = slice.as_mut_ptr();
+            self.mem_len = slice.len();
+        }
+
+        let input = &self.input.input;
+        self.calldata_base = if input.is_empty() {
+            ptr::null()
+        } else {
+            input.as_bytes_memory(self.memory).as_ptr()
+        };
     }
 }
 

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1574,37 +1574,6 @@ impl Builder for EvmLlvmBuilder<'_> {
         self.bcx.build_select(cond.into_int_value(), then_value, else_value, "").unwrap()
     }
 
-    fn lazy_select(
-        &mut self,
-        cond: Self::Value,
-        ty: Self::Type,
-        then_value: impl FnOnce(&mut Self) -> Self::Value,
-        else_value: impl FnOnce(&mut Self) -> Self::Value,
-    ) -> Self::Value {
-        let then_block = if let Some(current) = self.current_block() {
-            self.create_block_after(current, "then")
-        } else {
-            self.create_block("then")
-        };
-        let else_block = self.create_block_after(then_block, "else");
-        let done_block = self.create_block_after(else_block, "contd");
-
-        self.brif(cond, then_block, else_block);
-
-        self.switch_to_block(then_block);
-        let then_value = then_value(self);
-        self.br(done_block);
-
-        self.switch_to_block(else_block);
-        let else_value = else_value(self);
-        self.br(done_block);
-
-        self.switch_to_block(done_block);
-        let phi = self.bcx.build_phi(ty, "").unwrap();
-        phi.add_incoming(&[(&then_value, then_block), (&else_value, else_block)]);
-        phi.as_basic_value()
-    }
-
     fn iadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
         self.bcx.build_int_add(lhs.into_int_value(), rhs.into_int_value(), "").unwrap().into()
     }

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1432,6 +1432,24 @@ impl Builder for EvmLlvmBuilder<'_> {
         value
     }
 
+    fn load_invariant_aligned(
+        &mut self,
+        ty: Self::Type,
+        ptr: Self::Value,
+        align: usize,
+        name: &str,
+    ) -> Self::Value {
+        let value = self.load_aligned(ty, ptr, align, name);
+        let metadata = self.cx.metadata_node(&[]);
+        self.current_block()
+            .unwrap()
+            .get_last_instruction()
+            .unwrap()
+            .set_metadata(metadata, self.cx.get_kind_id("invariant.load"))
+            .unwrap();
+        value
+    }
+
     fn store(&mut self, value: Self::Value, ptr: Self::Value) {
         let inst = self.bcx.build_store(ptr.into_pointer_value(), value).unwrap();
         if value.get_type() == self.ty_i256.into() {


### PR DESCRIPTION
Inline `CALLDATALOAD` into generated code instead of routing it through the builtins path. This adds backend support for loading calldata bytes directly from the EVM context while preserving the existing out-of-bounds zero-fill behavior.

The latest update keeps the branch-building helpers local to codegen, uses a noinline cold IR helper for the partial calldata slow path, and refreshes cached context pointers in tests that mutate calldata through `modify_ecx`.

## Benchmarks

Headline numbers vs `main`: jit size +5.6%, opt.s +4.6%, and total compile time +4.9%. The calldata-focused benchmarks improve jit size slightly (`fibonacci-calldata` -0.8%, `factorial` -3.0%), while larger contracts generally regress in code size.

### Codegen statistics

| benchmark          |    unopt.ll |      opt.ll |       opt.s |    jit size |   i256 loads |   i256 stores |   mresize |      spills |      reloads |
|:-------------------|------------:|------------:|------------:|------------:|-------------:|--------------:|----------:|------------:|-------------:|
| fibonacci-calldata |    +11.6% 🔴 |    +23.0% 🔴 |    +20.1% 🔴 |     -0.8% 🟢 |            = |             = |         = |    -60.0% 🟢 |     +50.0% 🔴 |
| factorial          |    +11.9% 🔴 |    +22.7% 🔴 |    +16.3% 🔴 |     -3.0% 🟢 |            = |             = |         = |           = |     +50.0% 🔴 |
| counter            |     +6.4% 🔴 |    +15.3% 🔴 |    +15.0% 🔴 |    +15.2% 🔴 |     +22.2% 🔴 |      +22.2% 🔴 |         = |           - |            - |
| weth               |     +2.0% 🔴 |     +5.6% 🔴 |     +4.1% 🔴 |     +3.5% 🔴 |      +0.4% 🔴 |       +3.4% 🔴 |         = |           = |            = |
| hash_10k           |     +4.2% 🔴 |     +9.0% 🔴 |     +8.7% 🔴 |     +1.3% 🔴 |      +5.9% 🔴 |       +4.8% 🔴 |         = |           - |            - |
| erc20_transfer     |     +0.7% 🔴 |     +1.8% 🔴 |     +1.4% 🔴 |     +1.2% 🔴 |      +0.3% 🔴 |       -0.2% 🟢 |         = |     -9.1% 🟢 |     +84.8% 🔴 |
| usdc_proxy         |     +1.9% 🔴 |     +4.3% 🔴 |     +4.5% 🔴 |     +4.7% 🔴 |      +1.0% 🔴 |       +1.0% 🔴 |         = |    -11.1% 🟢 |     +62.5% 🔴 |
| fiat_token         |     +3.2% 🔴 |     +9.2% 🔴 |     +6.7% 🔴 |     +5.7% 🔴 |      +1.7% 🔴 |       -2.6% 🟢 |         = |     -4.7% 🟢 |    +291.4% 🔴 |
| uniswap_v2_pair    |     +1.5% 🔴 |     +4.0% 🔴 |     +3.1% 🔴 |     +3.1% 🔴 |      +1.1% 🔴 |       -1.1% 🟢 |         = |     -2.3% 🟢 |      +1.4% 🔴 |
| univ2_router       |     +3.7% 🔴 |    +10.2% 🔴 |     +8.1% 🔴 |     +9.5% 🔴 |      +1.0% 🔴 |       -4.0% 🟢 |         = |     -0.6% 🟢 |     -29.8% 🟢 |
| seaport            |     +2.1% 🔴 |     +4.4% 🔴 |     +3.5% 🔴 |     +3.7% 🔴 |      +0.3% 🔴 |       -0.4% 🟢 |         = |     -4.8% 🟢 |      +1.1% 🔴 |
| airdrop            |     +1.7% 🔴 |     +4.6% 🔴 |     +3.9% 🔴 |    +10.0% 🔴 |      +0.5% 🔴 |       -0.8% 🟢 |         = |    -20.5% 🟢 |      +4.0% 🔴 |
| bswap64            |     +3.0% 🔴 |     +5.4% 🔴 |    +15.4% 🔴 |     +6.1% 🔴 |     -51.7% 🟢 |       +6.2% 🔴 |         = |           - |            - |
| bswap64_opt        |     +3.4% 🔴 |     -2.1% 🟢 |     +5.0% 🔴 |     -8.7% 🟢 |     -79.4% 🟢 |      -18.5% 🟢 |         = |   +900.0% 🔴 |   +1200.0% 🔴 |
| eip4788            |    +10.6% 🔴 |    +22.0% 🔴 |    +20.1% 🔴 |    +29.8% 🔴 |     +11.1% 🔴 |      +20.0% 🔴 |         = |           = |            = |
| eip2935            |    +11.8% 🔴 |    +25.4% 🔴 |    +24.0% 🔴 |    +25.2% 🔴 |     +28.6% 🔴 |      +33.3% 🔴 |         = |           - |            - |
| curve_stableswap   |     +1.5% 🔴 |     +3.9% 🔴 |     +3.2% 🔴 |    +12.0% 🔴 |      +0.6% 🔴 |       -0.8% 🟢 |         = |    -21.1% 🟢 |    +111.1% 🔴 |
| onchain_lm_v2      |     +0.5% 🔴 |     +1.3% 🔴 |     +1.4% 🔴 |     +1.6% 🔴 |      +0.3% 🔴 |       +0.5% 🔴 |         = |     +1.6% 🔴 |      +1.0% 🔴 |
| burntpix           |     +0.7% 🔴 |     +1.7% 🔴 |     +1.4% 🔴 |     +2.5% 🔴 |      +0.2% 🔴 |       +0.2% 🔴 |         = |     +0.8% 🔴 |      -0.1% 🟢 |
| 0x184e2e0d92…      |     +0.9% 🔴 |     +2.4% 🔴 |     +1.2% 🔴 |     +2.9% 🔴 |      +0.6% 🔴 |       +0.7% 🔴 |         = |     -0.6% 🟢 |      -6.6% 🟢 |
| 0x26f3fa5857…      |     +4.3% 🔴 |    +11.3% 🔴 |     +8.3% 🔴 |     +7.9% 🔴 |      +0.4% 🔴 |       +0.6% 🔴 |         = |     +7.5% 🔴 |     -12.0% 🟢 |
| 0x7497bfab49…      |     +4.5% 🔴 |    +11.9% 🔴 |    +10.1% 🔴 |     +9.0% 🔴 |      +0.4% 🔴 |       +0.5% 🔴 |         = |     -0.5% 🟢 |     -50.5% 🟢 |
| 0x8819f74c38…      |     +4.3% 🔴 |    +10.7% 🔴 |    +14.9% 🔴 |    +13.6% 🔴 |      +0.3% 🔴 |       +0.6% 🔴 |         = |   +206.0% 🔴 |    +526.5% 🔴 |
| 0x9806ed1505…      |     +0.7% 🔴 |     +1.7% 🔴 |     +1.6% 🔴 |     +3.7% 🔴 |      +0.1% 🔴 |       +0.2% 🔴 |         = |           = |      -2.2% 🟢 |
| 0xcc74d4c66f…      |     +1.5% 🔴 |     +3.4% 🔴 |     +2.5% 🔴 |     +4.7% 🔴 |      +0.1% 🔴 |       +0.8% 🔴 |         = |     -6.3% 🟢 |     +25.1% 🔴 |
| 0xd450e90507…      |     +0.8% 🔴 |     +1.8% 🔴 |     +2.2% 🔴 |     +3.0% 🔴 |      +0.1% 🔴 |       +0.5% 🔴 |         = |     -4.8% 🟢 |      -0.2% 🟢 |
| 0xfbbee2ff80…      |     +1.5% 🔴 |     +3.5% 🔴 |     +2.5% 🔴 |     +4.7% 🔴 |      +0.2% 🔴 |       +0.8% 🔴 |         = |     -5.6% 🟢 |     +23.1% 🔴 |
| 0xfc5900eac5…      |     +0.6% 🔴 |     +1.5% 🔴 |     +1.5% 🔴 |     +2.3% 🔴 |      +0.3% 🔴 |       +0.3% 🔴 |         = |     +0.8% 🔴 |      -0.8% 🟢 |
| **TOTAL**          | **+2.0% 🔴** | **+5.0% 🔴** | **+4.6% 🔴** | **+5.6% 🔴** |  **+0.3% 🔴** |         **=** |     **=** | **+5.9% 🔴** | **+16.3% 🔴** |

<details><summary>Full details</summary>

| benchmark          |                          unopt.ll |                          opt.ll |                             opt.s |                           jit size |                    i256 loads |             i256 stores |               mresize |                      spills |                        reloads |
|:-------------------|----------------------------------:|--------------------------------:|----------------------------------:|-----------------------------------:|------------------------------:|------------------------:|----------------------:|----------------------------:|-------------------------------:|
| fibonacci-calldata |            370<br>413<br>+11.6% 🔴 |          126<br>155<br>+23.0% 🔴 |            354<br>425<br>+20.1% 🔴 |          400 B<br>397 B<br>-0.8% 🟢 |                   2<br>2<br>= |             2<br>2<br>= |           2<br>2<br>= |          5<br>2<br>-60.0% 🟢 |             4<br>6<br>+50.0% 🔴 |
| factorial          |            362<br>405<br>+11.9% 🔴 |          128<br>157<br>+22.7% 🔴 |            392<br>456<br>+16.3% 🔴 |          530 B<br>514 B<br>-3.0% 🟢 |                   2<br>2<br>= |             2<br>2<br>= |           2<br>2<br>= |                 5<br>5<br>= |             6<br>9<br>+50.0% 🔴 |
| counter            |           1038<br>1104<br>+6.4% 🔴 |          359<br>414<br>+15.3% 🔴 |            602<br>692<br>+15.0% 🔴 |       914 B<br>1.0 KiB<br>+15.2% 🔴 |           9<br>11<br>+22.2% 🔴 |     9<br>11<br>+22.2% 🔴 |           3<br>3<br>= |                 0<br>0<br>- |                    0<br>0<br>- |
| snailtracer        |         61771<br>61816<br>+0.1% 🔴 |       27714<br>27755<br>+0.1% 🔴 |         47245<br>47299<br>+0.1% 🔴 |        125.8 KiB<br>125.8 KiB<br>= |       1540<br>1541<br>+0.1% 🔴 |       2172<br>2173<br>= |       452<br>452<br>= |               29<br>29<br>= |                600<br>600<br>= |
| weth               |         13355<br>13626<br>+2.0% 🔴 |         4360<br>4605<br>+5.6% 🔴 |           7030<br>7319<br>+4.1% 🔴 |    20.8 KiB<br>21.5 KiB<br>+3.5% 🔴 |         267<br>268<br>+0.4% 🔴 |   349<br>361<br>+3.4% 🔴 |         35<br>35<br>= |               13<br>13<br>= |                  28<br>28<br>= |
| hash_10k           |           1036<br>1079<br>+4.2% 🔴 |           376<br>410<br>+9.0% 🔴 |             715<br>777<br>+8.7% 🔴 |      1.6 KiB<br>1.7 KiB<br>+1.3% 🔴 |           17<br>18<br>+5.9% 🔴 |     21<br>22<br>+4.8% 🔴 |           6<br>6<br>= |                 0<br>0<br>- |                    0<br>0<br>- |
| erc20_transfer     |         14652<br>14760<br>+0.7% 🔴 |         5673<br>5777<br>+1.8% 🔴 |         10766<br>10921<br>+1.4% 🔴 |    27.8 KiB<br>28.2 KiB<br>+1.2% 🔴 |         309<br>310<br>+0.3% 🔴 |   452<br>451<br>-0.2% 🟢 |         53<br>53<br>= |         11<br>10<br>-9.1% 🟢 |           33<br>61<br>+84.8% 🔴 |
| push0_proxy        |                   371<br>371<br>= |                 183<br>183<br>= |                   339<br>339<br>= |                633 B<br>633 B<br>= |                   1<br>1<br>= |           15<br>15<br>= |           0<br>0<br>- |                 0<br>0<br>- |                    0<br>0<br>- |
| usdc_proxy         |           7446<br>7588<br>+1.9% 🔴 |         2914<br>3040<br>+4.3% 🔴 |           5085<br>5316<br>+4.5% 🔴 |    11.8 KiB<br>12.4 KiB<br>+4.7% 🔴 |         104<br>105<br>+1.0% 🔴 |   196<br>198<br>+1.0% 🔴 |         22<br>22<br>= |          9<br>8<br>-11.1% 🟢 |            8<br>13<br>+62.5% 🔴 |
| fiat_token         |         82413<br>85081<br>+3.2% 🔴 |       29357<br>32049<br>+9.2% 🔴 |         49530<br>52847<br>+6.7% 🔴 |  153.7 KiB<br>162.4 KiB<br>+5.7% 🔴 |       1803<br>1834<br>+1.7% 🔴 | 2575<br>2507<br>-2.6% 🟢 |       313<br>313<br>= |         86<br>82<br>-4.7% 🟢 |        140<br>548<br>+291.4% 🔴 |
| uniswap_v2_pair    |         46530<br>47223<br>+1.5% 🔴 |       17194<br>17875<br>+4.0% 🔴 |         28601<br>29492<br>+3.1% 🔴 |    87.0 KiB<br>89.7 KiB<br>+3.1% 🔴 |         926<br>936<br>+1.1% 🔴 | 1398<br>1382<br>-1.1% 🟢 |       176<br>176<br>= |         44<br>43<br>-2.3% 🟢 |            69<br>70<br>+1.4% 🔴 |
| univ2_router       |         87397<br>90662<br>+3.7% 🔴 |      32338<br>35628<br>+10.2% 🔴 |         51399<br>55571<br>+8.1% 🔴 |  165.1 KiB<br>180.7 KiB<br>+9.5% 🔴 |       2061<br>2082<br>+1.0% 🔴 | 2819<br>2707<br>-4.0% 🟢 |       362<br>362<br>= |       169<br>168<br>-0.6% 🟢 |         547<br>384<br>-29.8% 🟢 |
| seaport            |       145378<br>148491<br>+2.1% 🔴 |       64808<br>67675<br>+4.4% 🔴 |       112445<br>116429<br>+3.5% 🔴 |  331.6 KiB<br>343.8 KiB<br>+3.7% 🔴 |       4577<br>4590<br>+0.3% 🔴 | 5099<br>5080<br>-0.4% 🟢 |       866<br>866<br>= |       228<br>217<br>-4.8% 🟢 |        3958<br>4000<br>+1.1% 🔴 |
| airdrop            |         28825<br>29320<br>+1.7% 🔴 |       10991<br>11496<br>+4.6% 🔴 |         18680<br>19406<br>+3.9% 🔴 |   48.5 KiB<br>53.4 KiB<br>+10.0% 🔴 |         575<br>578<br>+0.5% 🔴 |   861<br>854<br>-0.8% 🟢 |       100<br>100<br>= |        39<br>31<br>-20.5% 🟢 |          224<br>233<br>+4.0% 🔴 |
| bswap64            |           2195<br>2260<br>+3.0% 🔴 |           576<br>607<br>+5.4% 🔴 |           887<br>1024<br>+15.4% 🔴 |      2.2 KiB<br>2.3 KiB<br>+6.1% 🔴 |          29<br>14<br>-51.7% 🟢 |     32<br>34<br>+6.2% 🔴 |           6<br>6<br>= |                 0<br>9<br>- |                   0<br>13<br>- |
| bswap64_opt        |           1917<br>1982<br>+3.4% 🔴 |           584<br>572<br>-2.1% 🟢 |           1043<br>1095<br>+5.0% 🔴 |      2.8 KiB<br>2.5 KiB<br>-8.7% 🟢 |           34<br>7<br>-79.4% 🟢 |    54<br>44<br>-18.5% 🟢 |           8<br>8<br>= |        2<br>20<br>+900.0% 🔴 |          2<br>26<br>+1200.0% 🔴 |
| eip4788            |            614<br>679<br>+10.6% 🔴 |          241<br>294<br>+22.0% 🔴 |            473<br>568<br>+20.1% 🔴 |         764 B<br>992 B<br>+29.8% 🔴 |           9<br>10<br>+11.1% 🔴 |    10<br>12<br>+20.0% 🔴 |           2<br>2<br>= |                 1<br>1<br>= |                    1<br>1<br>= |
| eip2935            |            559<br>625<br>+11.8% 🔴 |          213<br>267<br>+25.4% 🔴 |            463<br>574<br>+24.0% 🔴 |         794 B<br>994 B<br>+25.2% 🔴 |            7<br>9<br>+28.6% 🔴 |      6<br>8<br>+33.3% 🔴 |           2<br>2<br>= |                 0<br>4<br>- |                    0<br>7<br>- |
| curve_stableswap   |         24115<br>24486<br>+1.5% 🔴 |         9436<br>9803<br>+3.9% 🔴 |         16631<br>17169<br>+3.2% 🔴 |   29.7 KiB<br>33.3 KiB<br>+12.0% 🔴 |         526<br>529<br>+0.6% 🔴 |   827<br>820<br>-0.8% 🟢 |         50<br>50<br>= |        19<br>15<br>-21.1% 🟢 |          27<br>57<br>+111.1% 🔴 |
| onchain_lm_v2      |         65644<br>65995<br>+0.5% 🔴 |       24072<br>24378<br>+1.3% 🔴 |         43717<br>44337<br>+1.4% 🔴 |  111.8 KiB<br>113.6 KiB<br>+1.6% 🔴 |       1369<br>1373<br>+0.3% 🔴 | 1654<br>1662<br>+0.5% 🔴 |       169<br>169<br>= |         61<br>62<br>+1.6% 🔴 |          289<br>292<br>+1.0% 🔴 |
| burntpix           |       226843<br>228532<br>+0.7% 🔴 |       89254<br>90771<br>+1.7% 🔴 |       148816<br>150847<br>+1.4% 🔴 |  240.2 KiB<br>246.1 KiB<br>+2.5% 🔴 |       5723<br>5734<br>+0.2% 🔴 | 6745<br>6760<br>+0.2% 🔴 |     1030<br>1030<br>= |       358<br>361<br>+0.8% 🔴 |        3374<br>3371<br>-0.1% 🟢 |
| 0x184e2e0d92…      |       138819<br>140035<br>+0.9% 🔴 |       43852<br>44915<br>+2.4% 🔴 |         74687<br>75604<br>+1.2% 🔴 |  241.9 KiB<br>249.0 KiB<br>+2.9% 🔴 |       3125<br>3143<br>+0.6% 🔴 | 4732<br>4765<br>+0.7% 🔴 |       253<br>253<br>= |       161<br>160<br>-0.6% 🟢 |        1856<br>1733<br>-6.6% 🟢 |
| 0x26f3fa5857…      |       150890<br>157332<br>+4.3% 🔴 |      50065<br>55739<br>+11.3% 🔴 |         88699<br>96080<br>+8.3% 🔴 |  320.2 KiB<br>345.7 KiB<br>+7.9% 🔴 |       3797<br>3811<br>+0.4% 🔴 | 5088<br>5119<br>+0.6% 🔴 |       832<br>832<br>= |       186<br>200<br>+7.5% 🔴 |         751<br>661<br>-12.0% 🟢 |
| 0x7497bfab49…      |       151235<br>158076<br>+4.5% 🔴 |      50172<br>56151<br>+11.9% 🔴 |        87776<br>96603<br>+10.1% 🔴 |  318.5 KiB<br>347.1 KiB<br>+9.0% 🔴 |       3808<br>3822<br>+0.4% 🔴 | 5077<br>5103<br>+0.5% 🔴 |       823<br>823<br>= |       205<br>204<br>-0.5% 🟢 |        1375<br>680<br>-50.5% 🟢 |
| 0x8819f74c38…      |       160455<br>167275<br>+4.3% 🔴 |      56591<br>62654<br>+10.7% 🔴 |       95933<br>110262<br>+14.9% 🔴 | 324.5 KiB<br>368.7 KiB<br>+13.6% 🔴 |       4110<br>4122<br>+0.3% 🔴 | 4911<br>4940<br>+0.6% 🔴 |       864<br>864<br>= |      84<br>257<br>+206.0% 🔴 |       562<br>3521<br>+526.5% 🔴 |
| 0x9806ed1505…      |       127930<br>128768<br>+0.7% 🔴 |       45614<br>46380<br>+1.7% 🔴 |         68219<br>69342<br>+1.6% 🔴 |  203.8 KiB<br>211.4 KiB<br>+3.7% 🔴 |       2585<br>2587<br>+0.1% 🔴 | 3453<br>3461<br>+0.2% 🔴 |       402<br>402<br>= |             268<br>268<br>= |          812<br>794<br>-2.2% 🟢 |
| 0xcc74d4c66f…      |       131624<br>133622<br>+1.5% 🔴 |       47929<br>49580<br>+3.4% 🔴 |         75179<br>77063<br>+2.5% 🔴 |  228.9 KiB<br>239.7 KiB<br>+4.7% 🔴 |       2675<br>2679<br>+0.1% 🔴 | 3449<br>3476<br>+0.8% 🔴 |       663<br>663<br>= |       142<br>133<br>-6.3% 🟢 |         773<br>967<br>+25.1% 🔴 |
| 0xd450e90507…      |       145835<br>146988<br>+0.8% 🔴 |       53262<br>54235<br>+1.8% 🔴 |         81626<br>83461<br>+2.2% 🔴 |  260.8 KiB<br>268.5 KiB<br>+3.0% 🔴 |       2895<br>2899<br>+0.1% 🔴 | 4360<br>4381<br>+0.5% 🔴 |       974<br>974<br>= |       270<br>257<br>-4.8% 🟢 |          405<br>404<br>-0.2% 🟢 |
| 0xfbbee2ff80…      |       130152<br>132150<br>+1.5% 🔴 |       47438<br>49093<br>+3.5% 🔴 |         74390<br>76262<br>+2.5% 🔴 |  226.5 KiB<br>237.2 KiB<br>+4.7% 🔴 |       2645<br>2650<br>+0.2% 🔴 | 3413<br>3442<br>+0.8% 🔴 |       659<br>659<br>= |       143<br>135<br>-5.6% 🟢 |         776<br>955<br>+23.1% 🔴 |
| 0xfc5900eac5…      |       101755<br>102330<br>+0.6% 🔴 |       34269<br>34774<br>+1.5% 🔴 |         48966<br>49677<br>+1.5% 🔴 |  148.5 KiB<br>151.9 KiB<br>+2.3% 🔴 |       1959<br>1964<br>+0.3% 🔴 | 2766<br>2774<br>+0.3% 🔴 |       295<br>295<br>= |       130<br>131<br>+0.8% 🔴 |          611<br>606<br>-0.8% 🟢 |
| **TOTAL**          | **2051526<br>2093074<br>+2.0% 🔴** | **750089<br>787432<br>+5.0% 🔴** | **1240688<br>1297257<br>+4.6% 🔴** |  **3.6 MiB<br>3.8 MiB<br>+5.6% 🔴** | **47489<br>47631<br>+0.3% 🔴** | **62547<br>62566<br>=** | **9424<br>9424<br>=** | **2668<br>2825<br>+5.9% 🔴** | **17231<br>20040<br>+16.3% 🔴** |

</details>

### Compile times

| benchmark          |       total |       parse |   translate |    finalize |     codegen |
|:-------------------|------------:|------------:|------------:|------------:|------------:|
| fibonacci-calldata |    +13.2% 🔴 |     -6.0% 🟢 |    -22.5% 🟢 |    +14.3% 🔴 |    +19.2% 🔴 |
| factorial          |     +4.6% 🔴 |    -12.9% 🟢 |    -22.2% 🟢 |     +5.1% 🔴 |     +8.7% 🔴 |
| counter            |    +15.1% 🔴 |    -14.6% 🟢 |     +5.0% 🔴 |    +15.5% 🔴 |    +17.9% 🔴 |
| snailtracer        |     -6.4% 🟢 |     +3.2% 🔴 |     -1.3% 🟢 |     -5.7% 🟢 |     -7.5% 🟢 |
| hash_10k           |     +9.7% 🔴 |     +6.2% 🔴 |     -0.6% 🟢 |    +10.2% 🔴 |     +9.8% 🔴 |
| erc20_transfer     |     -1.1% 🟢 |     -3.4% 🟢 |     -6.9% 🟢 |     -0.8% 🟢 |     -1.2% 🟢 |
| push0_proxy        |     -6.9% 🟢 |     -7.3% 🟢 |     -9.5% 🟢 |     -5.8% 🟢 |     -8.4% 🟢 |
| uniswap_v2_pair    |     -1.5% 🟢 |     -2.9% 🟢 |     -7.7% 🟢 |     -2.7% 🟢 |     +0.6% 🔴 |
| univ2_router       |     +4.9% 🔴 |     -6.2% 🟢 |     -4.7% 🟢 |     +6.9% 🔴 |     +2.3% 🔴 |
| seaport            |     +3.8% 🔴 |     -3.8% 🟢 |     -3.5% 🟢 |     +0.2% 🔴 |    +11.0% 🔴 |
| airdrop            |     +6.0% 🔴 |     +0.2% 🔴 |     +2.0% 🔴 |     +5.8% 🔴 |     +6.8% 🔴 |
| bswap64            |    +24.2% 🔴 |     -1.7% 🟢 |     +2.1% 🔴 |    +25.9% 🔴 |    +25.6% 🔴 |
| bswap64_opt        |     +6.8% 🔴 |     -1.6% 🟢 |     -5.2% 🟢 |     +6.2% 🔴 |     +9.2% 🔴 |
| eip4788            |    +13.7% 🔴 |     -3.3% 🟢 |     -0.9% 🟢 |    +11.7% 🔴 |    +20.1% 🔴 |
| eip2935            |    +30.6% 🔴 |     +2.5% 🔴 |    +12.8% 🔴 |    +33.0% 🔴 |    +30.3% 🔴 |
| curve_stableswap   |     +1.6% 🔴 |     -6.6% 🟢 |     +0.3% 🔴 |     +2.2% 🔴 |     +0.9% 🔴 |
| burntpix           |     +0.6% 🔴 |     -2.1% 🟢 |     -5.6% 🟢 |     -0.6% 🟢 |     +3.0% 🔴 |
| 0x184e2e0d92…      |     +4.5% 🔴 |     -6.2% 🟢 |     -3.0% 🟢 |     +4.8% 🔴 |     +4.5% 🔴 |
| 0x26f3fa5857…      |    +15.3% 🔴 |     -3.3% 🟢 |     +2.2% 🔴 |    +15.9% 🔴 |    +15.3% 🔴 |
| 0x7497bfab49…      |    +16.1% 🔴 |     +0.3% 🔴 |     -4.1% 🟢 |    +17.0% 🔴 |    +15.6% 🔴 |
| 0x8819f74c38…      |    +15.6% 🔴 |     +5.2% 🔴 |    +10.2% 🔴 |    +14.8% 🔴 |    +17.0% 🔴 |
| 0x9806ed1505…      |     +1.5% 🔴 |     +3.9% 🔴 |    -12.8% 🟢 |     +1.1% 🔴 |     +2.6% 🔴 |
| 0xcc74d4c66f…      |     +2.7% 🔴 |     +0.2% 🔴 |     -6.2% 🟢 |     +3.4% 🔴 |     +1.8% 🔴 |
| 0xfc5900eac5…      |     +2.5% 🔴 |     +0.9% 🔴 |     -7.0% 🟢 |     +2.9% 🔴 |     +2.2% 🔴 |
| **TOTAL**          | **+4.9% 🔴** | **-1.8% 🟢** | **-2.3% 🟢** | **+4.6% 🔴** | **+5.8% 🔴** |

<details><summary>Full compile times</summary>

| benchmark          |                             total |                             parse |                         translate |                          finalize |                           codegen |
|:-------------------|----------------------------------:|----------------------------------:|----------------------------------:|----------------------------------:|----------------------------------:|
| fibonacci-calldata |      9.82ms<br>11.1ms<br>+13.2% 🔴 |     172.8µs<br>162.4µs<br>-6.0% 🟢 |    627.1µs<br>485.8µs<br>-22.5% 🟢 |      5.88ms<br>6.72ms<br>+14.3% 🔴 |      3.15ms<br>3.75ms<br>+19.2% 🔴 |
| factorial          |       11.0ms<br>11.5ms<br>+4.6% 🔴 |    178.5µs<br>155.4µs<br>-12.9% 🟢 |    572.6µs<br>445.7µs<br>-22.2% 🟢 |       6.50ms<br>6.83ms<br>+5.1% 🔴 |       3.75ms<br>4.08ms<br>+8.7% 🔴 |
| counter            |      14.1ms<br>16.3ms<br>+15.1% 🔴 |    369.3µs<br>315.2µs<br>-14.6% 🟢 |     611.9µs<br>642.8µs<br>+5.0% 🔴 |      8.27ms<br>9.55ms<br>+15.5% 🔴 |      4.88ms<br>5.75ms<br>+17.9% 🔴 |
| snailtracer        |       2.003s<br>1.875s<br>-6.4% 🟢 |       8.02ms<br>8.27ms<br>+3.2% 🔴 |       12.1ms<br>11.9ms<br>-1.3% 🟢 |       1.149s<br>1.083s<br>-5.7% 🟢 |     834.2ms<br>771.6ms<br>-7.5% 🟢 |
| weth               |     195.9ms<br>202.3ms<br>+3.3% 🔴 |       2.07ms<br>2.11ms<br>+2.1% 🔴 |       2.91ms<br>2.89ms<br>-0.9% 🟢 |     114.6ms<br>118.6ms<br>+3.5% 🔴 |       76.4ms<br>78.7ms<br>+3.1% 🔴 |
| hash_10k           |       19.2ms<br>21.1ms<br>+9.7% 🔴 |     298.2µs<br>316.6µs<br>+6.2% 🔴 |     671.8µs<br>667.9µs<br>-0.6% 🟢 |      11.5ms<br>12.7ms<br>+10.2% 🔴 |       6.71ms<br>7.37ms<br>+9.8% 🔴 |
| erc20_transfer     |     370.5ms<br>366.5ms<br>-1.1% 🟢 |       2.30ms<br>2.22ms<br>-3.4% 🟢 |       3.38ms<br>3.15ms<br>-6.9% 🟢 |     216.0ms<br>214.2ms<br>-0.8% 🟢 |     148.8ms<br>147.0ms<br>-1.2% 🟢 |
| push0_proxy        |       9.99ms<br>9.30ms<br>-6.9% 🟢 |     158.4µs<br>146.8µs<br>-7.3% 🟢 |     493.2µs<br>446.2µs<br>-9.5% 🟢 |       5.92ms<br>5.58ms<br>-5.8% 🟢 |       3.42ms<br>3.13ms<br>-8.4% 🟢 |
| usdc_proxy         |     121.4ms<br>126.2ms<br>+3.9% 🔴 |       1.42ms<br>1.42ms<br>-0.1% 🟢 |       1.96ms<br>1.95ms<br>-0.2% 🟢 |       72.8ms<br>76.2ms<br>+4.6% 🔴 |       45.3ms<br>46.6ms<br>+2.9% 🔴 |
| fiat_token         |       1.580s<br>1.625s<br>+2.8% 🔴 |       14.7ms<br>14.4ms<br>-1.8% 🟢 |       15.4ms<br>15.4ms<br>+0.5% 🔴 |     939.0ms<br>970.3ms<br>+3.3% 🔴 |     611.4ms<br>625.2ms<br>+2.3% 🔴 |
| uniswap_v2_pair    |     787.9ms<br>775.9ms<br>-1.5% 🟢 |       7.12ms<br>6.91ms<br>-2.9% 🟢 |       9.69ms<br>8.95ms<br>-7.7% 🟢 |     463.8ms<br>451.1ms<br>-2.7% 🟢 |     307.3ms<br>308.9ms<br>+0.6% 🔴 |
| univ2_router       |       1.666s<br>1.748s<br>+4.9% 🔴 |       14.9ms<br>13.9ms<br>-6.2% 🟢 |       17.5ms<br>16.6ms<br>-4.7% 🟢 |      988.5ms<br>1.057s<br>+6.9% 🔴 |     645.0ms<br>660.1ms<br>+2.3% 🔴 |
| seaport            |       4.301s<br>4.463s<br>+3.8% 🔴 |       20.8ms<br>20.0ms<br>-3.8% 🟢 |       30.1ms<br>29.0ms<br>-3.5% 🟢 |       2.798s<br>2.803s<br>+0.2% 🔴 |      1.452s<br>1.611s<br>+11.0% 🔴 |
| airdrop            |     559.0ms<br>592.6ms<br>+6.0% 🔴 |       4.54ms<br>4.55ms<br>+0.2% 🔴 |       5.75ms<br>5.86ms<br>+2.0% 🔴 |     369.3ms<br>390.6ms<br>+5.8% 🔴 |     179.4ms<br>191.6ms<br>+6.8% 🔴 |
| bswap64            |      21.6ms<br>26.8ms<br>+24.2% 🔴 |     503.2µs<br>494.9µs<br>-1.7% 🟢 |     887.0µs<br>905.3µs<br>+2.1% 🔴 |      12.9ms<br>16.2ms<br>+25.9% 🔴 |      7.35ms<br>9.23ms<br>+25.6% 🔴 |
| bswap64_opt        |       25.8ms<br>27.6ms<br>+6.8% 🔴 |     427.4µs<br>420.4µs<br>-1.6% 🟢 |     836.2µs<br>793.0µs<br>-5.2% 🟢 |       15.1ms<br>16.0ms<br>+6.2% 🔴 |       9.47ms<br>10.3ms<br>+9.2% 🔴 |
| eip4788            |      12.6ms<br>14.4ms<br>+13.7% 🔴 |     231.8µs<br>224.2µs<br>-3.3% 🟢 |     567.6µs<br>562.5µs<br>-0.9% 🟢 |      7.48ms<br>8.36ms<br>+11.7% 🔴 |      4.36ms<br>5.23ms<br>+20.1% 🔴 |
| eip2935            |      11.4ms<br>14.9ms<br>+30.6% 🔴 |     198.0µs<br>203.0µs<br>+2.5% 🔴 |    514.0µs<br>580.0µs<br>+12.8% 🔴 |      6.70ms<br>8.90ms<br>+33.0% 🔴 |      4.01ms<br>5.22ms<br>+30.3% 🔴 |
| curve_stableswap   |     439.7ms<br>446.8ms<br>+1.6% 🔴 |       4.00ms<br>3.74ms<br>-6.6% 🟢 |       4.86ms<br>4.88ms<br>+0.3% 🔴 |     273.9ms<br>279.9ms<br>+2.2% 🔴 |     156.9ms<br>158.3ms<br>+0.9% 🔴 |
| onchain_lm_v2      |       1.650s<br>1.649s<br>-0.1% 🟢 |     231.7ms<br>224.7ms<br>-3.0% 🟢 |       14.1ms<br>14.6ms<br>+3.4% 🔴 |     833.4ms<br>848.0ms<br>+1.8% 🔴 |     571.0ms<br>561.7ms<br>-1.6% 🟢 |
| burntpix           |       5.783s<br>5.820s<br>+0.6% 🔴 |       34.2ms<br>33.5ms<br>-2.1% 🟢 |       43.4ms<br>41.0ms<br>-5.6% 🟢 |       3.632s<br>3.610s<br>-0.6% 🟢 |       2.073s<br>2.135s<br>+3.0% 🔴 |
| 0x184e2e0d92…      |       2.670s<br>2.790s<br>+4.5% 🔴 |       26.4ms<br>24.7ms<br>-6.2% 🟢 |       28.6ms<br>27.7ms<br>-3.0% 🟢 |       1.618s<br>1.695s<br>+4.8% 🔴 |      997.5ms<br>1.042s<br>+4.5% 🔴 |
| 0x26f3fa5857…      |      2.880s<br>3.322s<br>+15.3% 🔴 |       23.3ms<br>22.5ms<br>-3.3% 🟢 |       29.2ms<br>29.9ms<br>+2.2% 🔴 |      1.678s<br>1.944s<br>+15.9% 🔴 |      1.149s<br>1.325s<br>+15.3% 🔴 |
| 0x7497bfab49…      |      2.865s<br>3.325s<br>+16.1% 🔴 |       23.4ms<br>23.4ms<br>+0.3% 🔴 |       31.7ms<br>30.4ms<br>-4.1% 🟢 |      1.674s<br>1.958s<br>+17.0% 🔴 |      1.136s<br>1.313s<br>+15.6% 🔴 |
| 0x8819f74c38…      |      3.498s<br>4.042s<br>+15.6% 🔴 |       24.0ms<br>25.3ms<br>+5.2% 🔴 |      31.8ms<br>35.0ms<br>+10.2% 🔴 |      2.116s<br>2.429s<br>+14.8% 🔴 |      1.327s<br>1.553s<br>+17.0% 🔴 |
| 0x9806ed1505…      |       2.832s<br>2.874s<br>+1.5% 🔴 |       19.5ms<br>20.3ms<br>+3.9% 🔴 |      28.5ms<br>24.8ms<br>-12.8% 🟢 |       1.789s<br>1.808s<br>+1.1% 🔴 |      995.5ms<br>1.021s<br>+2.6% 🔴 |
| 0xcc74d4c66f…      |       2.855s<br>2.931s<br>+2.7% 🔴 |       19.7ms<br>19.7ms<br>+0.2% 🔴 |       27.6ms<br>25.9ms<br>-6.2% 🟢 |       1.770s<br>1.830s<br>+3.4% 🔴 |       1.037s<br>1.056s<br>+1.8% 🔴 |
| 0xd450e90507…      |       3.103s<br>3.199s<br>+3.1% 🔴 |       20.9ms<br>21.2ms<br>+1.5% 🔴 |       27.8ms<br>27.5ms<br>-1.3% 🟢 |       1.876s<br>1.939s<br>+3.4% 🔴 |       1.178s<br>1.212s<br>+2.9% 🔴 |
| 0xfbbee2ff80…      |       2.765s<br>2.880s<br>+4.2% 🔴 |       19.6ms<br>19.7ms<br>+0.7% 🔴 |       25.2ms<br>26.0ms<br>+2.9% 🔴 |       1.721s<br>1.795s<br>+4.3% 🔴 |      998.9ms<br>1.039s<br>+4.0% 🔴 |
| 0xfc5900eac5…      |       1.864s<br>1.911s<br>+2.5% 🔴 |       15.7ms<br>15.8ms<br>+0.9% 🔴 |       21.0ms<br>19.5ms<br>-7.0% 🟢 |       1.152s<br>1.185s<br>+2.9% 🔴 |     675.6ms<br>690.2ms<br>+2.2% 🔴 |
| **TOTAL**          | **44.925s<br>47.117s<br>+4.9% 🔴** | **540.8ms<br>531.1ms<br>-1.8% 🟢** | **418.4ms<br>408.6ms<br>-2.3% 🟢** | **27.325s<br>28.576s<br>+4.6% 🔴** | **16.642s<br>17.601s<br>+5.8% 🔴** |

</details>

