### PR TITLE
Resolve stack-balance return jumps

### DIFF
--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -321,6 +321,17 @@ fn push_unique(targets: &mut SmallVec<[Inst; 4]>, target: Inst) {
     }
 }
 
+fn push_unique_state(states: &mut Vec<Vec<AbsValue>>, state: &[AbsValue]) {
+    let start = state.len().saturating_sub(MAX_ABS_STACK_DEPTH);
+    let state = &state[start..];
+    if !states.iter().any(|existing| existing == state) {
+        states.push(state.to_vec());
+    }
+}
+
+type DiscoveredEdges = IndexVec<Block, SmallVec<[Block; 4]>>;
+type EdgeStates = IndexVec<Block, Vec<Vec<AbsValue>>>;
+
 /// CFG for abstract interpretation.
 #[derive(Default)]
 pub(crate) struct Cfg {
@@ -631,7 +642,8 @@ impl Bytecode<'_> {
         }
 
         let mut const_sets = ConstSetInterner::new();
-        let (discovered_edges, converged) = self.run_fixpoint(&mut block_states, &mut const_sets);
+        let (discovered_edges, edge_states, converged) =
+            self.run_fixpoint(&mut block_states, &mut const_sets);
 
         // On non-convergence, all fixpoint-derived snapshots are potentially stale.
         // Restore the safe block-local snapshots computed by `block_analysis_local`.
@@ -653,12 +665,13 @@ impl Bytecode<'_> {
             jump_targets.push((jump_inst, target));
         }
 
-        let pcr_jumps = if converged {
-            self.resolve_stack_balance_returns_from_hints(
-                &mut jump_targets,
-                &block_states,
-                &const_sets,
-            )
+        let edge_state_jumps = if converged {
+            self.resolve_jumps_from_edge_states(&mut jump_targets, &edge_states, &const_sets)
+        } else {
+            Vec::new()
+        };
+        let ranked_hint_jumps = if converged {
+            self.resolve_ranked_continuation_jumps(&mut jump_targets, &block_states, &const_sets)
         } else {
             Vec::new()
         };
@@ -678,15 +691,23 @@ impl Bytecode<'_> {
         }
 
         for &(jump_inst, ref target) in &jump_targets {
-            if pcr_jumps.contains(&jump_inst)
-                && let JumpTarget::Resolved(targets) = target
-            {
-                trace!(
-                    %jump_inst,
-                    pc = self.pc(jump_inst),
-                    n_targets = targets.len(),
-                    "resolved via PCR hint"
-                );
+            if let JumpTarget::Resolved(targets) = target {
+                if edge_state_jumps.contains(&jump_inst) {
+                    trace!(
+                        %jump_inst,
+                        pc = self.pc(jump_inst),
+                        n_targets = targets.len(),
+                        "resolved via edge state"
+                    );
+                }
+                if ranked_hint_jumps.contains(&jump_inst) {
+                    trace!(
+                        %jump_inst,
+                        pc = self.pc(jump_inst),
+                        n_targets = targets.len(),
+                        "resolved via ranked hint"
+                    );
+                }
             }
         }
 
@@ -737,15 +758,44 @@ impl Bytecode<'_> {
         }
     }
 
-    /// Resolves stack-balance return blocks using ranked continuation labels from call sites.
+    /// Resolves jumps by replaying blocks from path-sensitive incoming edge states.
     ///
-    /// Solidity often emits nested internal calls as `[..., outer_ret, ..., inner_ret, callee]`
-    /// followed by `JUMP`. The fixpoint can resolve the callee's return to `inner_ret`, but the
-    /// continuation block at `inner_ret` may recover `outer_ret` from a stack shape that was
-    /// merged away to `Top`. This mirrors Gigahorse's possible-call-return ranking in a narrow
-    /// form: labels left on the stack by a static call are ordered from top to bottom, and a
-    /// stack-balance return block for rank N can return to rank N + 1.
-    fn resolve_stack_balance_returns_from_hints(
+    /// The block-level fixpoint joins all predecessors into one entry state, which can erase
+    /// return labels that are still precise on each individual edge. Replaying an unresolved
+    /// jump block from every recorded incoming edge state lets us prove the jump operand without
+    /// assuming anything about the block's opcode shape.
+    fn resolve_jumps_from_edge_states(
+        &mut self,
+        jump_targets: &mut [(Inst, JumpTarget)],
+        edge_states: &EdgeStates,
+        const_sets: &ConstSetInterner,
+    ) -> Vec<Inst> {
+        let mut resolved = Vec::new();
+        for (jump_inst, target) in jump_targets {
+            if !matches!(target, JumpTarget::Top) {
+                continue;
+            }
+            let Some(block) = self.cfg.inst_to_block[*jump_inst] else { continue };
+            if edge_states[block].is_empty() {
+                continue;
+            }
+
+            if let Some(edge_target) =
+                self.resolve_jump_from_all_edge_states(*jump_inst, &edge_states[block], const_sets)
+            {
+                *target = edge_target;
+                resolved.push(*jump_inst);
+            }
+        }
+        resolved
+    }
+
+    /// Resolves continuation jumps from ranked JUMPDEST labels left by static call sites.
+    ///
+    /// If a static call leaves labels ranked as `[..., outer_ret, inner_ret]`, a later
+    /// unresolved jump in `inner_ret` can return to `outer_ret` even when the continuation
+    /// block contains work before the jump.
+    fn resolve_ranked_continuation_jumps(
         &mut self,
         jump_targets: &mut [(Inst, JumpTarget)],
         block_states: &IndexVec<Block, BlockState>,
@@ -805,10 +855,7 @@ impl Bytecode<'_> {
                 continue;
             }
             let Some(block) = self.cfg.inst_to_block[*jump_inst] else { continue };
-            if !matches!(block_states[block], BlockState::Known(_))
-                || !self.is_stack_balance_return_block(block)
-                || hints[block].is_empty()
-            {
+            if !matches!(block_states[block], BlockState::Known(_)) || hints[block].is_empty() {
                 continue;
             }
 
@@ -816,6 +863,77 @@ impl Bytecode<'_> {
             resolved.push(*jump_inst);
         }
         resolved
+    }
+
+    fn resolve_jump_from_all_edge_states(
+        &mut self,
+        jump_inst: Inst,
+        states: &[Vec<AbsValue>],
+        const_sets: &ConstSetInterner,
+    ) -> Option<JumpTarget> {
+        let mut targets = SmallVec::new();
+        let mut invalid = false;
+        for state in states {
+            match self.resolve_jump_from_edge_state(jump_inst, state, const_sets) {
+                JumpTarget::Resolved(edge_targets) => {
+                    for target in edge_targets {
+                        push_unique(&mut targets, target);
+                    }
+                }
+                JumpTarget::Invalid => invalid = true,
+                JumpTarget::Bottom | JumpTarget::Top => return None,
+            }
+        }
+
+        match (targets.is_empty(), invalid) {
+            (false, false) => Some(JumpTarget::Resolved(targets)),
+            (true, true) => Some(JumpTarget::Invalid),
+            _ => None,
+        }
+    }
+
+    fn resolve_jump_from_edge_state(
+        &mut self,
+        jump_inst: Inst,
+        state: &[AbsValue],
+        const_sets: &ConstSetInterner,
+    ) -> JumpTarget {
+        let Some(block) = self.cfg.inst_to_block[jump_inst] else {
+            return JumpTarget::Bottom;
+        };
+        let insts = self.cfg.blocks[block].insts().collect::<SmallVec<[Inst; 16]>>();
+        let old_inputs = insts
+            .iter()
+            .map(|&inst| self.snapshots.inputs[inst].clone())
+            .collect::<SmallVec<[OperandSnapshot; 16]>>();
+        let old_outputs = insts
+            .iter()
+            .map(|&inst| self.snapshots.outputs[inst])
+            .collect::<SmallVec<[Option<AbsValue>; 16]>>();
+        let compiler_gas_used = self.compiler_gas_used;
+
+        let mut stack = state.to_vec();
+        let interpreted = self.interpret_block(insts.iter().copied(), &mut stack);
+        let target = if interpreted {
+            self.snapshots.inputs[jump_inst].last().copied().map_or(JumpTarget::Bottom, |operand| {
+                self.resolve_jump_operand(operand, const_sets)
+            })
+        } else {
+            JumpTarget::Bottom
+        };
+
+        for ((&inst, inputs), output) in insts.iter().zip(old_inputs).zip(old_outputs) {
+            self.snapshots.inputs[inst] = inputs;
+            self.snapshots.outputs[inst] = output;
+        }
+        self.compiler_gas_used = compiler_gas_used;
+
+        target
+    }
+
+    fn block_for_jump_target(&self, target: Inst) -> Option<Block> {
+        let target = self.redirects.get(&target).copied().unwrap_or(target);
+        self.cfg.inst_to_block.get(target).copied().flatten()
     }
 
     fn jumpdest_targets_for_value(
@@ -842,30 +960,10 @@ impl Bytecode<'_> {
         (!targets.is_empty()).then_some(targets)
     }
 
-    fn block_for_jump_target(&self, target: Inst) -> Option<Block> {
-        let target = self.redirects.get(&target).copied().unwrap_or(target);
-        self.cfg.inst_to_block.get(target).copied().flatten()
-    }
-
-    fn is_stack_balance_return_block(&self, bid: Block) -> bool {
-        let block = &self.cfg.blocks[bid];
-        if self.insts[block.terminator()].opcode != op::JUMP {
-            return false;
+    fn record_edge_state(&self, succ: Block, stack: &[AbsValue], edge_states: &mut EdgeStates) {
+        if self.insts[self.cfg.blocks[succ].insts.start].is_jumpdest() {
+            push_unique_state(&mut edge_states[succ], stack);
         }
-
-        block.insts().all(|inst| {
-            matches!(
-                self.insts[inst].opcode,
-                op::JUMPDEST
-                    | op::POP
-                    | op::JUMP
-                    | op::DUP1..=op::DUP16
-                    | op::SWAP1..=op::SWAP16
-                    | op::DUPN
-                    | op::SWAPN
-                    | op::EXCHANGE
-            )
-        })
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -889,7 +987,7 @@ impl Bytecode<'_> {
                 continue;
             }
             let ti = self.pc_to_inst(target_pc);
-            if let Some(tb) = self.cfg.inst_to_block[ti]
+            if let Some(tb) = self.block_for_jump_target(ti)
                 && !discovered[bid].contains(&tb)
             {
                 discovered[bid].push(tb);
@@ -970,22 +1068,22 @@ impl Bytecode<'_> {
 
     /// Run a worklist-based fixpoint to compute abstract block states.
     ///
-    /// Returns `(discovered_edges, converged)`.
+    /// Returns `(discovered_edges, edge_states, converged)`.
     fn run_fixpoint(
         &mut self,
         block_states: &mut IndexVec<Block, BlockState>,
         const_sets: &mut ConstSetInterner,
-    ) -> (IndexVec<Block, SmallVec<[Block; 4]>>, bool) {
+    ) -> (DiscoveredEdges, EdgeStates, bool) {
         let num_blocks = self.cfg.blocks.len();
         let mut worklist = Worklist::new(num_blocks);
         worklist.push(Block::from_usize(0));
 
         // Discovered dynamic-jump target edges per block.
-        let mut discovered: IndexVec<Block, SmallVec<[Block; 4]>> =
-            IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
+        let mut discovered: DiscoveredEdges = IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
         // Reverse map: discovered predecessors per block.
         let mut disc_preds: IndexVec<Block, SmallVec<[Block; 4]>> =
             IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
+        let mut edge_states: EdgeStates = IndexVec::from_vec(vec![Vec::new(); num_blocks]);
 
         let max_iterations = num_blocks * 8;
         let mut iterations = 0;
@@ -1032,6 +1130,7 @@ impl Bytecode<'_> {
 
             // Propagate to static CFG successors and discovered dynamic-jump targets.
             for &succ in block.succs.iter().chain(&discovered[bid]) {
+                self.record_edge_state(succ, &stack_buf, &mut edge_states);
                 if block_states[succ].join(&stack_buf, const_sets) {
                     worklist.push(succ);
                 }
@@ -1043,7 +1142,7 @@ impl Bytecode<'_> {
             msg = if converged { "converged" } else { "did not converge" },
         );
 
-        (discovered, converged)
+        (discovered, edge_states, converged)
     }
 
     /// Interpret a sequence of instructions on the abstract stack.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -315,6 +315,12 @@ impl JumpTarget {
     }
 }
 
+fn push_unique(targets: &mut SmallVec<[Inst; 4]>, target: Inst) {
+    if !targets.contains(&target) {
+        targets.push(target);
+    }
+}
+
 /// CFG for abstract interpretation.
 #[derive(Default)]
 pub(crate) struct Cfg {
@@ -635,7 +641,6 @@ impl Bytecode<'_> {
 
         // After convergence, resolve each dynamic jump from its snapshot operand.
         let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
-        let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
             let target = match self.snapshots.inputs[jump_inst].last() {
                 Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
@@ -645,11 +650,20 @@ impl Bytecode<'_> {
                     JumpTarget::Bottom
                 }
             };
-            if matches!(target, JumpTarget::Top) {
-                has_top_jump = true;
-            }
             jump_targets.push((jump_inst, target));
         }
+
+        let pcr_jumps = if converged {
+            self.resolve_stack_balance_returns_from_hints(
+                &mut jump_targets,
+                &block_states,
+                &const_sets,
+            )
+        } else {
+            Vec::new()
+        };
+
+        let has_top_jump = jump_targets.iter().any(|(_, t)| matches!(t, JumpTarget::Top));
 
         // Invalidate resolutions that may be unsound due to incomplete analysis.
         // When the fixpoint didn't converge, partially-discovered ConstSets may be
@@ -661,6 +675,19 @@ impl Bytecode<'_> {
                 &discovered_edges,
                 local_snapshots,
             );
+        }
+
+        for &(jump_inst, ref target) in &jump_targets {
+            if pcr_jumps.contains(&jump_inst)
+                && let JumpTarget::Resolved(targets) = target
+            {
+                trace!(
+                    %jump_inst,
+                    pc = self.pc(jump_inst),
+                    n_targets = targets.len(),
+                    "resolved via PCR hint"
+                );
+            }
         }
 
         let count = jump_targets
@@ -708,6 +735,137 @@ impl Bytecode<'_> {
             }
             AbsValue::Top => JumpTarget::Top,
         }
+    }
+
+    /// Resolves stack-balance return blocks using ranked continuation labels from call sites.
+    ///
+    /// Solidity often emits nested internal calls as `[..., outer_ret, ..., inner_ret, callee]`
+    /// followed by `JUMP`. The fixpoint can resolve the callee's return to `inner_ret`, but the
+    /// continuation block at `inner_ret` may recover `outer_ret` from a stack shape that was
+    /// merged away to `Top`. This mirrors Gigahorse's possible-call-return ranking in a narrow
+    /// form: labels left on the stack by a static call are ordered from top to bottom, and a
+    /// stack-balance return block for rank N can return to rank N + 1.
+    fn resolve_stack_balance_returns_from_hints(
+        &mut self,
+        jump_targets: &mut [(Inst, JumpTarget)],
+        block_states: &IndexVec<Block, BlockState>,
+        const_sets: &ConstSetInterner,
+    ) -> Vec<Inst> {
+        let mut hints: IndexVec<Block, SmallVec<[Inst; 4]>> =
+            IndexVec::from_vec(vec![SmallVec::new(); self.cfg.blocks.len()]);
+
+        let mut stack = Vec::with_capacity(MAX_ABS_STACK_DEPTH);
+        for bid in self.cfg.blocks.indices() {
+            let block = &self.cfg.blocks[bid];
+            let term_inst = block.terminator();
+            let term = &self.insts[term_inst];
+            if term.opcode != op::JUMP
+                || !term.flags.contains(InstFlags::STATIC_JUMP)
+                || term.flags.contains(InstFlags::INVALID_JUMP)
+            {
+                continue;
+            }
+
+            stack.clear();
+            match &block_states[bid] {
+                BlockState::Known(state) => stack.extend_from_slice(state),
+                BlockState::Bottom => continue,
+            }
+
+            let compiler_gas_used = self.compiler_gas_used;
+            let interpreted = self.interpret_block_without_snapshots(block.insts(), &mut stack);
+            self.compiler_gas_used = compiler_gas_used;
+            if !interpreted {
+                continue;
+            }
+
+            let mut ranks = SmallVec::<[SmallVec<[Inst; 4]>; 4]>::new();
+            for &value in stack.iter().rev() {
+                if let Some(targets) = self.jumpdest_targets_for_value(value, const_sets) {
+                    ranks.push(targets);
+                }
+            }
+
+            for pair in ranks.windows(2) {
+                let [continuations, return_targets] = pair else { unreachable!() };
+                for &continuation in continuations {
+                    let Some(continuation_block) = self.block_for_jump_target(continuation) else {
+                        continue;
+                    };
+                    for &target in return_targets {
+                        push_unique(&mut hints[continuation_block], target);
+                    }
+                }
+            }
+        }
+
+        let mut resolved = Vec::new();
+        for (jump_inst, target) in jump_targets {
+            if !matches!(target, JumpTarget::Top) {
+                continue;
+            }
+            let Some(block) = self.cfg.inst_to_block[*jump_inst] else { continue };
+            if !matches!(block_states[block], BlockState::Known(_))
+                || !self.is_stack_balance_return_block(block)
+                || hints[block].is_empty()
+            {
+                continue;
+            }
+
+            *target = JumpTarget::Resolved(hints[block].clone());
+            resolved.push(*jump_inst);
+        }
+        resolved
+    }
+
+    fn jumpdest_targets_for_value(
+        &self,
+        value: AbsValue,
+        const_sets: &ConstSetInterner,
+    ) -> Option<SmallVec<[Inst; 4]>> {
+        let constants = match value {
+            AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
+            AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
+            AbsValue::Top => return None,
+        };
+
+        let interner = self.u256_interner.borrow();
+        let mut targets = SmallVec::new();
+        for imm in constants {
+            let Ok(pc) = usize::try_from(imm.get(&interner)) else { return None };
+            if !self.is_valid_jump(pc) {
+                return None;
+            }
+            push_unique(&mut targets, self.pc_to_inst(pc));
+        }
+
+        (!targets.is_empty()).then_some(targets)
+    }
+
+    fn block_for_jump_target(&self, target: Inst) -> Option<Block> {
+        let target = self.redirects.get(&target).copied().unwrap_or(target);
+        self.cfg.inst_to_block.get(target).copied().flatten()
+    }
+
+    fn is_stack_balance_return_block(&self, bid: Block) -> bool {
+        let block = &self.cfg.blocks[bid];
+        if self.insts[block.terminator()].opcode != op::JUMP {
+            return false;
+        }
+
+        block.insts().all(|inst| {
+            matches!(
+                self.insts[inst].opcode,
+                op::JUMPDEST
+                    | op::POP
+                    | op::JUMP
+                    | op::DUP1..=op::DUP16
+                    | op::SWAP1..=op::SWAP16
+                    | op::DUPN
+                    | op::SWAPN
+                    | op::EXCHANGE
+            )
+        })
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -898,6 +1056,23 @@ impl Bytecode<'_> {
         insts: impl IntoIterator<Item = Inst>,
         stack: &mut Vec<AbsValue>,
     ) -> bool {
+        self.interpret_block_inner(insts, stack, true)
+    }
+
+    fn interpret_block_without_snapshots(
+        &mut self,
+        insts: impl IntoIterator<Item = Inst>,
+        stack: &mut Vec<AbsValue>,
+    ) -> bool {
+        self.interpret_block_inner(insts, stack, false)
+    }
+
+    fn interpret_block_inner(
+        &mut self,
+        insts: impl IntoIterator<Item = Inst>,
+        stack: &mut Vec<AbsValue>,
+        record_snapshots: bool,
+    ) -> bool {
         for i in insts {
             let inst = &self.insts[i];
             if inst.is_dead_code() {
@@ -909,7 +1084,7 @@ impl Bytecode<'_> {
             let out = out as usize;
 
             // Record pre-instruction input operand snapshot (in stack order, TOS last).
-            if inp > 0 {
+            if record_snapshots && inp > 0 {
                 let start = stack.len().saturating_sub(inp);
                 let snap = &mut self.snapshots.inputs[i];
                 snap.clear();
@@ -1044,7 +1219,9 @@ impl Bytecode<'_> {
 
             // Record post-instruction output snapshot.
             // Skip SWAP/SWAPN/EXCHANGE: they modify two positions and have no single "output".
-            if out > 0 && !matches!(inst.opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
+            if record_snapshots
+                && out > 0
+                && !matches!(inst.opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
             {
                 self.snapshots.outputs[i] = stack.last().copied();
             }
@@ -1469,10 +1646,125 @@ pub(crate) mod tests {
 
         // The wrapper return JUMP (pc=30) remains dynamic because the outer
         // return address is lost to Top during the top-aligned join.
+        // This fixture also exceeds the fixpoint cap, so PCR hints are skipped.
         // Because an unresolved Top jump exists, the conservative invalidation
         // also invalidates the inner return JUMP — any reachable JUMPDEST
         // (including inner's entry) is suspect.
         assert!(bytecode.has_dynamic_jumps, "expected dynamic jumps to remain");
+    }
+
+    #[test]
+    fn nested_call_return_pcr_hint() {
+        // The direct inner call makes the inner function's entry stack join lose
+        // the wrapper's outer return address. The ranked continuation hint can
+        // still recover ret_w -> ret2 from the wrapper call block.
+        let bytecode = analyze_asm(
+            "
+            ; Call through wrapper first.
+            PUSH %ret2
+            PUSH1 0x42
+            PUSH %wrapper
+            JUMP
+        ret2:
+            JUMPDEST
+            ; Direct call to inner after the wrapper returns.
+            PUSH %ret1
+            PUSH %inner
+            JUMP
+        ret1:
+            JUMPDEST
+            POP
+            STOP
+            INVALID
+        wrapper:
+            JUMPDEST
+            PUSH %ret_w
+            PUSH %inner
+            JUMP
+            INVALID
+        ret_w:
+            JUMPDEST
+            POP
+            POP
+            JUMP
+            INVALID
+        inner:
+            JUMPDEST
+            PUSH1 0x42
+            SWAP1
+            JUMP
+        ",
+        );
+
+        assert!(!bytecode.has_dynamic_jumps, "expected all jumps to be resolved");
+
+        let wrapper_return =
+            bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 27 && d.is_jump());
+        let (jump_inst, jump) = wrapper_return.unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert_eq!(bytecode.pc(jump.static_jump_target()), 7);
+
+        let inner_return = bytecode
+            .iter_insts()
+            .find(|(_, d)| d.is_jump() && d.flags.contains(InstFlags::MULTI_JUMP));
+        let (inner_jump, _) = inner_return.unwrap();
+        assert_eq!(bytecode.multi_jump_targets(inner_jump).unwrap().len(), 2);
+        assert_ne!(jump_inst, inner_jump);
+    }
+
+    #[test]
+    fn opaque_wrapper_return_addr_not_pcr_resolved() {
+        // If any caller reaches the wrapper with an opaque outer return address,
+        // the wrapper call block no longer exposes a ranked next continuation.
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATALOAD
+            PUSH %opaque_call
+            JUMPI
+            ; Known caller.
+            PUSH %ret
+            PUSH1 0x42
+            PUSH %wrapper
+            JUMP
+        ret:
+            JUMPDEST
+            STOP
+        opaque_call:
+            JUMPDEST
+            PUSH0
+            MLOAD
+            PUSH1 0x42
+            PUSH %wrapper
+            JUMP
+        wrapper:
+            JUMPDEST
+            PUSH %ret_w
+            PUSH %inner
+            JUMP
+            INVALID
+        ret_w:
+            JUMPDEST
+            POP
+            POP
+            JUMP
+            INVALID
+        inner:
+            JUMPDEST
+            PUSH1 0x42
+            SWAP1
+            JUMP
+        ",
+        );
+
+        let wrapper_return =
+            bytecode.iter_insts().find(|(i, d)| bytecode.pc(*i) == 32 && d.is_jump());
+        let (_, jump) = wrapper_return.unwrap();
+        assert!(
+            !jump.flags.contains(InstFlags::STATIC_JUMP),
+            "wrapper return must stay dynamic with an opaque outer return address"
+        );
+        assert!(bytecode.has_dynamic_jumps);
     }
 
     /// Regression test: deep DUPN on Amsterdam must not cause the abstract interpreter to

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -59,27 +59,6 @@ pub(crate) struct Snapshots {
 }
 
 impl Snapshots {
-    fn join_inputs(&mut self, inst: Inst, incoming: &[AbsValue], sets: &mut ConstSetInterner) {
-        let snap = &mut self.inputs[inst];
-        if snap.is_empty() {
-            snap.extend_from_slice(incoming);
-            return;
-        }
-
-        debug_assert_eq!(snap.len(), incoming.len(), "mismatched snapshot arity at {inst}");
-        for (existing, incoming) in snap.iter_mut().zip(incoming.iter().copied()) {
-            *existing = sets.join(*existing, incoming);
-        }
-    }
-
-    fn join_output(&mut self, inst: Inst, incoming: Option<AbsValue>, sets: &mut ConstSetInterner) {
-        match (&mut self.outputs[inst], incoming) {
-            (slot @ None, Some(value)) => *slot = Some(value),
-            (Some(existing), Some(value)) => *existing = sets.join(*existing, value),
-            _ => {}
-        }
-    }
-
     /// Restores snapshots for the given instructions from a previously saved copy.
     pub(crate) fn restore_from(&mut self, insts: impl Iterator<Item = Inst>, saved: &Self) {
         for inst in insts {
@@ -95,11 +74,6 @@ pub(crate) enum AbsValue {
     Const(U256Imm),
     /// Multiple known constant values (interned, sorted, deduplicated).
     ConstSet(ConstSetIdx),
-    /// The value in block-entry stack slot `k` (0 = bottom of abstract stack at entry).
-    ///
-    /// Context refinement uses this to preserve return-address provenance through
-    /// block-local stack manipulation before resolving it against the context input.
-    EntrySlot(u16),
     /// Top value (unknown concrete value).
     #[default]
     Top,
@@ -111,19 +85,6 @@ impl AbsValue {
         match self {
             Self::Const(v) => Some(v),
             _ => None,
-        }
-    }
-
-    /// Returns `true` if this value carries concrete information.
-    fn is_known(self) -> bool {
-        !matches!(self, Self::Top)
-    }
-
-    /// Resolves `EntrySlot(k)` against the block's input state.
-    fn resolve(self, input: &[Self]) -> Self {
-        match self {
-            Self::EntrySlot(k) => input.get(usize::from(k)).copied().unwrap_or(Self::Top),
-            other => other,
         }
     }
 }
@@ -149,7 +110,6 @@ impl ConstSetInterner {
             AbsValue::Top => None,
             AbsValue::Const(v) => Some(std::slice::from_ref(v)),
             AbsValue::ConstSet(idx) => Some(self.get(*idx)),
-            AbsValue::EntrySlot(_) => None,
         }
     }
 
@@ -166,8 +126,6 @@ impl ConstSetInterner {
     fn join(&mut self, a: AbsValue, b: AbsValue) -> AbsValue {
         match (a, b) {
             (AbsValue::Top, _) | (_, AbsValue::Top) => AbsValue::Top,
-            (AbsValue::EntrySlot(x), AbsValue::EntrySlot(y)) if x == y => AbsValue::EntrySlot(x),
-            (AbsValue::EntrySlot(_), _) | (_, AbsValue::EntrySlot(_)) => AbsValue::Top,
             (AbsValue::Const(x), AbsValue::Const(y)) if x == y => AbsValue::Const(x),
             _ => {
                 let a = self.abs_const_set(&a).unwrap();
@@ -200,25 +158,6 @@ impl ConstSetInterner {
     }
 }
 
-/// Local per-block summary for call/return pattern detection.
-#[derive(Clone, Debug, Default)]
-struct BlockLocalSummary {
-    /// If the block pushes a valid JUMPDEST constant that survives on the stack at exit.
-    pushes_label: Option<U256Imm>,
-    /// If the block looks like a private function call.
-    private_call: Option<PrivateCallSummary>,
-    /// If the block ends in a return jump whose target comes from the entry stack.
-    is_private_return: bool,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct PrivateCallSummary {
-    callee_block: Block,
-    continuation: U256Imm,
-    /// The PUSH instruction that produced the continuation label.
-    continuation_push: Inst,
-}
-
 /// Maximum abstract stack depth tracked by the analysis. Top-aligned joins across paths with
 /// differing stack heights pad the shorter stack with `Top` at the bottom; on CFG cycles this
 /// padding can grow without bound. Clamping discards only those bottom `Top` entries, so no
@@ -227,23 +166,6 @@ struct PrivateCallSummary {
 /// Instructions that access deeper than this (e.g. Amsterdam DUPN/SWAPN up to depth 236)
 /// treat the out-of-range slot as `Top` rather than aborting block interpretation.
 const MAX_ABS_STACK_DEPTH: usize = 64;
-/// Maximum number of worklist visits per block for the flat fixpoint.
-const MAX_FIXPOINT_ITER_MULTIPLIER: usize = 8;
-/// Maximum number of context-sensitive worklist visits per block.
-const MAX_CONTEXT_FIXPOINT_ITER_MULTIPLIER: usize = 4096;
-/// Minimum worklist budget for context-sensitive refinement.
-const MIN_CONTEXT_FIXPOINT_ITERATIONS: usize = 256;
-/// Skip context refinement on larger CFGs where the second pass is usually wasted work.
-const MAX_CONTEXT_REFINEMENT_BLOCKS: usize = 20_000;
-/// Maximum number of call-string frames tracked during context-sensitive refinement.
-const MAX_CALL_CONTEXT_DEPTH: u8 = 2;
-
-#[derive(Clone)]
-struct InterpResult {
-    jump_targets: Vec<(Inst, JumpTarget)>,
-    count: usize,
-    converged: bool,
-}
 
 /// Abstract state at the entry of a block.
 #[derive(Clone, Debug)]
@@ -314,94 +236,6 @@ oxc_index::define_nonmax_u32_index_type! {
 }
 crate::bytecode::impl_index_display!(Block, "bb{}");
 
-oxc_index::define_nonmax_u32_index_type! {
-    /// A call-string context tracked during CFG discovery.
-    struct Context;
-}
-crate::bytecode::impl_index_display!(Context, "ctx{}");
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ContextData {
-    return_pc: Option<U256Imm>,
-    parent: Option<Context>,
-    depth: u8,
-}
-
-struct ContextInterner {
-    contexts: IndexVec<Context, ContextData>,
-}
-
-impl ContextInterner {
-    fn new() -> Self {
-        let mut contexts = IndexVec::new();
-        contexts.push(ContextData { return_pc: None, parent: None, depth: 0 });
-        Self { contexts }
-    }
-
-    fn root(&self) -> Context {
-        Context::from_usize(0)
-    }
-
-    fn head(&self, ctx: Context) -> Option<U256Imm> {
-        self.contexts[ctx].return_pc
-    }
-
-    fn pop(&self, ctx: Context) -> Context {
-        self.contexts[ctx].parent.unwrap_or(ctx)
-    }
-
-    fn push(&mut self, parent: Context, return_pc: U256Imm) -> Context {
-        if self.contexts[parent].depth >= MAX_CALL_CONTEXT_DEPTH {
-            return parent;
-        }
-
-        if let Some((ctx, _)) = self
-            .contexts
-            .iter_enumerated()
-            .find(|(_, data)| data.return_pc == Some(return_pc) && data.parent == Some(parent))
-        {
-            return ctx;
-        }
-
-        let depth = self.contexts[parent].depth.saturating_add(1);
-        self.contexts.push(ContextData { return_pc: Some(return_pc), parent: Some(parent), depth })
-    }
-}
-
-#[derive(Clone, Debug)]
-struct BlockContexts(IndexVec<Block, Vec<(Context, BlockState)>>);
-
-impl BlockContexts {
-    fn new(num_blocks: usize) -> Self {
-        Self(IndexVec::from_vec(vec![Vec::new(); num_blocks]))
-    }
-
-    fn get(&self, block: Block, ctx: Context) -> Option<&BlockState> {
-        self.0[block].iter().find_map(|(id, state)| (*id == ctx).then_some(state))
-    }
-
-    fn has_known(&self, block: Block) -> bool {
-        self.0[block].iter().any(|(_, state)| matches!(state, BlockState::Known(_)))
-    }
-
-    fn join(
-        &mut self,
-        block: Block,
-        ctx: Context,
-        incoming: &[AbsValue],
-        sets: &mut ConstSetInterner,
-    ) -> bool {
-        if let Some((_, state)) = self.0[block].iter_mut().find(|(id, _)| *id == ctx) {
-            return state.join(incoming, sets);
-        }
-
-        let mut state = BlockState::Bottom;
-        let changed = state.join(incoming, sets);
-        self.0[block].push((ctx, state));
-        changed
-    }
-}
-
 /// FIFO worklist with deduplication.
 struct Worklist {
     queue: VecDeque<Block>,
@@ -425,39 +259,6 @@ impl Worklist {
         let id = self.queue.pop_front()?;
         self.in_queue.set(id.index(), false);
         Some(id)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct WorkItem {
-    block: Block,
-    ctx: Context,
-}
-
-struct ContextWorklist {
-    queue: VecDeque<WorkItem>,
-    in_queue: IndexVec<Block, Vec<Context>>,
-}
-
-impl ContextWorklist {
-    fn new(size: usize) -> Self {
-        Self { queue: VecDeque::new(), in_queue: IndexVec::from_vec(vec![Vec::new(); size]) }
-    }
-
-    fn push(&mut self, block: Block, ctx: Context) {
-        if self.in_queue[block].contains(&ctx) {
-            return;
-        }
-        self.in_queue[block].push(ctx);
-        self.queue.push_back(WorkItem { block, ctx });
-    }
-
-    fn pop(&mut self) -> Option<WorkItem> {
-        let item = self.queue.pop_front()?;
-        if let Some(pos) = self.in_queue[item.block].iter().position(|queued| *queued == item.ctx) {
-            self.in_queue[item.block].swap_remove(pos);
-        }
-        Some(item)
     }
 }
 
@@ -817,188 +618,6 @@ impl Bytecode<'_> {
         assert_ne!(cfg.blocks.len(), 0, "should always build at least one block");
     }
 
-    /// Computes local per-block summaries for private call/return pattern detection.
-    fn compute_local_summaries(&mut self) -> IndexVec<Block, BlockLocalSummary> {
-        let num_blocks = self.cfg.blocks.len();
-        let mut summaries = IndexVec::from_vec(vec![BlockLocalSummary::default(); num_blocks]);
-
-        let max_entry = 32usize;
-        let mut stack = Vec::with_capacity(max_entry + 32);
-        let mut producers = Vec::with_capacity(max_entry + 32);
-
-        for bid in self.cfg.blocks.indices() {
-            let block = &self.cfg.blocks[bid];
-
-            stack.clear();
-            producers.clear();
-            for k in 0..max_entry {
-                stack.push(AbsValue::EntrySlot(k as u16));
-                producers.push(None);
-            }
-
-            let term_inst = block.terminator();
-            let mut ok = true;
-            for i in block.insts() {
-                if i == term_inst {
-                    break;
-                }
-                let inst = &self.insts[i];
-                if inst.is_dead_code() {
-                    continue;
-                }
-
-                let (inp, out) = inst.stack_io();
-                let inp = inp as usize;
-                let out = out as usize;
-
-                match inst.opcode {
-                    op::PUSH0..=op::PUSH32 => {
-                        stack.push(AbsValue::Const(inst.imm()));
-                        producers.push(Some(i));
-                    }
-                    op::POP => {
-                        if stack.pop().is_none() {
-                            ok = false;
-                            break;
-                        }
-                        producers.pop();
-                    }
-                    op::DUP1..=op::DUP16 => {
-                        let depth = (inst.opcode - op::DUP1 + 1) as usize;
-                        if stack.len() < depth {
-                            ok = false;
-                            break;
-                        }
-                        let idx = stack.len() - depth;
-                        stack.push(stack[idx]);
-                        producers.push(producers[idx]);
-                    }
-                    op::SWAP1..=op::SWAP16 => {
-                        let depth = (inst.opcode - op::SWAP1 + 1) as usize;
-                        let len = stack.len();
-                        if len < depth + 1 {
-                            ok = false;
-                            break;
-                        }
-                        stack.swap(len - 1, len - 1 - depth);
-                        producers.swap(len - 1, len - 1 - depth);
-                    }
-                    _ => {
-                        if stack.len() < inp {
-                            ok = false;
-                            break;
-                        }
-
-                        let result = if out > 0 {
-                            super::const_fold::try_const_fold(
-                                inst,
-                                &stack[stack.len() - inp..],
-                                &mut self.u256_interner.borrow_mut(),
-                                self.code.len(),
-                            )
-                        } else {
-                            None
-                        };
-                        stack.truncate(stack.len() - inp);
-                        producers.truncate(producers.len() - inp);
-                        if let Some(folded) = result {
-                            stack.push(folded);
-                            producers.push(None);
-                        } else {
-                            stack.resize(stack.len() + out, AbsValue::Top);
-                            producers.resize(producers.len() + out, None);
-                        }
-                    }
-                }
-            }
-
-            if !ok {
-                continue;
-            }
-
-            let term = &self.insts[term_inst];
-            if !term.is_jump() {
-                continue;
-            }
-
-            let target_operand = stack.last().copied();
-            let is_return = matches!(target_operand, Some(AbsValue::EntrySlot(_)));
-            let static_target_pc =
-                term.is_static_jump().then(|| self.pc(term.static_jump_target()));
-
-            let callee_block =
-                if term.is_static_jump() && !term.flags.contains(InstFlags::MULTI_JUMP) {
-                    let target = term.static_jump_target();
-                    let target = self.redirects.get(&target).copied().unwrap_or(target);
-                    self.cfg.inst_to_block.get(target).copied().flatten()
-                } else {
-                    target_operand.and_then(|v| match v {
-                        AbsValue::Const(imm) => {
-                            let val = imm.get(&self.u256_interner.borrow());
-                            let pc = usize::try_from(val).ok()?;
-                            if !self.is_valid_jump(pc) {
-                                return None;
-                            }
-                            let target = self.pc_to_inst(pc);
-                            let target = self.redirects.get(&target).copied().unwrap_or(target);
-                            self.cfg.inst_to_block.get(target).copied().flatten()
-                        }
-                        _ => None,
-                    })
-                };
-
-            let (search_stack, search_producers) = if term.is_static_jump() {
-                (stack.as_slice(), producers.as_slice())
-            } else if term.opcode == op::JUMP {
-                let n = stack.len().saturating_sub(1);
-                (&stack[..n], &producers[..n])
-            } else {
-                let n = stack.len().saturating_sub(2);
-                (&stack[..n], &producers[..n])
-            };
-
-            let mut pushed_label = None;
-            for (value, producer) in search_stack.iter().rev().zip(search_producers.iter().rev()) {
-                let AbsValue::Const(imm) = value else { continue };
-                let val = imm.get(&self.u256_interner.borrow());
-                let Ok(pc) = usize::try_from(val) else { continue };
-                if self.is_valid_jump(pc)
-                    && static_target_pc != Some(pc as u32)
-                    && !matches!(target_operand, Some(AbsValue::Const(target)) if target == *imm)
-                {
-                    pushed_label = Some((*imm, *producer));
-                    break;
-                }
-            }
-
-            summaries[bid].pushes_label = pushed_label.map(|(imm, _)| imm);
-
-            if is_return && term.opcode == op::JUMP {
-                summaries[bid].is_private_return = true;
-            }
-
-            if let (Some(callee), Some((continuation, Some(continuation_push)))) =
-                (callee_block, pushed_label)
-                && term.opcode == op::JUMP
-            {
-                summaries[bid].private_call = Some(PrivateCallSummary {
-                    callee_block: callee,
-                    continuation,
-                    continuation_push,
-                });
-            }
-        }
-
-        if enabled!(tracing::Level::DEBUG) {
-            let calls = summaries.iter().filter(|s| s.private_call.is_some()).count();
-            let returns = summaries.iter().filter(|s| s.is_private_return).count();
-            let labels = summaries.iter().filter(|s| s.pushes_label.is_some()).count();
-            debug!(calls, returns, labels, "local block summaries");
-        }
-
-        summaries
-    }
-
     /// Run worklist-based abstract interpretation over the CFG.
     ///
     /// Returns a list of (jump_inst, resolved_target) pairs and the count of resolvable jumps.
@@ -1112,53 +731,7 @@ impl Bytecode<'_> {
             .filter(|(_, t)| matches!(t, JumpTarget::Resolved(_) | JumpTarget::Invalid))
             .count();
 
-        let flat = InterpResult { jump_targets, count, converged };
-        if std::env::var_os("REVMC_CONTEXT_JUMP_REFINEMENT").is_none() {
-            return (flat.jump_targets, flat.count);
-        }
-        let summaries = self.compute_local_summaries();
-        if !self.should_refine_with_contexts(&flat, &summaries) {
-            return (flat.jump_targets, flat.count);
-        }
-
-        let flat_snapshots = self.snapshots.clone();
-        let n = self.insts.len();
-        self.snapshots = Snapshots {
-            inputs: IndexVec::from_vec(vec![SmallVec::new(); n]),
-            outputs: IndexVec::from_vec(vec![None; n]),
-        };
-
-        let refined = self.run_context_sensitive_interp(&jump_insts, &summaries, local_snapshots);
-        if refined.converged && refined.count > flat.count {
-            debug!(
-                baseline = flat.count,
-                refined = refined.count,
-                "using context-sensitive refinement"
-            );
-            return (refined.jump_targets, refined.count);
-        }
-
-        if !refined.converged {
-            debug!(
-                baseline = flat.count,
-                refined = refined.count,
-                "discarding non-converged context-sensitive refinement"
-            );
-        }
-
-        self.snapshots = flat_snapshots;
-        (flat.jump_targets, flat.count)
-    }
-
-    fn should_refine_with_contexts(
-        &self,
-        flat: &InterpResult,
-        summaries: &IndexVec<Block, BlockLocalSummary>,
-    ) -> bool {
-        std::env::var_os("REVMC_CONTEXT_JUMP_REFINEMENT").is_some()
-            && self.cfg.blocks.len() <= MAX_CONTEXT_REFINEMENT_BLOCKS
-            && flat.jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Top))
-            && summaries.iter().any(|s| s.private_call.is_some())
+        (jump_targets, count)
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
@@ -1196,7 +769,6 @@ impl Bytecode<'_> {
                     JumpTarget::Invalid
                 }
             }
-            AbsValue::EntrySlot(_) => JumpTarget::Top,
             AbsValue::Top => JumpTarget::Top,
         }
     }
@@ -1387,7 +959,7 @@ impl Bytecode<'_> {
         let constants = match value {
             AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
             AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
-            AbsValue::EntrySlot(_) | AbsValue::Top => return None,
+            AbsValue::Top => return None,
         };
 
         let interner = self.u256_interner.borrow();
@@ -1421,7 +993,7 @@ impl Bytecode<'_> {
         let consts = match operand {
             AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
             AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
-            AbsValue::EntrySlot(_) | AbsValue::Top => return,
+            AbsValue::Top => return,
         };
         let interner = self.u256_interner.borrow();
         for imm in consts {
@@ -1516,58 +1088,6 @@ impl Bytecode<'_> {
         }
     }
 
-    fn invalidate_suspect_context_jumps(
-        &mut self,
-        jump_targets: &mut [(Inst, JumpTarget)],
-        block_states: &BlockContexts,
-        discovered_edges: &IndexVec<Block, SmallVec<[Block; 4]>>,
-    ) {
-        let num_blocks = self.cfg.blocks.len();
-
-        let mut suspect: BitVec = BitVec::repeat(false, num_blocks);
-        for bid in self.cfg.blocks.indices() {
-            if block_states.has_known(bid)
-                && self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest()
-            {
-                suspect.set(bid.index(), true);
-            }
-        }
-
-        let mut propagate = Worklist::new(num_blocks);
-        for bid in self.cfg.blocks.indices() {
-            if suspect[bid.index()] {
-                propagate.push(bid);
-            }
-        }
-        while let Some(bid) = propagate.pop() {
-            for &succ in self.cfg.blocks[bid].succs.iter().chain(discovered_edges[bid].iter()) {
-                let si = succ.index();
-                if !suspect[si] {
-                    suspect.set(si, true);
-                    propagate.push(succ);
-                }
-            }
-        }
-
-        for (inst, target) in jump_targets.iter_mut() {
-            if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
-                continue;
-            }
-            if let Some(bid) = self.cfg.inst_to_block[*inst]
-                && suspect[bid.index()]
-            {
-                trace!(
-                    %inst,
-                    pc = self.pc(*inst),
-                    %bid,
-                    target = ?target,
-                    "invalidated suspect context jump resolution"
-                );
-                *target = JumpTarget::Top;
-            }
-        }
-    }
-
     /// Run a worklist-based fixpoint to compute abstract block states.
     ///
     /// Returns `(discovered_edges, edge_states, converged)`.
@@ -1587,7 +1107,7 @@ impl Bytecode<'_> {
             IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
         let mut edge_states: EdgeStates = IndexVec::from_vec(vec![Vec::new(); num_blocks]);
 
-        let max_iterations = num_blocks.saturating_mul(MAX_FIXPOINT_ITER_MULTIPLIER);
+        let max_iterations = num_blocks * 8;
         let mut iterations = 0;
         let mut converged = true;
 
@@ -1645,453 +1165,6 @@ impl Bytecode<'_> {
         );
 
         (discovered, edge_states, converged)
-    }
-
-    fn run_context_sensitive_interp(
-        &mut self,
-        jump_insts: &[Inst],
-        summaries: &IndexVec<Block, BlockLocalSummary>,
-        local_snapshots: &Snapshots,
-    ) -> InterpResult {
-        let num_blocks = self.cfg.blocks.len();
-
-        let mut const_sets = ConstSetInterner::new();
-        let mut contexts = ContextInterner::new();
-        let root_ctx = contexts.root();
-
-        let mut block_states = BlockContexts::new(num_blocks);
-        block_states.join(Block::from_usize(0), root_ctx, &[], &mut const_sets);
-
-        let (discovered_edges, converged) =
-            self.run_context_fixpoint(&mut block_states, &mut const_sets, &mut contexts, summaries);
-
-        if !converged {
-            self.snapshots.restore_from(self.insts.indices(), local_snapshots);
-        }
-
-        let mut jump_targets = Vec::new();
-        for &jump_inst in jump_insts {
-            let snap = &self.snapshots.inputs[jump_inst];
-            let target = if snap.is_empty() {
-                trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                JumpTarget::Bottom
-            } else {
-                self.resolve_jump_operand(*snap.last().unwrap(), &const_sets)
-            };
-            jump_targets.push((jump_inst, target));
-        }
-
-        let has_top_jump = jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Top));
-        if has_top_jump || !converged {
-            let resolved_before_invalidation = jump_targets
-                .iter()
-                .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_)))
-                .count();
-            let invalid_before_invalidation = jump_targets
-                .iter()
-                .filter(|(_, target)| matches!(target, JumpTarget::Invalid))
-                .count();
-            debug!(
-                has_top_jump,
-                converged,
-                resolved_before_invalidation,
-                invalid_before_invalidation,
-                "invalidating suspect context jump resolutions"
-            );
-            self.invalidate_suspect_context_jumps(
-                &mut jump_targets,
-                &block_states,
-                &discovered_edges,
-            );
-        }
-
-        for &(jump_inst, ref target) in &jump_targets {
-            if let JumpTarget::Resolved(targets) = target {
-                trace!(
-                    %jump_inst,
-                    pc = self.pc(jump_inst),
-                    n_targets = targets.len(),
-                    "resolved via context"
-                );
-            }
-        }
-
-        let count = jump_targets
-            .iter()
-            .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid))
-            .count();
-
-        InterpResult { jump_targets, count, converged }
-    }
-
-    /// Runs a context-sensitive fixpoint that tracks call-string return continuations.
-    fn run_context_fixpoint(
-        &mut self,
-        block_states: &mut BlockContexts,
-        const_sets: &mut ConstSetInterner,
-        contexts: &mut ContextInterner,
-        summaries: &IndexVec<Block, BlockLocalSummary>,
-    ) -> (DiscoveredEdges, bool) {
-        let num_blocks = self.cfg.blocks.len();
-        let mut worklist = ContextWorklist::new(num_blocks);
-        worklist.push(Block::from_usize(0), contexts.root());
-
-        let mut discovered: DiscoveredEdges = IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
-        let mut disc_preds: IndexVec<Block, SmallVec<[Block; 4]>> =
-            IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
-
-        let max_iterations = num_blocks
-            .saturating_mul(MAX_CONTEXT_FIXPOINT_ITER_MULTIPLIER)
-            .max(MIN_CONTEXT_FIXPOINT_ITERATIONS);
-        let mut iterations = 0;
-        let mut converged = true;
-        let mut stack_buf = Vec::with_capacity(MAX_ABS_STACK_DEPTH);
-
-        while let Some(item) = worklist.pop() {
-            iterations += 1;
-            if iterations > max_iterations {
-                converged = false;
-                break;
-            }
-
-            let bid = item.block;
-            let ctx = item.ctx;
-
-            stack_buf.clear();
-            let input = match block_states.get(bid, ctx) {
-                Some(BlockState::Known(s)) => {
-                    stack_buf.extend_from_slice(s);
-                    s.as_slice()
-                }
-                Some(BlockState::Bottom) | None => continue,
-            };
-
-            for (k, value) in stack_buf.iter_mut().enumerate() {
-                if !value.is_known() {
-                    *value = AbsValue::EntrySlot(k as u16);
-                }
-            }
-
-            let term_inst = self.cfg.blocks[bid].terminator();
-            let insts = self.cfg.blocks[bid].insts().collect::<SmallVec<[Inst; 16]>>();
-            let succs = self.cfg.blocks[bid].succs.clone();
-            let term = &self.insts[term_inst];
-            let term_opcode = term.opcode;
-            let term_is_jump = term.is_jump();
-            let term_is_static_jump = term.is_static_jump();
-            let term_can_fall_through = term.can_fall_through();
-
-            let (ok, term_snap) = self.interpret_block_context(
-                insts.iter().copied(),
-                term_inst,
-                input,
-                &mut stack_buf,
-                const_sets,
-            );
-            if !ok {
-                continue;
-            }
-
-            if term_is_jump
-                && !term_is_static_jump
-                && let Some(operand) = term_snap.as_ref().and_then(|snap| snap.last()).copied()
-            {
-                self.discover_jump_edges(
-                    operand,
-                    bid,
-                    const_sets,
-                    &mut discovered,
-                    &mut disc_preds,
-                );
-            }
-
-            for value in &mut stack_buf {
-                *value = value.resolve(input);
-            }
-
-            let (skip_fallthrough, skip_jump) = if term_opcode == op::JUMPI
-                && let Some(AbsValue::Const(imm)) =
-                    term_snap.as_ref().and_then(|snap| snap.first()).copied()
-            {
-                if imm.get(&self.u256_interner.borrow()).is_zero() {
-                    (false, true)
-                } else {
-                    (true, false)
-                }
-            } else {
-                (false, false)
-            };
-
-            for (si, &succ) in succs.iter().chain(&discovered[bid]).enumerate() {
-                let is_fallthrough = si == 0 && term_opcode == op::JUMPI && term_can_fall_through;
-                let is_jump_edge = !is_fallthrough;
-                if (is_fallthrough && skip_fallthrough) || (is_jump_edge && skip_jump) {
-                    continue;
-                }
-
-                let succ_ctx =
-                    self.successor_context(summaries, contexts, ctx, bid, succ, &stack_buf);
-                if block_states.join(succ, succ_ctx, &stack_buf, const_sets) {
-                    worklist.push(succ, succ_ctx);
-                }
-            }
-
-            if summaries[bid].is_private_return
-                && term_opcode == op::JUMP
-                && !term_is_static_jump
-                && let Some(return_pc) = contexts.head(ctx)
-            {
-                let return_pc = return_pc.get(&self.u256_interner.borrow());
-                if let Ok(pc) = usize::try_from(return_pc)
-                    && self.is_valid_jump(pc)
-                {
-                    let target = self.pc_to_inst(pc);
-                    let target = self.redirects.get(&target).copied().unwrap_or(target);
-                    if let Some(target_block) =
-                        self.cfg.inst_to_block.get(target).copied().flatten()
-                    {
-                        let return_ctx = contexts.pop(ctx);
-                        if !discovered[bid].contains(&target_block) {
-                            discovered[bid].push(target_block);
-                            disc_preds[target_block].push(bid);
-                        }
-                        if block_states.join(target_block, return_ctx, &stack_buf, const_sets) {
-                            worklist.push(target_block, return_ctx);
-                        }
-                    }
-                }
-            }
-        }
-
-        debug!(
-            "{msg} after {iterations} iterations (max={max_iterations})",
-            msg = if converged { "context converged" } else { "context did not converge" },
-        );
-
-        (discovered, converged)
-    }
-
-    fn interpret_block_context(
-        &mut self,
-        insts: impl IntoIterator<Item = Inst>,
-        term_inst: Inst,
-        entry_input: &[AbsValue],
-        stack: &mut Vec<AbsValue>,
-        const_sets: &mut ConstSetInterner,
-    ) -> (bool, Option<OperandSnapshot>) {
-        let mut term_snapshot = None;
-
-        for i in insts {
-            let inst = &self.insts[i];
-            if inst.is_dead_code() {
-                continue;
-            }
-
-            let (inp, out) = inst.stack_io();
-            let inp = inp as usize;
-            let out = out as usize;
-
-            let start = stack.len().saturating_sub(inp);
-            let snap = stack[start..]
-                .iter()
-                .copied()
-                .map(|value| value.resolve(entry_input))
-                .collect::<OperandSnapshot>();
-            if snap.len() != inp {
-                return (false, None);
-            }
-            self.snapshots.join_inputs(i, &snap, const_sets);
-            if i == term_inst {
-                term_snapshot = Some(snap.clone());
-            }
-
-            match inst.opcode {
-                op::PUSH0..=op::PUSH32 => {
-                    stack.push(AbsValue::Const(inst.imm()));
-                }
-                op::POP => {
-                    if stack.pop().is_none() {
-                        return (false, None);
-                    }
-                }
-                op::DUP1..=op::DUP16 => {
-                    let depth = (inst.opcode - op::DUP1 + 1) as usize;
-                    if stack.len() < depth {
-                        return (false, None);
-                    }
-                    stack.push(stack[stack.len() - depth]);
-                }
-                op::SWAP1..=op::SWAP16 => {
-                    let depth = (inst.opcode - op::SWAP1 + 1) as usize;
-                    let len = stack.len();
-                    if len < depth + 1 {
-                        return (false, None);
-                    }
-                    stack.swap(len - 1, len - 1 - depth);
-                }
-                op::DUPN => {
-                    let depth = crate::decode_single(inst.imm_byte());
-                    match depth {
-                        Some(n) => {
-                            let n = n as usize;
-                            if stack.len() < n {
-                                stack.push(AbsValue::Top);
-                            } else {
-                                stack.push(stack[stack.len() - n]);
-                            }
-                        }
-                        None => return (false, None),
-                    }
-                }
-                op::SWAPN => {
-                    let depth = crate::decode_single(inst.imm_byte());
-                    match depth {
-                        Some(n) => {
-                            let n = n as usize;
-                            let len = stack.len();
-                            if len < n + 1 {
-                                if let Some(tos) = stack.last_mut() {
-                                    *tos = AbsValue::Top;
-                                }
-                            } else {
-                                stack.swap(len - 1, len - 1 - n);
-                            }
-                        }
-                        None => return (false, None),
-                    }
-                }
-                op::EXCHANGE => {
-                    let pair = crate::decode_pair(inst.imm_byte());
-                    match pair {
-                        Some((n, m)) => {
-                            let (n, m) = (n as usize, m as usize);
-                            let len = stack.len();
-                            if len < m + 1 {
-                                if len > n {
-                                    stack[len - 1 - n] = AbsValue::Top;
-                                }
-                            } else {
-                                stack.swap(len - 1 - n, len - 1 - m);
-                            }
-                        }
-                        None => return (false, None),
-                    }
-                }
-                _ => {
-                    if stack.len() < inp {
-                        return (false, None);
-                    }
-
-                    let result = if out > 0 && self.compiler_gas_used < self.compiler_gas_limit {
-                        let inputs_slice = &stack[stack.len() - inp..];
-                        let mut interner = self.u256_interner.borrow_mut();
-                        let gas =
-                            super::const_fold::const_fold_gas(inst.opcode, inputs_slice, &interner);
-                        if let Some(cost) = gas
-                            && self.compiler_gas_used.saturating_add(cost)
-                                <= self.compiler_gas_limit
-                        {
-                            let folded = super::const_fold::try_const_fold(
-                                inst,
-                                inputs_slice,
-                                &mut interner,
-                                self.code.len(),
-                            );
-                            if folded.is_some() {
-                                self.compiler_gas_used += cost;
-                            }
-                            folded
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-
-                    stack.truncate(stack.len() - inp);
-                    if let Some(folded) = result {
-                        debug_assert_eq!(out, 1);
-                        stack.push(folded);
-                    } else {
-                        stack.resize(stack.len() + out, AbsValue::Top);
-                    }
-                }
-            }
-
-            if out > 0 && !matches!(inst.opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
-            {
-                self.snapshots.join_output(
-                    i,
-                    stack.last().copied().map(|value| value.resolve(entry_input)),
-                    const_sets,
-                );
-            }
-
-            #[cfg(test)]
-            if inst.opcode == crate::TEST_SUSPEND {
-                stack.fill(AbsValue::Top);
-            }
-        }
-
-        (true, term_snapshot)
-    }
-
-    fn successor_context(
-        &self,
-        summaries: &IndexVec<Block, BlockLocalSummary>,
-        contexts: &mut ContextInterner,
-        current: Context,
-        bid: Block,
-        succ: Block,
-        _outgoing: &[AbsValue],
-    ) -> Context {
-        if summaries[bid].is_private_return {
-            let succ_pc = self.pc(self.cfg.blocks[succ].insts.start) as usize;
-            if let Some(return_pc) = contexts.head(current) {
-                let return_pc = return_pc.get(&self.u256_interner.borrow());
-                if usize::try_from(return_pc) == Ok(succ_pc) {
-                    return contexts.pop(current);
-                }
-            }
-        }
-
-        if let Some(call) = &summaries[bid].private_call
-            && call.callee_block == succ
-        {
-            trace!(
-                %bid,
-                %succ,
-                continuation_push = %call.continuation_push,
-                "pushed continuation context"
-            );
-            return contexts.push(current, call.continuation);
-        }
-
-        let term = &self.insts[self.cfg.blocks[bid].terminator()];
-        if term.opcode == op::JUMP
-            && term.is_static_jump()
-            && let Some(return_pc) = self.call_return_candidate(
-                _outgoing,
-                self.pc(self.cfg.blocks[succ].insts.start) as usize,
-            )
-        {
-            trace!(%bid, %succ, "pushed inferred continuation context");
-            return contexts.push(current, return_pc);
-        }
-
-        current
-    }
-
-    fn call_return_candidate(&self, outgoing: &[AbsValue], target_pc: usize) -> Option<U256Imm> {
-        let interner = self.u256_interner.borrow();
-        for value in outgoing.iter().rev() {
-            let AbsValue::Const(imm) = *value else { continue };
-            let Ok(pc) = usize::try_from(imm.get(&interner)) else { continue };
-            if pc != target_pc && self.is_valid_jump(pc) {
-                return Some(imm);
-            }
-        }
-        None
     }
 
     /// Interpret a sequence of instructions on the abstract stack.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -682,6 +682,21 @@ impl Bytecode<'_> {
         // When the fixpoint didn't converge, partially-discovered ConstSets may be
         // incomplete, so we must conservatively invalidate them too.
         if has_top_jump || !converged {
+            let resolved_before_invalidation = jump_targets
+                .iter()
+                .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_)))
+                .count();
+            let invalid_before_invalidation = jump_targets
+                .iter()
+                .filter(|(_, target)| matches!(target, JumpTarget::Invalid))
+                .count();
+            debug!(
+                has_top_jump,
+                converged,
+                resolved_before_invalidation,
+                invalid_before_invalidation,
+                "invalidating suspect jump resolutions"
+            );
             self.invalidate_suspect_jumps(
                 &mut jump_targets,
                 &block_states,
@@ -1050,6 +1065,13 @@ impl Bytecode<'_> {
             if let Some(bid) = self.cfg.inst_to_block[*inst]
                 && suspect[bid.index()]
             {
+                trace!(
+                    %inst,
+                    pc = self.pc(*inst),
+                    %bid,
+                    target = ?target,
+                    "invalidated suspect jump resolution"
+                );
                 *target = JumpTarget::Top;
             }
         }

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -59,6 +59,27 @@ pub(crate) struct Snapshots {
 }
 
 impl Snapshots {
+    fn join_inputs(&mut self, inst: Inst, incoming: &[AbsValue], sets: &mut ConstSetInterner) {
+        let snap = &mut self.inputs[inst];
+        if snap.is_empty() {
+            snap.extend_from_slice(incoming);
+            return;
+        }
+
+        debug_assert_eq!(snap.len(), incoming.len(), "mismatched snapshot arity at {inst}");
+        for (existing, incoming) in snap.iter_mut().zip(incoming.iter().copied()) {
+            *existing = sets.join(*existing, incoming);
+        }
+    }
+
+    fn join_output(&mut self, inst: Inst, incoming: Option<AbsValue>, sets: &mut ConstSetInterner) {
+        match (&mut self.outputs[inst], incoming) {
+            (slot @ None, Some(value)) => *slot = Some(value),
+            (Some(existing), Some(value)) => *existing = sets.join(*existing, value),
+            _ => {}
+        }
+    }
+
     /// Restores snapshots for the given instructions from a previously saved copy.
     pub(crate) fn restore_from(&mut self, insts: impl Iterator<Item = Inst>, saved: &Self) {
         for inst in insts {
@@ -74,6 +95,11 @@ pub(crate) enum AbsValue {
     Const(U256Imm),
     /// Multiple known constant values (interned, sorted, deduplicated).
     ConstSet(ConstSetIdx),
+    /// The value in block-entry stack slot `k` (0 = bottom of abstract stack at entry).
+    ///
+    /// Context refinement uses this to preserve return-address provenance through
+    /// block-local stack manipulation before resolving it against the context input.
+    EntrySlot(u16),
     /// Top value (unknown concrete value).
     #[default]
     Top,
@@ -85,6 +111,19 @@ impl AbsValue {
         match self {
             Self::Const(v) => Some(v),
             _ => None,
+        }
+    }
+
+    /// Returns `true` if this value carries concrete information.
+    fn is_known(self) -> bool {
+        !matches!(self, Self::Top)
+    }
+
+    /// Resolves `EntrySlot(k)` against the block's input state.
+    fn resolve(self, input: &[Self]) -> Self {
+        match self {
+            Self::EntrySlot(k) => input.get(usize::from(k)).copied().unwrap_or(Self::Top),
+            other => other,
         }
     }
 }
@@ -110,6 +149,7 @@ impl ConstSetInterner {
             AbsValue::Top => None,
             AbsValue::Const(v) => Some(std::slice::from_ref(v)),
             AbsValue::ConstSet(idx) => Some(self.get(*idx)),
+            AbsValue::EntrySlot(_) => None,
         }
     }
 
@@ -126,6 +166,8 @@ impl ConstSetInterner {
     fn join(&mut self, a: AbsValue, b: AbsValue) -> AbsValue {
         match (a, b) {
             (AbsValue::Top, _) | (_, AbsValue::Top) => AbsValue::Top,
+            (AbsValue::EntrySlot(x), AbsValue::EntrySlot(y)) if x == y => AbsValue::EntrySlot(x),
+            (AbsValue::EntrySlot(_), _) | (_, AbsValue::EntrySlot(_)) => AbsValue::Top,
             (AbsValue::Const(x), AbsValue::Const(y)) if x == y => AbsValue::Const(x),
             _ => {
                 let a = self.abs_const_set(&a).unwrap();
@@ -158,6 +200,25 @@ impl ConstSetInterner {
     }
 }
 
+/// Local per-block summary for call/return pattern detection.
+#[derive(Clone, Debug, Default)]
+struct BlockLocalSummary {
+    /// If the block pushes a valid JUMPDEST constant that survives on the stack at exit.
+    pushes_label: Option<U256Imm>,
+    /// If the block looks like a private function call.
+    private_call: Option<PrivateCallSummary>,
+    /// If the block ends in a return jump whose target comes from the entry stack.
+    is_private_return: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PrivateCallSummary {
+    callee_block: Block,
+    continuation: U256Imm,
+    /// The PUSH instruction that produced the continuation label.
+    continuation_push: Inst,
+}
+
 /// Maximum abstract stack depth tracked by the analysis. Top-aligned joins across paths with
 /// differing stack heights pad the shorter stack with `Top` at the bottom; on CFG cycles this
 /// padding can grow without bound. Clamping discards only those bottom `Top` entries, so no
@@ -166,6 +227,23 @@ impl ConstSetInterner {
 /// Instructions that access deeper than this (e.g. Amsterdam DUPN/SWAPN up to depth 236)
 /// treat the out-of-range slot as `Top` rather than aborting block interpretation.
 const MAX_ABS_STACK_DEPTH: usize = 64;
+/// Maximum number of worklist visits per block for the flat fixpoint.
+const MAX_FIXPOINT_ITER_MULTIPLIER: usize = 8;
+/// Maximum number of context-sensitive worklist visits per block.
+const MAX_CONTEXT_FIXPOINT_ITER_MULTIPLIER: usize = 4096;
+/// Minimum worklist budget for context-sensitive refinement.
+const MIN_CONTEXT_FIXPOINT_ITERATIONS: usize = 256;
+/// Skip context refinement on larger CFGs where the second pass is usually wasted work.
+const MAX_CONTEXT_REFINEMENT_BLOCKS: usize = 20_000;
+/// Maximum number of call-string frames tracked during context-sensitive refinement.
+const MAX_CALL_CONTEXT_DEPTH: u8 = 2;
+
+#[derive(Clone)]
+struct InterpResult {
+    jump_targets: Vec<(Inst, JumpTarget)>,
+    count: usize,
+    converged: bool,
+}
 
 /// Abstract state at the entry of a block.
 #[derive(Clone, Debug)]
@@ -236,6 +314,94 @@ oxc_index::define_nonmax_u32_index_type! {
 }
 crate::bytecode::impl_index_display!(Block, "bb{}");
 
+oxc_index::define_nonmax_u32_index_type! {
+    /// A call-string context tracked during CFG discovery.
+    struct Context;
+}
+crate::bytecode::impl_index_display!(Context, "ctx{}");
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ContextData {
+    return_pc: Option<U256Imm>,
+    parent: Option<Context>,
+    depth: u8,
+}
+
+struct ContextInterner {
+    contexts: IndexVec<Context, ContextData>,
+}
+
+impl ContextInterner {
+    fn new() -> Self {
+        let mut contexts = IndexVec::new();
+        contexts.push(ContextData { return_pc: None, parent: None, depth: 0 });
+        Self { contexts }
+    }
+
+    fn root(&self) -> Context {
+        Context::from_usize(0)
+    }
+
+    fn head(&self, ctx: Context) -> Option<U256Imm> {
+        self.contexts[ctx].return_pc
+    }
+
+    fn pop(&self, ctx: Context) -> Context {
+        self.contexts[ctx].parent.unwrap_or(ctx)
+    }
+
+    fn push(&mut self, parent: Context, return_pc: U256Imm) -> Context {
+        if self.contexts[parent].depth >= MAX_CALL_CONTEXT_DEPTH {
+            return parent;
+        }
+
+        if let Some((ctx, _)) = self
+            .contexts
+            .iter_enumerated()
+            .find(|(_, data)| data.return_pc == Some(return_pc) && data.parent == Some(parent))
+        {
+            return ctx;
+        }
+
+        let depth = self.contexts[parent].depth.saturating_add(1);
+        self.contexts.push(ContextData { return_pc: Some(return_pc), parent: Some(parent), depth })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BlockContexts(IndexVec<Block, Vec<(Context, BlockState)>>);
+
+impl BlockContexts {
+    fn new(num_blocks: usize) -> Self {
+        Self(IndexVec::from_vec(vec![Vec::new(); num_blocks]))
+    }
+
+    fn get(&self, block: Block, ctx: Context) -> Option<&BlockState> {
+        self.0[block].iter().find_map(|(id, state)| (*id == ctx).then_some(state))
+    }
+
+    fn has_known(&self, block: Block) -> bool {
+        self.0[block].iter().any(|(_, state)| matches!(state, BlockState::Known(_)))
+    }
+
+    fn join(
+        &mut self,
+        block: Block,
+        ctx: Context,
+        incoming: &[AbsValue],
+        sets: &mut ConstSetInterner,
+    ) -> bool {
+        if let Some((_, state)) = self.0[block].iter_mut().find(|(id, _)| *id == ctx) {
+            return state.join(incoming, sets);
+        }
+
+        let mut state = BlockState::Bottom;
+        let changed = state.join(incoming, sets);
+        self.0[block].push((ctx, state));
+        changed
+    }
+}
+
 /// FIFO worklist with deduplication.
 struct Worklist {
     queue: VecDeque<Block>,
@@ -259,6 +425,39 @@ impl Worklist {
         let id = self.queue.pop_front()?;
         self.in_queue.set(id.index(), false);
         Some(id)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WorkItem {
+    block: Block,
+    ctx: Context,
+}
+
+struct ContextWorklist {
+    queue: VecDeque<WorkItem>,
+    in_queue: IndexVec<Block, Vec<Context>>,
+}
+
+impl ContextWorklist {
+    fn new(size: usize) -> Self {
+        Self { queue: VecDeque::new(), in_queue: IndexVec::from_vec(vec![Vec::new(); size]) }
+    }
+
+    fn push(&mut self, block: Block, ctx: Context) {
+        if self.in_queue[block].contains(&ctx) {
+            return;
+        }
+        self.in_queue[block].push(ctx);
+        self.queue.push_back(WorkItem { block, ctx });
+    }
+
+    fn pop(&mut self) -> Option<WorkItem> {
+        let item = self.queue.pop_front()?;
+        if let Some(pos) = self.in_queue[item.block].iter().position(|queued| *queued == item.ctx) {
+            self.in_queue[item.block].swap_remove(pos);
+        }
+        Some(item)
     }
 }
 
@@ -618,6 +817,188 @@ impl Bytecode<'_> {
         assert_ne!(cfg.blocks.len(), 0, "should always build at least one block");
     }
 
+    /// Computes local per-block summaries for private call/return pattern detection.
+    fn compute_local_summaries(&mut self) -> IndexVec<Block, BlockLocalSummary> {
+        let num_blocks = self.cfg.blocks.len();
+        let mut summaries = IndexVec::from_vec(vec![BlockLocalSummary::default(); num_blocks]);
+
+        let max_entry = 32usize;
+        let mut stack = Vec::with_capacity(max_entry + 32);
+        let mut producers = Vec::with_capacity(max_entry + 32);
+
+        for bid in self.cfg.blocks.indices() {
+            let block = &self.cfg.blocks[bid];
+
+            stack.clear();
+            producers.clear();
+            for k in 0..max_entry {
+                stack.push(AbsValue::EntrySlot(k as u16));
+                producers.push(None);
+            }
+
+            let term_inst = block.terminator();
+            let mut ok = true;
+            for i in block.insts() {
+                if i == term_inst {
+                    break;
+                }
+                let inst = &self.insts[i];
+                if inst.is_dead_code() {
+                    continue;
+                }
+
+                let (inp, out) = inst.stack_io();
+                let inp = inp as usize;
+                let out = out as usize;
+
+                match inst.opcode {
+                    op::PUSH0..=op::PUSH32 => {
+                        stack.push(AbsValue::Const(inst.imm()));
+                        producers.push(Some(i));
+                    }
+                    op::POP => {
+                        if stack.pop().is_none() {
+                            ok = false;
+                            break;
+                        }
+                        producers.pop();
+                    }
+                    op::DUP1..=op::DUP16 => {
+                        let depth = (inst.opcode - op::DUP1 + 1) as usize;
+                        if stack.len() < depth {
+                            ok = false;
+                            break;
+                        }
+                        let idx = stack.len() - depth;
+                        stack.push(stack[idx]);
+                        producers.push(producers[idx]);
+                    }
+                    op::SWAP1..=op::SWAP16 => {
+                        let depth = (inst.opcode - op::SWAP1 + 1) as usize;
+                        let len = stack.len();
+                        if len < depth + 1 {
+                            ok = false;
+                            break;
+                        }
+                        stack.swap(len - 1, len - 1 - depth);
+                        producers.swap(len - 1, len - 1 - depth);
+                    }
+                    _ => {
+                        if stack.len() < inp {
+                            ok = false;
+                            break;
+                        }
+
+                        let result = if out > 0 {
+                            super::const_fold::try_const_fold(
+                                inst,
+                                &stack[stack.len() - inp..],
+                                &mut self.u256_interner.borrow_mut(),
+                                self.code.len(),
+                            )
+                        } else {
+                            None
+                        };
+                        stack.truncate(stack.len() - inp);
+                        producers.truncate(producers.len() - inp);
+                        if let Some(folded) = result {
+                            stack.push(folded);
+                            producers.push(None);
+                        } else {
+                            stack.resize(stack.len() + out, AbsValue::Top);
+                            producers.resize(producers.len() + out, None);
+                        }
+                    }
+                }
+            }
+
+            if !ok {
+                continue;
+            }
+
+            let term = &self.insts[term_inst];
+            if !term.is_jump() {
+                continue;
+            }
+
+            let target_operand = stack.last().copied();
+            let is_return = matches!(target_operand, Some(AbsValue::EntrySlot(_)));
+            let static_target_pc =
+                term.is_static_jump().then(|| self.pc(term.static_jump_target()));
+
+            let callee_block =
+                if term.is_static_jump() && !term.flags.contains(InstFlags::MULTI_JUMP) {
+                    let target = term.static_jump_target();
+                    let target = self.redirects.get(&target).copied().unwrap_or(target);
+                    self.cfg.inst_to_block.get(target).copied().flatten()
+                } else {
+                    target_operand.and_then(|v| match v {
+                        AbsValue::Const(imm) => {
+                            let val = imm.get(&self.u256_interner.borrow());
+                            let pc = usize::try_from(val).ok()?;
+                            if !self.is_valid_jump(pc) {
+                                return None;
+                            }
+                            let target = self.pc_to_inst(pc);
+                            let target = self.redirects.get(&target).copied().unwrap_or(target);
+                            self.cfg.inst_to_block.get(target).copied().flatten()
+                        }
+                        _ => None,
+                    })
+                };
+
+            let (search_stack, search_producers) = if term.is_static_jump() {
+                (stack.as_slice(), producers.as_slice())
+            } else if term.opcode == op::JUMP {
+                let n = stack.len().saturating_sub(1);
+                (&stack[..n], &producers[..n])
+            } else {
+                let n = stack.len().saturating_sub(2);
+                (&stack[..n], &producers[..n])
+            };
+
+            let mut pushed_label = None;
+            for (value, producer) in search_stack.iter().rev().zip(search_producers.iter().rev()) {
+                let AbsValue::Const(imm) = value else { continue };
+                let val = imm.get(&self.u256_interner.borrow());
+                let Ok(pc) = usize::try_from(val) else { continue };
+                if self.is_valid_jump(pc)
+                    && static_target_pc != Some(pc as u32)
+                    && !matches!(target_operand, Some(AbsValue::Const(target)) if target == *imm)
+                {
+                    pushed_label = Some((*imm, *producer));
+                    break;
+                }
+            }
+
+            summaries[bid].pushes_label = pushed_label.map(|(imm, _)| imm);
+
+            if is_return && term.opcode == op::JUMP {
+                summaries[bid].is_private_return = true;
+            }
+
+            if let (Some(callee), Some((continuation, Some(continuation_push)))) =
+                (callee_block, pushed_label)
+                && term.opcode == op::JUMP
+            {
+                summaries[bid].private_call = Some(PrivateCallSummary {
+                    callee_block: callee,
+                    continuation,
+                    continuation_push,
+                });
+            }
+        }
+
+        if enabled!(tracing::Level::DEBUG) {
+            let calls = summaries.iter().filter(|s| s.private_call.is_some()).count();
+            let returns = summaries.iter().filter(|s| s.is_private_return).count();
+            let labels = summaries.iter().filter(|s| s.pushes_label.is_some()).count();
+            debug!(calls, returns, labels, "local block summaries");
+        }
+
+        summaries
+    }
+
     /// Run worklist-based abstract interpretation over the CFG.
     ///
     /// Returns a list of (jump_inst, resolved_target) pairs and the count of resolvable jumps.
@@ -731,7 +1112,53 @@ impl Bytecode<'_> {
             .filter(|(_, t)| matches!(t, JumpTarget::Resolved(_) | JumpTarget::Invalid))
             .count();
 
-        (jump_targets, count)
+        let flat = InterpResult { jump_targets, count, converged };
+        if std::env::var_os("REVMC_CONTEXT_JUMP_REFINEMENT").is_none() {
+            return (flat.jump_targets, flat.count);
+        }
+        let summaries = self.compute_local_summaries();
+        if !self.should_refine_with_contexts(&flat, &summaries) {
+            return (flat.jump_targets, flat.count);
+        }
+
+        let flat_snapshots = self.snapshots.clone();
+        let n = self.insts.len();
+        self.snapshots = Snapshots {
+            inputs: IndexVec::from_vec(vec![SmallVec::new(); n]),
+            outputs: IndexVec::from_vec(vec![None; n]),
+        };
+
+        let refined = self.run_context_sensitive_interp(&jump_insts, &summaries, local_snapshots);
+        if refined.converged && refined.count > flat.count {
+            debug!(
+                baseline = flat.count,
+                refined = refined.count,
+                "using context-sensitive refinement"
+            );
+            return (refined.jump_targets, refined.count);
+        }
+
+        if !refined.converged {
+            debug!(
+                baseline = flat.count,
+                refined = refined.count,
+                "discarding non-converged context-sensitive refinement"
+            );
+        }
+
+        self.snapshots = flat_snapshots;
+        (flat.jump_targets, flat.count)
+    }
+
+    fn should_refine_with_contexts(
+        &self,
+        flat: &InterpResult,
+        summaries: &IndexVec<Block, BlockLocalSummary>,
+    ) -> bool {
+        std::env::var_os("REVMC_CONTEXT_JUMP_REFINEMENT").is_some()
+            && self.cfg.blocks.len() <= MAX_CONTEXT_REFINEMENT_BLOCKS
+            && flat.jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Top))
+            && summaries.iter().any(|s| s.private_call.is_some())
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
@@ -769,6 +1196,7 @@ impl Bytecode<'_> {
                     JumpTarget::Invalid
                 }
             }
+            AbsValue::EntrySlot(_) => JumpTarget::Top,
             AbsValue::Top => JumpTarget::Top,
         }
     }
@@ -959,7 +1387,7 @@ impl Bytecode<'_> {
         let constants = match value {
             AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
             AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
-            AbsValue::Top => return None,
+            AbsValue::EntrySlot(_) | AbsValue::Top => return None,
         };
 
         let interner = self.u256_interner.borrow();
@@ -993,7 +1421,7 @@ impl Bytecode<'_> {
         let consts = match operand {
             AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
             AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
-            AbsValue::Top => return,
+            AbsValue::EntrySlot(_) | AbsValue::Top => return,
         };
         let interner = self.u256_interner.borrow();
         for imm in consts {
@@ -1088,6 +1516,58 @@ impl Bytecode<'_> {
         }
     }
 
+    fn invalidate_suspect_context_jumps(
+        &mut self,
+        jump_targets: &mut [(Inst, JumpTarget)],
+        block_states: &BlockContexts,
+        discovered_edges: &IndexVec<Block, SmallVec<[Block; 4]>>,
+    ) {
+        let num_blocks = self.cfg.blocks.len();
+
+        let mut suspect: BitVec = BitVec::repeat(false, num_blocks);
+        for bid in self.cfg.blocks.indices() {
+            if block_states.has_known(bid)
+                && self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest()
+            {
+                suspect.set(bid.index(), true);
+            }
+        }
+
+        let mut propagate = Worklist::new(num_blocks);
+        for bid in self.cfg.blocks.indices() {
+            if suspect[bid.index()] {
+                propagate.push(bid);
+            }
+        }
+        while let Some(bid) = propagate.pop() {
+            for &succ in self.cfg.blocks[bid].succs.iter().chain(discovered_edges[bid].iter()) {
+                let si = succ.index();
+                if !suspect[si] {
+                    suspect.set(si, true);
+                    propagate.push(succ);
+                }
+            }
+        }
+
+        for (inst, target) in jump_targets.iter_mut() {
+            if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
+                continue;
+            }
+            if let Some(bid) = self.cfg.inst_to_block[*inst]
+                && suspect[bid.index()]
+            {
+                trace!(
+                    %inst,
+                    pc = self.pc(*inst),
+                    %bid,
+                    target = ?target,
+                    "invalidated suspect context jump resolution"
+                );
+                *target = JumpTarget::Top;
+            }
+        }
+    }
+
     /// Run a worklist-based fixpoint to compute abstract block states.
     ///
     /// Returns `(discovered_edges, edge_states, converged)`.
@@ -1107,7 +1587,7 @@ impl Bytecode<'_> {
             IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
         let mut edge_states: EdgeStates = IndexVec::from_vec(vec![Vec::new(); num_blocks]);
 
-        let max_iterations = num_blocks * 8;
+        let max_iterations = num_blocks.saturating_mul(MAX_FIXPOINT_ITER_MULTIPLIER);
         let mut iterations = 0;
         let mut converged = true;
 
@@ -1165,6 +1645,453 @@ impl Bytecode<'_> {
         );
 
         (discovered, edge_states, converged)
+    }
+
+    fn run_context_sensitive_interp(
+        &mut self,
+        jump_insts: &[Inst],
+        summaries: &IndexVec<Block, BlockLocalSummary>,
+        local_snapshots: &Snapshots,
+    ) -> InterpResult {
+        let num_blocks = self.cfg.blocks.len();
+
+        let mut const_sets = ConstSetInterner::new();
+        let mut contexts = ContextInterner::new();
+        let root_ctx = contexts.root();
+
+        let mut block_states = BlockContexts::new(num_blocks);
+        block_states.join(Block::from_usize(0), root_ctx, &[], &mut const_sets);
+
+        let (discovered_edges, converged) =
+            self.run_context_fixpoint(&mut block_states, &mut const_sets, &mut contexts, summaries);
+
+        if !converged {
+            self.snapshots.restore_from(self.insts.indices(), local_snapshots);
+        }
+
+        let mut jump_targets = Vec::new();
+        for &jump_inst in jump_insts {
+            let snap = &self.snapshots.inputs[jump_inst];
+            let target = if snap.is_empty() {
+                trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
+                JumpTarget::Bottom
+            } else {
+                self.resolve_jump_operand(*snap.last().unwrap(), &const_sets)
+            };
+            jump_targets.push((jump_inst, target));
+        }
+
+        let has_top_jump = jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Top));
+        if has_top_jump || !converged {
+            let resolved_before_invalidation = jump_targets
+                .iter()
+                .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_)))
+                .count();
+            let invalid_before_invalidation = jump_targets
+                .iter()
+                .filter(|(_, target)| matches!(target, JumpTarget::Invalid))
+                .count();
+            debug!(
+                has_top_jump,
+                converged,
+                resolved_before_invalidation,
+                invalid_before_invalidation,
+                "invalidating suspect context jump resolutions"
+            );
+            self.invalidate_suspect_context_jumps(
+                &mut jump_targets,
+                &block_states,
+                &discovered_edges,
+            );
+        }
+
+        for &(jump_inst, ref target) in &jump_targets {
+            if let JumpTarget::Resolved(targets) = target {
+                trace!(
+                    %jump_inst,
+                    pc = self.pc(jump_inst),
+                    n_targets = targets.len(),
+                    "resolved via context"
+                );
+            }
+        }
+
+        let count = jump_targets
+            .iter()
+            .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid))
+            .count();
+
+        InterpResult { jump_targets, count, converged }
+    }
+
+    /// Runs a context-sensitive fixpoint that tracks call-string return continuations.
+    fn run_context_fixpoint(
+        &mut self,
+        block_states: &mut BlockContexts,
+        const_sets: &mut ConstSetInterner,
+        contexts: &mut ContextInterner,
+        summaries: &IndexVec<Block, BlockLocalSummary>,
+    ) -> (DiscoveredEdges, bool) {
+        let num_blocks = self.cfg.blocks.len();
+        let mut worklist = ContextWorklist::new(num_blocks);
+        worklist.push(Block::from_usize(0), contexts.root());
+
+        let mut discovered: DiscoveredEdges = IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
+        let mut disc_preds: IndexVec<Block, SmallVec<[Block; 4]>> =
+            IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
+
+        let max_iterations = num_blocks
+            .saturating_mul(MAX_CONTEXT_FIXPOINT_ITER_MULTIPLIER)
+            .max(MIN_CONTEXT_FIXPOINT_ITERATIONS);
+        let mut iterations = 0;
+        let mut converged = true;
+        let mut stack_buf = Vec::with_capacity(MAX_ABS_STACK_DEPTH);
+
+        while let Some(item) = worklist.pop() {
+            iterations += 1;
+            if iterations > max_iterations {
+                converged = false;
+                break;
+            }
+
+            let bid = item.block;
+            let ctx = item.ctx;
+
+            stack_buf.clear();
+            let input = match block_states.get(bid, ctx) {
+                Some(BlockState::Known(s)) => {
+                    stack_buf.extend_from_slice(s);
+                    s.as_slice()
+                }
+                Some(BlockState::Bottom) | None => continue,
+            };
+
+            for (k, value) in stack_buf.iter_mut().enumerate() {
+                if !value.is_known() {
+                    *value = AbsValue::EntrySlot(k as u16);
+                }
+            }
+
+            let term_inst = self.cfg.blocks[bid].terminator();
+            let insts = self.cfg.blocks[bid].insts().collect::<SmallVec<[Inst; 16]>>();
+            let succs = self.cfg.blocks[bid].succs.clone();
+            let term = &self.insts[term_inst];
+            let term_opcode = term.opcode;
+            let term_is_jump = term.is_jump();
+            let term_is_static_jump = term.is_static_jump();
+            let term_can_fall_through = term.can_fall_through();
+
+            let (ok, term_snap) = self.interpret_block_context(
+                insts.iter().copied(),
+                term_inst,
+                input,
+                &mut stack_buf,
+                const_sets,
+            );
+            if !ok {
+                continue;
+            }
+
+            if term_is_jump
+                && !term_is_static_jump
+                && let Some(operand) = term_snap.as_ref().and_then(|snap| snap.last()).copied()
+            {
+                self.discover_jump_edges(
+                    operand,
+                    bid,
+                    const_sets,
+                    &mut discovered,
+                    &mut disc_preds,
+                );
+            }
+
+            for value in &mut stack_buf {
+                *value = value.resolve(input);
+            }
+
+            let (skip_fallthrough, skip_jump) = if term_opcode == op::JUMPI
+                && let Some(AbsValue::Const(imm)) =
+                    term_snap.as_ref().and_then(|snap| snap.first()).copied()
+            {
+                if imm.get(&self.u256_interner.borrow()).is_zero() {
+                    (false, true)
+                } else {
+                    (true, false)
+                }
+            } else {
+                (false, false)
+            };
+
+            for (si, &succ) in succs.iter().chain(&discovered[bid]).enumerate() {
+                let is_fallthrough = si == 0 && term_opcode == op::JUMPI && term_can_fall_through;
+                let is_jump_edge = !is_fallthrough;
+                if (is_fallthrough && skip_fallthrough) || (is_jump_edge && skip_jump) {
+                    continue;
+                }
+
+                let succ_ctx =
+                    self.successor_context(summaries, contexts, ctx, bid, succ, &stack_buf);
+                if block_states.join(succ, succ_ctx, &stack_buf, const_sets) {
+                    worklist.push(succ, succ_ctx);
+                }
+            }
+
+            if summaries[bid].is_private_return
+                && term_opcode == op::JUMP
+                && !term_is_static_jump
+                && let Some(return_pc) = contexts.head(ctx)
+            {
+                let return_pc = return_pc.get(&self.u256_interner.borrow());
+                if let Ok(pc) = usize::try_from(return_pc)
+                    && self.is_valid_jump(pc)
+                {
+                    let target = self.pc_to_inst(pc);
+                    let target = self.redirects.get(&target).copied().unwrap_or(target);
+                    if let Some(target_block) =
+                        self.cfg.inst_to_block.get(target).copied().flatten()
+                    {
+                        let return_ctx = contexts.pop(ctx);
+                        if !discovered[bid].contains(&target_block) {
+                            discovered[bid].push(target_block);
+                            disc_preds[target_block].push(bid);
+                        }
+                        if block_states.join(target_block, return_ctx, &stack_buf, const_sets) {
+                            worklist.push(target_block, return_ctx);
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!(
+            "{msg} after {iterations} iterations (max={max_iterations})",
+            msg = if converged { "context converged" } else { "context did not converge" },
+        );
+
+        (discovered, converged)
+    }
+
+    fn interpret_block_context(
+        &mut self,
+        insts: impl IntoIterator<Item = Inst>,
+        term_inst: Inst,
+        entry_input: &[AbsValue],
+        stack: &mut Vec<AbsValue>,
+        const_sets: &mut ConstSetInterner,
+    ) -> (bool, Option<OperandSnapshot>) {
+        let mut term_snapshot = None;
+
+        for i in insts {
+            let inst = &self.insts[i];
+            if inst.is_dead_code() {
+                continue;
+            }
+
+            let (inp, out) = inst.stack_io();
+            let inp = inp as usize;
+            let out = out as usize;
+
+            let start = stack.len().saturating_sub(inp);
+            let snap = stack[start..]
+                .iter()
+                .copied()
+                .map(|value| value.resolve(entry_input))
+                .collect::<OperandSnapshot>();
+            if snap.len() != inp {
+                return (false, None);
+            }
+            self.snapshots.join_inputs(i, &snap, const_sets);
+            if i == term_inst {
+                term_snapshot = Some(snap.clone());
+            }
+
+            match inst.opcode {
+                op::PUSH0..=op::PUSH32 => {
+                    stack.push(AbsValue::Const(inst.imm()));
+                }
+                op::POP => {
+                    if stack.pop().is_none() {
+                        return (false, None);
+                    }
+                }
+                op::DUP1..=op::DUP16 => {
+                    let depth = (inst.opcode - op::DUP1 + 1) as usize;
+                    if stack.len() < depth {
+                        return (false, None);
+                    }
+                    stack.push(stack[stack.len() - depth]);
+                }
+                op::SWAP1..=op::SWAP16 => {
+                    let depth = (inst.opcode - op::SWAP1 + 1) as usize;
+                    let len = stack.len();
+                    if len < depth + 1 {
+                        return (false, None);
+                    }
+                    stack.swap(len - 1, len - 1 - depth);
+                }
+                op::DUPN => {
+                    let depth = crate::decode_single(inst.imm_byte());
+                    match depth {
+                        Some(n) => {
+                            let n = n as usize;
+                            if stack.len() < n {
+                                stack.push(AbsValue::Top);
+                            } else {
+                                stack.push(stack[stack.len() - n]);
+                            }
+                        }
+                        None => return (false, None),
+                    }
+                }
+                op::SWAPN => {
+                    let depth = crate::decode_single(inst.imm_byte());
+                    match depth {
+                        Some(n) => {
+                            let n = n as usize;
+                            let len = stack.len();
+                            if len < n + 1 {
+                                if let Some(tos) = stack.last_mut() {
+                                    *tos = AbsValue::Top;
+                                }
+                            } else {
+                                stack.swap(len - 1, len - 1 - n);
+                            }
+                        }
+                        None => return (false, None),
+                    }
+                }
+                op::EXCHANGE => {
+                    let pair = crate::decode_pair(inst.imm_byte());
+                    match pair {
+                        Some((n, m)) => {
+                            let (n, m) = (n as usize, m as usize);
+                            let len = stack.len();
+                            if len < m + 1 {
+                                if len > n {
+                                    stack[len - 1 - n] = AbsValue::Top;
+                                }
+                            } else {
+                                stack.swap(len - 1 - n, len - 1 - m);
+                            }
+                        }
+                        None => return (false, None),
+                    }
+                }
+                _ => {
+                    if stack.len() < inp {
+                        return (false, None);
+                    }
+
+                    let result = if out > 0 && self.compiler_gas_used < self.compiler_gas_limit {
+                        let inputs_slice = &stack[stack.len() - inp..];
+                        let mut interner = self.u256_interner.borrow_mut();
+                        let gas =
+                            super::const_fold::const_fold_gas(inst.opcode, inputs_slice, &interner);
+                        if let Some(cost) = gas
+                            && self.compiler_gas_used.saturating_add(cost)
+                                <= self.compiler_gas_limit
+                        {
+                            let folded = super::const_fold::try_const_fold(
+                                inst,
+                                inputs_slice,
+                                &mut interner,
+                                self.code.len(),
+                            );
+                            if folded.is_some() {
+                                self.compiler_gas_used += cost;
+                            }
+                            folded
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    stack.truncate(stack.len() - inp);
+                    if let Some(folded) = result {
+                        debug_assert_eq!(out, 1);
+                        stack.push(folded);
+                    } else {
+                        stack.resize(stack.len() + out, AbsValue::Top);
+                    }
+                }
+            }
+
+            if out > 0 && !matches!(inst.opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
+            {
+                self.snapshots.join_output(
+                    i,
+                    stack.last().copied().map(|value| value.resolve(entry_input)),
+                    const_sets,
+                );
+            }
+
+            #[cfg(test)]
+            if inst.opcode == crate::TEST_SUSPEND {
+                stack.fill(AbsValue::Top);
+            }
+        }
+
+        (true, term_snapshot)
+    }
+
+    fn successor_context(
+        &self,
+        summaries: &IndexVec<Block, BlockLocalSummary>,
+        contexts: &mut ContextInterner,
+        current: Context,
+        bid: Block,
+        succ: Block,
+        _outgoing: &[AbsValue],
+    ) -> Context {
+        if summaries[bid].is_private_return {
+            let succ_pc = self.pc(self.cfg.blocks[succ].insts.start) as usize;
+            if let Some(return_pc) = contexts.head(current) {
+                let return_pc = return_pc.get(&self.u256_interner.borrow());
+                if usize::try_from(return_pc) == Ok(succ_pc) {
+                    return contexts.pop(current);
+                }
+            }
+        }
+
+        if let Some(call) = &summaries[bid].private_call
+            && call.callee_block == succ
+        {
+            trace!(
+                %bid,
+                %succ,
+                continuation_push = %call.continuation_push,
+                "pushed continuation context"
+            );
+            return contexts.push(current, call.continuation);
+        }
+
+        let term = &self.insts[self.cfg.blocks[bid].terminator()];
+        if term.opcode == op::JUMP
+            && term.is_static_jump()
+            && let Some(return_pc) = self.call_return_candidate(
+                _outgoing,
+                self.pc(self.cfg.blocks[succ].insts.start) as usize,
+            )
+        {
+            trace!(%bid, %succ, "pushed inferred continuation context");
+            return contexts.push(current, return_pc);
+        }
+
+        current
+    }
+
+    fn call_return_candidate(&self, outgoing: &[AbsValue], target_pc: usize) -> Option<U256Imm> {
+        let interner = self.u256_interner.borrow();
+        for value in outgoing.iter().rev() {
+            let AbsValue::Const(imm) = *value else { continue };
+            let Ok(pc) = usize::try_from(imm.get(&interner)) else { continue };
+            if pc != target_pc && self.is_valid_jump(pc) {
+                return Some(imm);
+            }
+        }
+        None
     }
 
     /// Interpret a sequence of instructions on the abstract stack.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -321,17 +321,6 @@ fn push_unique(targets: &mut SmallVec<[Inst; 4]>, target: Inst) {
     }
 }
 
-fn push_unique_state(states: &mut Vec<Vec<AbsValue>>, state: &[AbsValue]) {
-    let start = state.len().saturating_sub(MAX_ABS_STACK_DEPTH);
-    let state = &state[start..];
-    if !states.iter().any(|existing| existing == state) {
-        states.push(state.to_vec());
-    }
-}
-
-type DiscoveredEdges = IndexVec<Block, SmallVec<[Block; 4]>>;
-type EdgeStates = IndexVec<Block, Vec<Vec<AbsValue>>>;
-
 /// CFG for abstract interpretation.
 #[derive(Default)]
 pub(crate) struct Cfg {
@@ -642,8 +631,7 @@ impl Bytecode<'_> {
         }
 
         let mut const_sets = ConstSetInterner::new();
-        let (discovered_edges, edge_states, converged) =
-            self.run_fixpoint(&mut block_states, &mut const_sets);
+        let (discovered_edges, converged) = self.run_fixpoint(&mut block_states, &mut const_sets);
 
         // On non-convergence, all fixpoint-derived snapshots are potentially stale.
         // Restore the safe block-local snapshots computed by `block_analysis_local`.
@@ -665,13 +653,12 @@ impl Bytecode<'_> {
             jump_targets.push((jump_inst, target));
         }
 
-        let edge_state_jumps = if converged {
-            self.resolve_jumps_from_edge_states(&mut jump_targets, &edge_states, &const_sets)
-        } else {
-            Vec::new()
-        };
-        let ranked_hint_jumps = if converged {
-            self.resolve_ranked_continuation_jumps(&mut jump_targets, &block_states, &const_sets)
+        let pcr_jumps = if converged {
+            self.resolve_stack_balance_returns_from_hints(
+                &mut jump_targets,
+                &block_states,
+                &const_sets,
+            )
         } else {
             Vec::new()
         };
@@ -691,23 +678,15 @@ impl Bytecode<'_> {
         }
 
         for &(jump_inst, ref target) in &jump_targets {
-            if let JumpTarget::Resolved(targets) = target {
-                if edge_state_jumps.contains(&jump_inst) {
-                    trace!(
-                        %jump_inst,
-                        pc = self.pc(jump_inst),
-                        n_targets = targets.len(),
-                        "resolved via edge state"
-                    );
-                }
-                if ranked_hint_jumps.contains(&jump_inst) {
-                    trace!(
-                        %jump_inst,
-                        pc = self.pc(jump_inst),
-                        n_targets = targets.len(),
-                        "resolved via ranked hint"
-                    );
-                }
+            if pcr_jumps.contains(&jump_inst)
+                && let JumpTarget::Resolved(targets) = target
+            {
+                trace!(
+                    %jump_inst,
+                    pc = self.pc(jump_inst),
+                    n_targets = targets.len(),
+                    "resolved via PCR hint"
+                );
             }
         }
 
@@ -758,44 +737,15 @@ impl Bytecode<'_> {
         }
     }
 
-    /// Resolves jumps by replaying blocks from path-sensitive incoming edge states.
+    /// Resolves stack-balance return blocks using ranked continuation labels from call sites.
     ///
-    /// The block-level fixpoint joins all predecessors into one entry state, which can erase
-    /// return labels that are still precise on each individual edge. Replaying an unresolved
-    /// jump block from every recorded incoming edge state lets us prove the jump operand without
-    /// assuming anything about the block's opcode shape.
-    fn resolve_jumps_from_edge_states(
-        &mut self,
-        jump_targets: &mut [(Inst, JumpTarget)],
-        edge_states: &EdgeStates,
-        const_sets: &ConstSetInterner,
-    ) -> Vec<Inst> {
-        let mut resolved = Vec::new();
-        for (jump_inst, target) in jump_targets {
-            if !matches!(target, JumpTarget::Top) {
-                continue;
-            }
-            let Some(block) = self.cfg.inst_to_block[*jump_inst] else { continue };
-            if edge_states[block].is_empty() {
-                continue;
-            }
-
-            if let Some(edge_target) =
-                self.resolve_jump_from_all_edge_states(*jump_inst, &edge_states[block], const_sets)
-            {
-                *target = edge_target;
-                resolved.push(*jump_inst);
-            }
-        }
-        resolved
-    }
-
-    /// Resolves continuation jumps from ranked JUMPDEST labels left by static call sites.
-    ///
-    /// If a static call leaves labels ranked as `[..., outer_ret, inner_ret]`, a later
-    /// unresolved jump in `inner_ret` can return to `outer_ret` even when the continuation
-    /// block contains work before the jump.
-    fn resolve_ranked_continuation_jumps(
+    /// Solidity often emits nested internal calls as `[..., outer_ret, ..., inner_ret, callee]`
+    /// followed by `JUMP`. The fixpoint can resolve the callee's return to `inner_ret`, but the
+    /// continuation block at `inner_ret` may recover `outer_ret` from a stack shape that was
+    /// merged away to `Top`. This mirrors Gigahorse's possible-call-return ranking in a narrow
+    /// form: labels left on the stack by a static call are ordered from top to bottom, and a
+    /// stack-balance return block for rank N can return to rank N + 1.
+    fn resolve_stack_balance_returns_from_hints(
         &mut self,
         jump_targets: &mut [(Inst, JumpTarget)],
         block_states: &IndexVec<Block, BlockState>,
@@ -855,7 +805,10 @@ impl Bytecode<'_> {
                 continue;
             }
             let Some(block) = self.cfg.inst_to_block[*jump_inst] else { continue };
-            if !matches!(block_states[block], BlockState::Known(_)) || hints[block].is_empty() {
+            if !matches!(block_states[block], BlockState::Known(_))
+                || !self.is_stack_balance_return_block(block)
+                || hints[block].is_empty()
+            {
                 continue;
             }
 
@@ -863,77 +816,6 @@ impl Bytecode<'_> {
             resolved.push(*jump_inst);
         }
         resolved
-    }
-
-    fn resolve_jump_from_all_edge_states(
-        &mut self,
-        jump_inst: Inst,
-        states: &[Vec<AbsValue>],
-        const_sets: &ConstSetInterner,
-    ) -> Option<JumpTarget> {
-        let mut targets = SmallVec::new();
-        let mut invalid = false;
-        for state in states {
-            match self.resolve_jump_from_edge_state(jump_inst, state, const_sets) {
-                JumpTarget::Resolved(edge_targets) => {
-                    for target in edge_targets {
-                        push_unique(&mut targets, target);
-                    }
-                }
-                JumpTarget::Invalid => invalid = true,
-                JumpTarget::Bottom | JumpTarget::Top => return None,
-            }
-        }
-
-        match (targets.is_empty(), invalid) {
-            (false, false) => Some(JumpTarget::Resolved(targets)),
-            (true, true) => Some(JumpTarget::Invalid),
-            _ => None,
-        }
-    }
-
-    fn resolve_jump_from_edge_state(
-        &mut self,
-        jump_inst: Inst,
-        state: &[AbsValue],
-        const_sets: &ConstSetInterner,
-    ) -> JumpTarget {
-        let Some(block) = self.cfg.inst_to_block[jump_inst] else {
-            return JumpTarget::Bottom;
-        };
-        let insts = self.cfg.blocks[block].insts().collect::<SmallVec<[Inst; 16]>>();
-        let old_inputs = insts
-            .iter()
-            .map(|&inst| self.snapshots.inputs[inst].clone())
-            .collect::<SmallVec<[OperandSnapshot; 16]>>();
-        let old_outputs = insts
-            .iter()
-            .map(|&inst| self.snapshots.outputs[inst])
-            .collect::<SmallVec<[Option<AbsValue>; 16]>>();
-        let compiler_gas_used = self.compiler_gas_used;
-
-        let mut stack = state.to_vec();
-        let interpreted = self.interpret_block(insts.iter().copied(), &mut stack);
-        let target = if interpreted {
-            self.snapshots.inputs[jump_inst].last().copied().map_or(JumpTarget::Bottom, |operand| {
-                self.resolve_jump_operand(operand, const_sets)
-            })
-        } else {
-            JumpTarget::Bottom
-        };
-
-        for ((&inst, inputs), output) in insts.iter().zip(old_inputs).zip(old_outputs) {
-            self.snapshots.inputs[inst] = inputs;
-            self.snapshots.outputs[inst] = output;
-        }
-        self.compiler_gas_used = compiler_gas_used;
-
-        target
-    }
-
-    fn block_for_jump_target(&self, target: Inst) -> Option<Block> {
-        let target = self.redirects.get(&target).copied().unwrap_or(target);
-        self.cfg.inst_to_block.get(target).copied().flatten()
     }
 
     fn jumpdest_targets_for_value(
@@ -960,10 +842,30 @@ impl Bytecode<'_> {
         (!targets.is_empty()).then_some(targets)
     }
 
-    fn record_edge_state(&self, succ: Block, stack: &[AbsValue], edge_states: &mut EdgeStates) {
-        if self.insts[self.cfg.blocks[succ].insts.start].is_jumpdest() {
-            push_unique_state(&mut edge_states[succ], stack);
+    fn block_for_jump_target(&self, target: Inst) -> Option<Block> {
+        let target = self.redirects.get(&target).copied().unwrap_or(target);
+        self.cfg.inst_to_block.get(target).copied().flatten()
+    }
+
+    fn is_stack_balance_return_block(&self, bid: Block) -> bool {
+        let block = &self.cfg.blocks[bid];
+        if self.insts[block.terminator()].opcode != op::JUMP {
+            return false;
         }
+
+        block.insts().all(|inst| {
+            matches!(
+                self.insts[inst].opcode,
+                op::JUMPDEST
+                    | op::POP
+                    | op::JUMP
+                    | op::DUP1..=op::DUP16
+                    | op::SWAP1..=op::SWAP16
+                    | op::DUPN
+                    | op::SWAPN
+                    | op::EXCHANGE
+            )
+        })
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -987,7 +889,7 @@ impl Bytecode<'_> {
                 continue;
             }
             let ti = self.pc_to_inst(target_pc);
-            if let Some(tb) = self.block_for_jump_target(ti)
+            if let Some(tb) = self.cfg.inst_to_block[ti]
                 && !discovered[bid].contains(&tb)
             {
                 discovered[bid].push(tb);
@@ -1068,22 +970,22 @@ impl Bytecode<'_> {
 
     /// Run a worklist-based fixpoint to compute abstract block states.
     ///
-    /// Returns `(discovered_edges, edge_states, converged)`.
+    /// Returns `(discovered_edges, converged)`.
     fn run_fixpoint(
         &mut self,
         block_states: &mut IndexVec<Block, BlockState>,
         const_sets: &mut ConstSetInterner,
-    ) -> (DiscoveredEdges, EdgeStates, bool) {
+    ) -> (IndexVec<Block, SmallVec<[Block; 4]>>, bool) {
         let num_blocks = self.cfg.blocks.len();
         let mut worklist = Worklist::new(num_blocks);
         worklist.push(Block::from_usize(0));
 
         // Discovered dynamic-jump target edges per block.
-        let mut discovered: DiscoveredEdges = IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
+        let mut discovered: IndexVec<Block, SmallVec<[Block; 4]>> =
+            IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
         // Reverse map: discovered predecessors per block.
         let mut disc_preds: IndexVec<Block, SmallVec<[Block; 4]>> =
             IndexVec::from_vec(vec![SmallVec::new(); num_blocks]);
-        let mut edge_states: EdgeStates = IndexVec::from_vec(vec![Vec::new(); num_blocks]);
 
         let max_iterations = num_blocks * 8;
         let mut iterations = 0;
@@ -1130,7 +1032,6 @@ impl Bytecode<'_> {
 
             // Propagate to static CFG successors and discovered dynamic-jump targets.
             for &succ in block.succs.iter().chain(&discovered[bid]) {
-                self.record_edge_state(succ, &stack_buf, &mut edge_states);
                 if block_states[succ].join(&stack_buf, const_sets) {
                     worklist.push(succ);
                 }
@@ -1142,7 +1043,7 @@ impl Bytecode<'_> {
             msg = if converged { "converged" } else { "did not converge" },
         );
 
-        (discovered, edge_states, converged)
+        (discovered, converged)
     }
 
     /// Interpret a sequence of instructions on the abstract stack.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -682,21 +682,6 @@ impl Bytecode<'_> {
         // When the fixpoint didn't converge, partially-discovered ConstSets may be
         // incomplete, so we must conservatively invalidate them too.
         if has_top_jump || !converged {
-            let resolved_before_invalidation = jump_targets
-                .iter()
-                .filter(|(_, target)| matches!(target, JumpTarget::Resolved(_)))
-                .count();
-            let invalid_before_invalidation = jump_targets
-                .iter()
-                .filter(|(_, target)| matches!(target, JumpTarget::Invalid))
-                .count();
-            debug!(
-                has_top_jump,
-                converged,
-                resolved_before_invalidation,
-                invalid_before_invalidation,
-                "invalidating suspect jump resolutions"
-            );
             self.invalidate_suspect_jumps(
                 &mut jump_targets,
                 &block_states,
@@ -1065,13 +1050,6 @@ impl Bytecode<'_> {
             if let Some(bid) = self.cfg.inst_to_block[*inst]
                 && suspect[bid.index()]
             {
-                trace!(
-                    %inst,
-                    pc = self.pc(*inst),
-                    %bid,
-                    target = ?target,
-                    "invalidated suspect jump resolution"
-                );
                 *target = JumpTarget::Top;
             }
         }

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -463,7 +463,7 @@ mod tests {
         bytecode.config = AnalysisConfig::DEDUP;
         bytecode.analyze().unwrap();
 
-        assert_eq!(bytecode.redirects.len(), 13);
+        assert_eq!(bytecode.redirects.len(), 20);
     }
 
     #[test]

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -106,11 +106,12 @@ def dump_subdir(bench: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _indicator(delta: float) -> str:
-    """🟢 for improvement (negative delta), 🔴 for regression, empty for neutral."""
-    if delta < 0:
+def _indicator(delta: float, lower_is_better: bool = True) -> str:
+    """🟢 for improvement, 🔴 for regression, empty for neutral."""
+    score = delta if lower_is_better else -delta
+    if score < 0:
         return " 🟢"
-    if delta > 0:
+    if score > 0:
         return " 🔴"
     return ""
 
@@ -120,13 +121,56 @@ def fmt_diff(base: int, current: int) -> str:
     return "=" if d == 0 else f"{d:+d}"
 
 
-def fmt_pct(base: float | int, current: float | int) -> str:
+def fmt_pct(
+    base: float | int, current: float | int, lower_is_better: bool = True
+) -> str:
     if base == 0:
         return "-"
     pct = (current - base) / base * 100
     if round(pct, 1) == 0:
         return "="
-    return f"{pct:+.1f}%{_indicator(pct)}"
+    return f"{pct:+.1f}%{_indicator(pct, lower_is_better)}"
+
+
+def fmt_change(
+    base: float | int, current: float | int, lower_is_better: bool = True
+) -> str:
+    if base == 0:
+        delta = current - base
+        if delta == 0:
+            return "="
+        return f"{delta:+g}{_indicator(delta, lower_is_better)}"
+    return fmt_pct(base, current, lower_is_better)
+
+
+def fmt_ratio(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "-"
+    return f"{numerator}/{denominator} ({numerator / denominator * 100:.0f}%)"
+
+
+def fmt_ratio_change(
+    base_numerator: int,
+    base_denominator: int,
+    current_numerator: int,
+    current_denominator: int,
+    lower_is_better: bool = False,
+) -> str:
+    base = base_numerator / base_denominator if base_denominator else 0.0
+    current = current_numerator / current_denominator if current_denominator else 0.0
+    return fmt_change(base, current, lower_is_better)
+
+
+def ratio_is_noise(
+    base_numerator: int,
+    base_denominator: int,
+    current_numerator: int,
+    current_denominator: int,
+    noise: float,
+) -> bool:
+    base = base_numerator / base_denominator if base_denominator else 0.0
+    current = current_numerator / current_denominator if current_denominator else 0.0
+    return is_noise(base, current, noise)
 
 
 def fmt_detail(current: str | int, base: str | int, diff: str) -> str:
@@ -150,6 +194,7 @@ def is_noise(base: float | int, current: float | int, noise: float) -> bool:
 # (the `<details>` table still shows them).
 NOISE_CODEGEN = 1.0  # codegen line counts, jit size, spills, reloads
 NOISE_TIME = 5.0  # compile times (high run-to-run variance)
+NOISE_ANALYSIS = 0.0  # analysis counters are deterministic
 
 
 def fmt_dur(s: float) -> str:
@@ -681,6 +726,17 @@ class CompileTime(Analysis):
 
 
 class JumpResolution(Analysis):
+    KEYS = ["local", "non_adj", "pcr", "fixpt", "unresolved", "total"]
+    HEADERS = ["benchmark", "local", "nonadj", "pcr", "fixpt", "unres", "total"]
+    LOWER_IS_BETTER = {
+        "local": False,
+        "non_adj": False,
+        "pcr": False,
+        "fixpt": False,
+        "unresolved": True,
+        "total": False,
+    }
+
     def needs_codegen(self) -> bool:
         return False
 
@@ -727,24 +783,102 @@ class JumpResolution(Analysis):
             "total": total,
         }
 
+    @classmethod
+    def _collect(cls, benches, outputs):
+        rows = [(bench_name(bench), cls._analyze(outputs.get(bench, ""))) for bench in benches]
+        totals = {k: 0 for k in cls.KEYS}
+        for _, stats in rows:
+            for key in cls.KEYS:
+                totals[key] += stats[key]
+        return rows, totals
+
     def report(self, benches, dump_dir, outputs):
         print("### Jump resolution\n")
-        headers = ["benchmark", "local", "nonadj", "pcr", "fixpt", "unres", "total"]
+        rows, totals = self._collect(benches, outputs)
+        table = [[name, *[s[k] for k in self.KEYS]] for name, s in rows]
+        table.append(["**TOTAL**", *[f"**{totals[k]}**" for k in self.KEYS]])
+        print_table(self.HEADERS, table)
+
+    def report_diff(
+        self, benches, dump_dir, outputs, base_dump, base_outputs, base_label
+    ):
+        cur_rows, cur_totals = self._collect(benches, outputs)
+        base_rows, base_totals = self._collect(benches, base_outputs)
+        base_map = dict(base_rows)
+
+        print("### Jump resolution\n")
         table = []
-        for bench in benches:
-            s = self._analyze(outputs.get(bench, ""))
+        for name, cur in cur_rows:
+            base = base_map.get(name)
+            if not base:
+                table.append([name, *[cur[k] for k in self.KEYS]])
+                continue
+            if all(base[k] == cur[k] for k in self.KEYS):
+                continue
             table.append(
                 [
-                    bench_name(bench),
-                    s["local"],
-                    s["non_adj"],
-                    s["pcr"],
-                    s["fixpt"],
-                    s["unresolved"],
-                    s["total"],
+                    name,
+                    *[
+                        fmt_change(
+                            base[k],
+                            cur[k],
+                            lower_is_better=self.LOWER_IS_BETTER[k],
+                        )
+                        for k in self.KEYS
+                    ],
                 ]
             )
-        print_table(headers, table)
+        table.append(
+            [
+                "**TOTAL**",
+                *[
+                    f"**{fmt_change(base_totals[k], cur_totals[k], lower_is_better=self.LOWER_IS_BETTER[k])}**"
+                    for k in self.KEYS
+                ],
+            ]
+        )
+        print_table(self.HEADERS, table)
+
+        print("<details><summary>Full jump resolution</summary>\n")
+        detail_table = []
+        for name, cur in cur_rows:
+            base = base_map.get(name, {k: 0 for k in self.KEYS})
+            detail_table.append(
+                [
+                    name,
+                    *[
+                        fmt_detail(
+                            cur[k],
+                            base[k],
+                            fmt_change(
+                                base[k],
+                                cur[k],
+                                lower_is_better=self.LOWER_IS_BETTER[k],
+                            ),
+                        )
+                        for k in self.KEYS
+                    ],
+                ]
+            )
+        detail_table.append(
+            [
+                "**TOTAL**",
+                *[
+                    fmt_detail_bold(
+                        cur_totals[k],
+                        base_totals[k],
+                        fmt_change(
+                            base_totals[k],
+                            cur_totals[k],
+                            lower_is_better=self.LOWER_IS_BETTER[k],
+                        ),
+                    )
+                    for k in self.KEYS
+                ],
+            ]
+        )
+        print_table(self.HEADERS, detail_table)
+        print("</details>\n")
 
 
 # ---------------------------------------------------------------------------
@@ -803,36 +937,58 @@ class BlockStats(Analysis):
             "block_median": int(m.group(10)),
         }
 
+    @staticmethod
+    def _collect(benches, outputs):
+        rows = []
+        for bench in benches:
+            stats = BlockStats._parse(outputs.get(bench, ""))
+            if stats:
+                rows.append((bench_name(bench), stats))
+        return rows
+
     def report(self, benches, dump_dir, outputs):
         print("### IR stats\n")
         headers = ["benchmark"] + IR_STAT_KEYS
-        table = []
-        for bench in benches:
-            s = self._parse(outputs.get(bench, ""))
-            if not s:
-                continue
-            table.append([bench_name(bench)] + [s[k] for k in IR_STAT_KEYS])
+        rows = self._collect(benches, outputs)
+        table = [[name] + [s[k] for k in IR_STAT_KEYS] for name, s in rows]
         print_table(headers, table)
 
     def report_diff(
         self, benches, dump_dir, outputs, base_dump, base_outputs, base_label
     ):
+        cur_rows = self._collect(benches, outputs)
+        base_rows = self._collect(benches, base_outputs)
+        base_map = dict(base_rows)
+
         print("### IR stats\n")
         headers = ["benchmark"] + IR_STAT_KEYS
         table = []
-        for bench in benches:
-            cur = self._parse(outputs.get(bench, ""))
-            base = self._parse(base_outputs.get(bench, ""))
-            if not cur:
-                continue
+        for name, cur in cur_rows:
+            base = base_map.get(name)
             if not base:
-                table.append([bench_name(bench)] + [cur[k] for k in IR_STAT_KEYS])
-            else:
-                table.append(
-                    [bench_name(bench)]
-                    + [fmt_pct(base[k], cur[k]) for k in IR_STAT_KEYS]
-                )
+                table.append([name] + [cur[k] for k in IR_STAT_KEYS])
+                continue
+            pairs = [(base[k], cur[k]) for k in IR_STAT_KEYS]
+            if all(is_noise(b, c, NOISE_ANALYSIS) for b, c in pairs):
+                continue
+            table.append([name] + [fmt_change(b, c) for b, c in pairs])
         print_table(headers, table)
+
+        print("<details><summary>Full IR stats</summary>\n")
+        detail_table = []
+        for name, cur in cur_rows:
+            base = base_map.get(name, {k: 0 for k in IR_STAT_KEYS})
+            detail_table.append(
+                [
+                    name,
+                    *[
+                        fmt_detail(cur[k], base[k], fmt_change(base[k], cur[k]))
+                        for k in IR_STAT_KEYS
+                    ],
+                ]
+            )
+        print_table(headers, detail_table)
+        print("</details>\n")
 
 
 # ---------------------------------------------------------------------------
@@ -926,39 +1082,251 @@ class InputStats(Analysis):
                 agg["per_input"][i][2] += u
 
     @classmethod
-    def _print(cls, stats, title):
-        print(f"\n=== {title} ===")
+    def _collect(cls, benches, outputs):
+        rows = []
+        aggregate = {}
+        for bench in benches:
+            stats = cls._parse(outputs.get(bench, ""))
+            if stats:
+                rows.append((bench_name(bench), stats))
+                cls._merge(aggregate, stats)
+        return rows, aggregate
+
+    @staticmethod
+    def _per_input_totals(stats):
+        total = sum(i[0] for i in stats["per_input"])
+        const = sum(i[1] for i in stats["per_input"])
+        usize = sum(i[2] for i in stats["per_input"])
+        return total, const, usize
+
+    @classmethod
+    def _stat_table(cls, stats):
+        rows = []
         for name in sorted(stats, key=lambda n: stats[n].get("opbyte", 0)):
             s = stats[name]
-            t = s["total"]
-            if t == 0:
+            total = s["total"]
+            if total == 0:
                 continue
-            ac = s["all_const"]
-            co = s.get("const_output", 0)
-            line = (
-                f"  {name:<16} {t} occ, {s['inputs']} inputs, "
-                f"all_const={ac}/{t} ({cls._pct(ac, t)})"
+            input_total, input_const, input_usize = cls._per_input_totals(s)
+            rows.append(
+                [
+                    name,
+                    total,
+                    s["inputs"],
+                    fmt_ratio(s["all_const"], total),
+                    fmt_ratio(s.get("const_output", 0), total),
+                    fmt_ratio(input_const, input_total),
+                    fmt_ratio(input_usize, input_total),
+                ]
             )
-            if co:
-                line += f", const_output={co}/{t} ({cls._pct(co, t)})"
-            print(line)
-            for i, [total, const, usize] in enumerate(s["per_input"]):
-                if total > 0:
-                    print(
-                        f"    [{i}]: const={const}/{total} ({cls._pct(const, total)}), "
-                        f"fits_usize={usize}/{total} ({cls._pct(usize, total)})"
-                    )
+        return rows
+
+    @classmethod
+    def _stat_detail(cls, stats):
+        parts = []
+        for i, (total, const, usize) in enumerate(stats["per_input"]):
+            if total > 0:
+                parts.append(
+                    f"[{i}] const={fmt_ratio(const, total)}, usize={fmt_ratio(usize, total)}"
+                )
+        return "; ".join(parts) if parts else "-"
 
     def report(self, benches, dump_dir, outputs):
         print("### Constant-input stats\n")
-        aggregate = {}
-        for bench in benches:
-            stats = self._parse(outputs.get(bench, ""))
-            if stats:
-                self._merge(aggregate, stats)
-                self._print(stats, bench_name(bench))
-        self._print(aggregate, f"AGGREGATE ({len(benches)} benchmarks)")
-        print()
+        rows, aggregate = self._collect(benches, outputs)
+        headers = [
+            "opcode",
+            "occ",
+            "inputs",
+            "all const",
+            "const output",
+            "input const",
+            "fits usize",
+        ]
+        print_table(headers, self._stat_table(aggregate))
+
+        print("<details><summary>Per-benchmark constant-input stats</summary>\n")
+        for name, stats in rows:
+            print(f"#### {name}\n")
+            print_table(headers, self._stat_table(stats))
+        print("</details>\n")
+
+    def report_diff(
+        self, benches, dump_dir, outputs, base_dump, base_outputs, base_label
+    ):
+        _, cur = self._collect(benches, outputs)
+        _, base = self._collect(benches, base_outputs)
+        names = sorted(
+            set(cur) | set(base),
+            key=lambda n: cur.get(n, base.get(n, {})).get("opbyte", 0),
+        )
+
+        print("### Constant-input stats\n")
+        headers = [
+            "opcode",
+            "occ",
+            "all const",
+            "const output",
+            "input const",
+            "fits usize",
+        ]
+        table = []
+        for name in names:
+            c = cur.get(name)
+            b = base.get(name)
+            if not c:
+                continue
+            if not b:
+                table.append([name, c["total"], "-", "-", "-", "-"])
+                continue
+
+            c_input_total, c_input_const, c_input_usize = self._per_input_totals(c)
+            b_input_total, b_input_const, b_input_usize = self._per_input_totals(b)
+            changes = [
+                not is_noise(b["total"], c["total"], NOISE_ANALYSIS),
+                not ratio_is_noise(
+                    b["all_const"], b["total"], c["all_const"], c["total"], NOISE_ANALYSIS
+                ),
+                not ratio_is_noise(
+                    b.get("const_output", 0),
+                    b["total"],
+                    c.get("const_output", 0),
+                    c["total"],
+                    NOISE_ANALYSIS,
+                ),
+                not ratio_is_noise(
+                    b_input_const,
+                    b_input_total,
+                    c_input_const,
+                    c_input_total,
+                    NOISE_ANALYSIS,
+                ),
+                not ratio_is_noise(
+                    b_input_usize,
+                    b_input_total,
+                    c_input_usize,
+                    c_input_total,
+                    NOISE_ANALYSIS,
+                ),
+            ]
+            if not any(changes):
+                continue
+            table.append(
+                [
+                    name,
+                    fmt_change(b["total"], c["total"]),
+                    fmt_ratio_change(b["all_const"], b["total"], c["all_const"], c["total"]),
+                    fmt_ratio_change(
+                        b.get("const_output", 0),
+                        b["total"],
+                        c.get("const_output", 0),
+                        c["total"],
+                    ),
+                    fmt_ratio_change(
+                        b_input_const,
+                        b_input_total,
+                        c_input_const,
+                        c_input_total,
+                    ),
+                    fmt_ratio_change(
+                        b_input_usize,
+                        b_input_total,
+                        c_input_usize,
+                        c_input_total,
+                    ),
+                ]
+            )
+        print_table(headers, table)
+
+        print("<details><summary>Full constant-input stats</summary>\n")
+        detail_headers = [
+            "opcode",
+            "occ",
+            "inputs",
+            "all const",
+            "const output",
+            "input const",
+            "fits usize",
+            "per input",
+        ]
+        detail_table = []
+        for name in names:
+            c = cur.get(name)
+            b = base.get(name)
+            if not c:
+                continue
+            if not b:
+                detail_table.append(
+                    [
+                        name,
+                        c["total"],
+                        c["inputs"],
+                        fmt_ratio(c["all_const"], c["total"]),
+                        fmt_ratio(c.get("const_output", 0), c["total"]),
+                        "-",
+                        "-",
+                        self._stat_detail(c),
+                    ]
+                )
+                continue
+
+            c_input_total, c_input_const, c_input_usize = self._per_input_totals(c)
+            b_input_total, b_input_const, b_input_usize = self._per_input_totals(b)
+            detail_table.append(
+                [
+                    name,
+                    fmt_detail(
+                        c["total"],
+                        b["total"],
+                        fmt_change(b["total"], c["total"]),
+                    ),
+                    fmt_detail(c["inputs"], b["inputs"], fmt_diff(b["inputs"], c["inputs"])),
+                    fmt_detail(
+                        fmt_ratio(c["all_const"], c["total"]),
+                        fmt_ratio(b["all_const"], b["total"]),
+                        fmt_ratio_change(
+                            b["all_const"], b["total"], c["all_const"], c["total"]
+                        ),
+                    ),
+                    fmt_detail(
+                        fmt_ratio(c.get("const_output", 0), c["total"]),
+                        fmt_ratio(b.get("const_output", 0), b["total"]),
+                        fmt_ratio_change(
+                            b.get("const_output", 0),
+                            b["total"],
+                            c.get("const_output", 0),
+                            c["total"],
+                        ),
+                    ),
+                    fmt_detail(
+                        fmt_ratio(c_input_const, c_input_total),
+                        fmt_ratio(b_input_const, b_input_total),
+                        fmt_ratio_change(
+                            b_input_const,
+                            b_input_total,
+                            c_input_const,
+                            c_input_total,
+                        ),
+                    ),
+                    fmt_detail(
+                        fmt_ratio(c_input_usize, c_input_total),
+                        fmt_ratio(b_input_usize, b_input_total),
+                        fmt_ratio_change(
+                            b_input_usize,
+                            b_input_total,
+                            c_input_usize,
+                            c_input_total,
+                        ),
+                    ),
+                    fmt_detail(
+                        self._stat_detail(c),
+                        self._stat_detail(b),
+                        "=" if self._stat_detail(c) == self._stat_detail(b) else "changed",
+                    ),
+                ]
+            )
+        print_table(detail_headers, detail_table)
+        print("</details>\n")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -726,13 +726,12 @@ class CompileTime(Analysis):
 
 
 class JumpResolution(Analysis):
-    KEYS = ["local", "non_adj", "hint", "edge", "fixpt", "unresolved", "total"]
-    HEADERS = ["benchmark", "local", "nonadj", "hint", "edge", "fixpt", "unres", "total"]
+    KEYS = ["local", "non_adj", "pcr", "fixpt", "unresolved", "total"]
+    HEADERS = ["benchmark", "local", "nonadj", "pcr", "fixpt", "unres", "total"]
     LOWER_IS_BETTER = {
         "local": False,
         "non_adj": False,
-        "hint": False,
-        "edge": False,
+        "pcr": False,
         "fixpt": False,
         "unresolved": True,
         "total": False,
@@ -757,8 +756,7 @@ class JumpResolution(Analysis):
     def _analyze(cls, output: str) -> dict[str, int]:
         local_res = cls._last_match(r"local_jumps.*newly_resolved=(\d+)", output)
         non_adj = cls._count_matches(r"resolved non-adjacent jump", output)
-        hint_res = cls._count_matches(r"resolved via ranked hint", output)
-        edge_res = cls._count_matches(r"resolved via edge state", output)
+        pcr_res = cls._count_matches(r"resolved via PCR hint", output)
         fixpt_res = cls._last_match(r"ba:.*newly_resolved=(\d+)", output)
 
         ba_unres_matches = re.findall(
@@ -779,8 +777,7 @@ class JumpResolution(Analysis):
         return {
             "local": local_res,
             "non_adj": non_adj,
-            "hint": hint_res,
-            "edge": edge_res,
+            "pcr": pcr_res,
             "fixpt": fixpt_res,
             "unresolved": unresolved,
             "total": total,

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -726,12 +726,13 @@ class CompileTime(Analysis):
 
 
 class JumpResolution(Analysis):
-    KEYS = ["local", "non_adj", "pcr", "fixpt", "unresolved", "total"]
-    HEADERS = ["benchmark", "local", "nonadj", "pcr", "fixpt", "unres", "total"]
+    KEYS = ["local", "non_adj", "hint", "edge", "fixpt", "unresolved", "total"]
+    HEADERS = ["benchmark", "local", "nonadj", "hint", "edge", "fixpt", "unres", "total"]
     LOWER_IS_BETTER = {
         "local": False,
         "non_adj": False,
-        "pcr": False,
+        "hint": False,
+        "edge": False,
         "fixpt": False,
         "unresolved": True,
         "total": False,
@@ -756,7 +757,8 @@ class JumpResolution(Analysis):
     def _analyze(cls, output: str) -> dict[str, int]:
         local_res = cls._last_match(r"local_jumps.*newly_resolved=(\d+)", output)
         non_adj = cls._count_matches(r"resolved non-adjacent jump", output)
-        pcr_res = cls._count_matches(r"resolved via PCR hint", output)
+        hint_res = cls._count_matches(r"resolved via ranked hint", output)
+        edge_res = cls._count_matches(r"resolved via edge state", output)
         fixpt_res = cls._last_match(r"ba:.*newly_resolved=(\d+)", output)
 
         ba_unres_matches = re.findall(
@@ -777,7 +779,8 @@ class JumpResolution(Analysis):
         return {
             "local": local_res,
             "non_adj": non_adj,
-            "pcr": pcr_res,
+            "hint": hint_res,
+            "edge": edge_res,
             "fixpt": fixpt_res,
             "unresolved": unresolved,
             "total": total,


### PR DESCRIPTION
Resolve stack-balance return jumps using ranked continuation hints from converged static call states. The pass only applies hints to return blocks with known fixpoint state, avoiding edges from unreachable local snapshots.

This also updates the benchmark script so non-codegen analyses get the same diff presentation as codegen stats: a compact summary table, emoji-marked percent deltas, and a collapsible full details table.

## Benchmarks

Headline numbers vs `main`: total codegen size moves by -0.1% across `unopt.ll`, `opt.ll`, `opt.s`, and JIT size. WETH is the material win: `opt.ll` -25.2%, `opt.s` -15.5%, and JIT size -8.9%. Total measured compile time is +2.9%, with WETH compile time -19.6%.

Jump resolution: WETH improves from 11 unresolved dynamic jumps on `main` to 0 on this branch. The summary table shows `pcr=+1`, `fixpt=+11`, and `unres=-100.0%` for WETH.

### Codegen statistics

| benchmark   |    unopt.ll |      opt.ll |       opt.s |    jit size |   i256 loads |   i256 stores |   mresize |   spills |   reloads |
|:------------|------------:|------------:|------------:|------------:|-------------:|--------------:|----------:|---------:|----------:|
| weth        |     -8.4% 🟢 |    -25.2% 🟢 |    -15.5% 🟢 |     -8.9% 🟢 |     -12.0% 🟢 |       -8.0% 🟢 |  -11.4% 🟢 |  -7.7% 🟢 |  +10.7% 🔴 |
| **TOTAL**   | **-0.1% 🟢** | **-0.1% 🟢** | **-0.1% 🟢** | **-0.1% 🟢** |  **-0.1% 🟢** |         **=** |     **=** |    **=** |     **=** |

<details><summary>Full details</summary>

| benchmark          |                          unopt.ll |                          opt.ll |                             opt.s |                          jit size |                    i256 loads |             i256 stores |               mresize |                spills |                 reloads |
|:-------------------|----------------------------------:|--------------------------------:|----------------------------------:|----------------------------------:|------------------------------:|------------------------:|----------------------:|----------------------:|------------------------:|
| fibonacci-calldata |                   370<br>370<br>= |                 126<br>126<br>= |                   354<br>354<br>= |               400 B<br>400 B<br>= |                   2<br>2<br>= |             2<br>2<br>= |           2<br>2<br>= |           5<br>5<br>= |             4<br>4<br>= |
| factorial          |                   362<br>362<br>= |                 128<br>128<br>= |                   392<br>392<br>= |               530 B<br>530 B<br>= |                   2<br>2<br>= |             2<br>2<br>= |           2<br>2<br>= |           5<br>5<br>= |             6<br>6<br>= |
| counter            |                 1038<br>1038<br>= |                 359<br>359<br>= |                   602<br>602<br>= |               914 B<br>914 B<br>= |                   9<br>9<br>= |             9<br>9<br>= |           3<br>3<br>= |           0<br>0<br>- |             0<br>0<br>- |
| snailtracer        |               61771<br>61771<br>= |             27714<br>27714<br>= |               47245<br>47245<br>= |       125.8 KiB<br>125.8 KiB<br>= |             1540<br>1540<br>= |       2172<br>2172<br>= |       452<br>452<br>= |         29<br>29<br>= |         600<br>600<br>= |
| weth               |         13355<br>12235<br>-8.4% 🟢 |        4360<br>3263<br>-25.2% 🟢 |          7030<br>5937<br>-15.5% 🟢 |   20.8 KiB<br>18.9 KiB<br>-8.9% 🟢 |        267<br>235<br>-12.0% 🟢 |   349<br>321<br>-8.0% 🟢 |  35<br>31<br>-11.4% 🟢 |   13<br>12<br>-7.7% 🟢 |    28<br>31<br>+10.7% 🔴 |
| hash_10k           |                 1036<br>1036<br>= |                 376<br>376<br>= |                   715<br>715<br>= |           1.6 KiB<br>1.6 KiB<br>= |                 17<br>17<br>= |           21<br>21<br>= |           6<br>6<br>= |           0<br>0<br>- |             0<br>0<br>- |
| erc20_transfer     |               14652<br>14652<br>= |               5673<br>5673<br>= |               10766<br>10766<br>= |         27.8 KiB<br>27.8 KiB<br>= |               309<br>309<br>= |         452<br>452<br>= |         53<br>53<br>= |         11<br>11<br>= |           33<br>33<br>= |
| push0_proxy        |                   371<br>371<br>= |                 183<br>183<br>= |                   339<br>339<br>= |               633 B<br>633 B<br>= |                   1<br>1<br>= |           15<br>15<br>= |           0<br>0<br>- |           0<br>0<br>- |             0<br>0<br>- |
| usdc_proxy         |                 7446<br>7446<br>= |               2914<br>2914<br>= |                 5085<br>5085<br>= |         11.8 KiB<br>11.8 KiB<br>= |               104<br>104<br>= |         196<br>196<br>= |         22<br>22<br>= |           9<br>9<br>= |             8<br>8<br>= |
| fiat_token         |               82413<br>82413<br>= |             29357<br>29357<br>= |               49530<br>49530<br>= |       153.7 KiB<br>153.7 KiB<br>= |             1803<br>1803<br>= |       2575<br>2575<br>= |       313<br>313<br>= |         86<br>86<br>= |         140<br>140<br>= |
| uniswap_v2_pair    |               46530<br>46530<br>= |             17194<br>17194<br>= |               28601<br>28601<br>= |         87.0 KiB<br>87.0 KiB<br>= |               926<br>926<br>= |       1398<br>1398<br>= |       176<br>176<br>= |         44<br>44<br>= |           69<br>69<br>= |
| univ2_router       |               87397<br>87397<br>= |             32338<br>32338<br>= |               51399<br>51399<br>= |       165.1 KiB<br>165.1 KiB<br>= |             2061<br>2061<br>= |       2819<br>2819<br>= |       362<br>362<br>= |       169<br>169<br>= |         547<br>547<br>= |
| seaport            |             145378<br>145378<br>= |             64808<br>64808<br>= |             112445<br>112445<br>= |       331.6 KiB<br>331.6 KiB<br>= |             4577<br>4577<br>= |       5099<br>5099<br>= |       866<br>866<br>= |       228<br>228<br>= |       3958<br>3958<br>= |
| airdrop            |               28825<br>28825<br>= |             10991<br>10991<br>= |               18680<br>18680<br>= |         48.5 KiB<br>48.5 KiB<br>= |               575<br>575<br>= |         861<br>861<br>= |       100<br>100<br>= |         39<br>39<br>= |         224<br>224<br>= |
| bswap64            |                 2195<br>2195<br>= |                 576<br>576<br>= |                   887<br>887<br>= |           2.2 KiB<br>2.2 KiB<br>= |                 29<br>29<br>= |           32<br>32<br>= |           6<br>6<br>= |           0<br>0<br>- |             0<br>0<br>- |
| bswap64_opt        |                 1917<br>1917<br>= |                 584<br>584<br>= |                 1043<br>1043<br>= |           2.8 KiB<br>2.8 KiB<br>= |                 34<br>34<br>= |           54<br>54<br>= |           8<br>8<br>= |           2<br>2<br>= |             2<br>2<br>= |
| eip4788            |                   614<br>614<br>= |                 241<br>241<br>= |                   473<br>473<br>= |               764 B<br>764 B<br>= |                   9<br>9<br>= |           10<br>10<br>= |           2<br>2<br>= |           1<br>1<br>= |             1<br>1<br>= |
| eip2935            |                   559<br>559<br>= |                 213<br>213<br>= |                   463<br>463<br>= |               794 B<br>794 B<br>= |                   7<br>7<br>= |             6<br>6<br>= |           2<br>2<br>= |           0<br>0<br>- |             0<br>0<br>- |
| curve_stableswap   |               24115<br>24115<br>= |               9436<br>9436<br>= |               16631<br>16631<br>= |         29.7 KiB<br>29.7 KiB<br>= |               526<br>526<br>= |         827<br>827<br>= |         50<br>50<br>= |         19<br>19<br>= |           27<br>27<br>= |
| onchain_lm_v2      |               65644<br>65644<br>= |             24072<br>24072<br>= |               43717<br>43717<br>= |       111.8 KiB<br>111.8 KiB<br>= |             1369<br>1369<br>= |       1654<br>1654<br>= |       169<br>169<br>= |         61<br>61<br>= |         289<br>289<br>= |
| burntpix           |             226843<br>226843<br>= |             89254<br>89254<br>= |             148816<br>148816<br>= |       240.2 KiB<br>240.2 KiB<br>= |             5723<br>5723<br>= |       6745<br>6745<br>= |     1030<br>1030<br>= |       358<br>358<br>= |       3374<br>3374<br>= |
| 0x184e2e0d92…      |             138819<br>138819<br>= |             43852<br>43852<br>= |               74687<br>74687<br>= |       241.9 KiB<br>241.9 KiB<br>= |             3125<br>3125<br>= |       4732<br>4732<br>= |       253<br>253<br>= |       161<br>161<br>= |       1856<br>1856<br>= |
| 0x26f3fa5857…      |             150890<br>150890<br>= |             50065<br>50065<br>= |               88699<br>88699<br>= |       320.2 KiB<br>320.2 KiB<br>= |             3797<br>3797<br>= |       5088<br>5088<br>= |       832<br>832<br>= |       186<br>186<br>= |         751<br>751<br>= |
| 0x7497bfab49…      |             151235<br>151235<br>= |             50172<br>50172<br>= |               87776<br>87776<br>= |       318.5 KiB<br>318.5 KiB<br>= |             3808<br>3808<br>= |       5077<br>5077<br>= |       823<br>823<br>= |       205<br>205<br>= |       1375<br>1375<br>= |
| 0x8819f74c38…      |             160455<br>160455<br>= |             56591<br>56591<br>= |               95933<br>95933<br>= |       324.5 KiB<br>324.5 KiB<br>= |             4110<br>4110<br>= |       4911<br>4911<br>= |       864<br>864<br>= |         84<br>84<br>= |         562<br>562<br>= |
| 0x9806ed1505…      |             127930<br>127930<br>= |             45614<br>45614<br>= |               68219<br>68219<br>= |       203.8 KiB<br>203.8 KiB<br>= |             2585<br>2585<br>= |       3453<br>3453<br>= |       402<br>402<br>= |       268<br>268<br>= |         812<br>812<br>= |
| 0xcc74d4c66f…      |             131624<br>131624<br>= |             47929<br>47929<br>= |               75179<br>75179<br>= |       228.9 KiB<br>228.9 KiB<br>= |             2675<br>2675<br>= |       3449<br>3449<br>= |       663<br>663<br>= |       142<br>142<br>= |         773<br>773<br>= |
| 0xd450e90507…      |             145835<br>145835<br>= |             53262<br>53262<br>= |               81626<br>81626<br>= |       260.8 KiB<br>260.8 KiB<br>= |             2895<br>2895<br>= |       4360<br>4360<br>= |       974<br>974<br>= |       270<br>270<br>= |         405<br>405<br>= |
| 0xfbbee2ff80…      |             130152<br>130152<br>= |             47438<br>47438<br>= |               74390<br>74390<br>= |       226.5 KiB<br>226.5 KiB<br>= |             2645<br>2645<br>= |       3413<br>3413<br>= |       659<br>659<br>= |       143<br>143<br>= |         776<br>776<br>= |
| 0xfc5900eac5…      |             101755<br>101755<br>= |             34269<br>34269<br>= |               48966<br>48966<br>= |       148.5 KiB<br>148.5 KiB<br>= |             1959<br>1959<br>= |       2766<br>2766<br>= |       295<br>295<br>= |       130<br>130<br>= |         611<br>611<br>= |
| **TOTAL**          | **2051526<br>2050406<br>-0.1% 🟢** | **750089<br>748992<br>-0.1% 🟢** | **1240688<br>1239595<br>-0.1% 🟢** | **3.6 MiB<br>3.6 MiB<br>-0.1% 🟢** | **47489<br>47457<br>-0.1% 🟢** | **62547<br>62519<br>=** | **9424<br>9420<br>=** | **2668<br>2667<br>=** | **17231<br>17234<br>=** |

</details>

### Compile times

| benchmark          |       total |       parse |   translate |    finalize |     codegen |
|:-------------------|------------:|------------:|------------:|------------:|------------:|
| fibonacci-calldata |    +13.0% 🔴 |    +15.6% 🔴 |    +11.5% 🔴 |    +11.4% 🔴 |    +15.9% 🔴 |
| factorial          |     +6.0% 🔴 |     +8.3% 🔴 |     -0.2% 🟢 |     +4.7% 🔴 |     +8.8% 🔴 |
| counter            |     +8.9% 🔴 |     +9.0% 🔴 |    +10.7% 🔴 |     +7.8% 🔴 |    +10.6% 🔴 |
| snailtracer        |    +14.6% 🔴 |     +1.9% 🔴 |     -4.9% 🟢 |    +12.0% 🔴 |    +18.7% 🔴 |
| weth               |    -19.6% 🟢 |     -7.8% 🟢 |    -11.2% 🟢 |    -17.7% 🟢 |    -23.1% 🟢 |
| hash_10k           |     +7.3% 🔴 |    +13.6% 🔴 |     +2.3% 🔴 |     +5.6% 🔴 |    +10.5% 🔴 |
| erc20_transfer     |     +2.5% 🔴 |     +1.1% 🔴 |     -5.4% 🟢 |     +1.3% 🔴 |     +4.5% 🔴 |
| push0_proxy        |     +8.4% 🔴 |    +11.3% 🔴 |     +6.9% 🔴 |     +5.7% 🔴 |    +13.3% 🔴 |
| fiat_token         |    +10.7% 🔴 |     -7.9% 🟢 |     -2.6% 🟢 |     +8.8% 🔴 |    +14.5% 🔴 |
| uniswap_v2_pair    |     +7.8% 🔴 |     +1.4% 🔴 |     -3.0% 🟢 |    +11.0% 🔴 |     +3.6% 🔴 |
| seaport            |     +7.1% 🔴 |     -1.5% 🟢 |     +5.6% 🔴 |     +7.7% 🔴 |     +6.2% 🔴 |
| airdrop            |     +5.9% 🔴 |    -11.9% 🟢 |     +3.7% 🔴 |     +5.3% 🔴 |     +8.1% 🔴 |
| bswap64            |     +6.9% 🔴 |     +3.6% 🔴 |     +4.4% 🔴 |     +8.2% 🔴 |     +5.3% 🔴 |
| bswap64_opt        |     +6.2% 🔴 |     +0.4% 🔴 |     -0.4% 🟢 |     +4.9% 🔴 |     +9.4% 🔴 |
| eip4788            |     -1.8% 🟢 |     +7.5% 🔴 |     +1.5% 🔴 |     -3.9% 🟢 |     +0.9% 🔴 |
| eip2935            |     -0.3% 🟢 |    -26.7% 🟢 |    -28.7% 🟢 |     +1.6% 🔴 |     +4.6% 🔴 |
| onchain_lm_v2      |    -14.7% 🟢 |     +0.7% 🔴 |     -4.8% 🟢 |    -19.5% 🟢 |    -12.4% 🟢 |
| burntpix           |     -3.9% 🟢 |     +0.5% 🔴 |    -11.9% 🟢 |     -2.3% 🟢 |     -6.9% 🟢 |
| 0x184e2e0d92…      |    +22.3% 🔴 |     -3.1% 🟢 |     -9.1% 🟢 |     +6.2% 🔴 |    +50.4% 🔴 |
| 0x26f3fa5857…      |    +27.1% 🔴 |     +6.8% 🔴 |    +20.8% 🔴 |    +30.8% 🔴 |    +22.5% 🔴 |
| 0x7497bfab49…      |     -5.6% 🟢 |     +4.4% 🔴 |     -1.5% 🟢 |     -5.1% 🟢 |     -6.5% 🟢 |
| 0x8819f74c38…      |     -5.7% 🟢 |     +4.5% 🔴 |     -2.5% 🟢 |     -7.3% 🟢 |     -3.3% 🟢 |
| 0xcc74d4c66f…      |     +0.4% 🔴 |     +1.0% 🔴 |     +8.2% 🔴 |     +0.3% 🔴 |     +0.2% 🔴 |
| 0xd450e90507…      |     +0.3% 🔴 |     +5.8% 🔴 |     -7.2% 🟢 |     +0.3% 🔴 |     +0.4% 🔴 |
| 0xfbbee2ff80…      |     -1.4% 🟢 |     +2.2% 🔴 |     -5.2% 🟢 |     -1.1% 🟢 |     -1.9% 🟢 |
| **TOTAL**          | **+2.9% 🔴** | **+1.0% 🔴** | **-1.6% 🟢** | **+2.0% 🔴** | **+4.7% 🔴** |

<details><summary>Full compile times</summary>

| benchmark          |                             total |                             parse |                         translate |                          finalize |                           codegen |
|:-------------------|----------------------------------:|----------------------------------:|----------------------------------:|----------------------------------:|----------------------------------:|
| fibonacci-calldata |      9.47ms<br>10.7ms<br>+13.0% 🔴 |    223.8µs<br>258.8µs<br>+15.6% 🔴 |    474.2µs<br>529.0µs<br>+11.5% 🔴 |      5.60ms<br>6.24ms<br>+11.4% 🔴 |      3.17ms<br>3.68ms<br>+15.9% 🔴 |
| factorial          |       10.8ms<br>11.5ms<br>+6.0% 🔴 |     244.6µs<br>264.8µs<br>+8.3% 🔴 |     509.9µs<br>508.8µs<br>-0.2% 🟢 |       6.34ms<br>6.64ms<br>+4.7% 🔴 |       3.72ms<br>4.05ms<br>+8.8% 🔴 |
| counter            |       14.0ms<br>15.2ms<br>+8.9% 🔴 |     417.6µs<br>455.2µs<br>+9.0% 🔴 |    605.3µs<br>669.9µs<br>+10.7% 🔴 |       8.22ms<br>8.86ms<br>+7.8% 🔴 |      4.72ms<br>5.22ms<br>+10.6% 🔴 |
| snailtracer        |      1.973s<br>2.262s<br>+14.6% 🔴 |       9.96ms<br>10.2ms<br>+1.9% 🔴 |       13.0ms<br>12.4ms<br>-4.9% 🟢 |      1.139s<br>1.276s<br>+12.0% 🔴 |    811.2ms<br>963.1ms<br>+18.7% 🔴 |
| weth               |    198.1ms<br>159.3ms<br>-19.6% 🟢 |       2.91ms<br>2.68ms<br>-7.8% 🟢 |      3.25ms<br>2.89ms<br>-11.2% 🟢 |     115.3ms<br>94.9ms<br>-17.7% 🟢 |      76.6ms<br>58.9ms<br>-23.1% 🟢 |
| hash_10k           |       19.2ms<br>20.6ms<br>+7.3% 🔴 |    408.9µs<br>464.5µs<br>+13.6% 🔴 |     658.8µs<br>674.0µs<br>+2.3% 🔴 |       11.5ms<br>12.2ms<br>+5.6% 🔴 |      6.63ms<br>7.33ms<br>+10.5% 🔴 |
| erc20_transfer     |     369.8ms<br>379.0ms<br>+2.5% 🔴 |       2.85ms<br>2.88ms<br>+1.1% 🔴 |       3.48ms<br>3.29ms<br>-5.4% 🟢 |     217.7ms<br>220.4ms<br>+1.3% 🔴 |     145.8ms<br>152.4ms<br>+4.5% 🔴 |
| push0_proxy        |       9.59ms<br>10.4ms<br>+8.4% 🔴 |    237.0µs<br>263.8µs<br>+11.3% 🔴 |     465.7µs<br>497.7µs<br>+6.9% 🔴 |       5.71ms<br>6.04ms<br>+5.7% 🔴 |      3.17ms<br>3.59ms<br>+13.3% 🔴 |
| usdc_proxy         |     123.5ms<br>127.3ms<br>+3.0% 🔴 |       1.71ms<br>1.74ms<br>+1.7% 🔴 |       1.98ms<br>1.99ms<br>+0.6% 🔴 |       73.6ms<br>76.0ms<br>+3.2% 🔴 |       46.2ms<br>47.5ms<br>+2.8% 🔴 |
| fiat_token         |      1.569s<br>1.737s<br>+10.7% 🔴 |       18.6ms<br>17.1ms<br>-7.9% 🟢 |       16.1ms<br>15.7ms<br>-2.6% 🟢 |      931.9ms<br>1.014s<br>+8.8% 🔴 |    602.4ms<br>689.9ms<br>+14.5% 🔴 |
| uniswap_v2_pair    |     788.0ms<br>849.6ms<br>+7.8% 🔴 |       8.72ms<br>8.84ms<br>+1.4% 🔴 |       9.95ms<br>9.65ms<br>-3.0% 🟢 |    459.1ms<br>509.7ms<br>+11.0% 🔴 |     310.3ms<br>321.5ms<br>+3.6% 🔴 |
| univ2_router       |       1.698s<br>1.730s<br>+1.9% 🔴 |       17.0ms<br>16.3ms<br>-4.2% 🟢 |       17.4ms<br>17.6ms<br>+1.3% 🔴 |       1.024s<br>1.033s<br>+0.9% 🔴 |     639.7ms<br>663.4ms<br>+3.7% 🔴 |
| seaport            |       4.194s<br>4.493s<br>+7.1% 🔴 |       24.8ms<br>24.4ms<br>-1.5% 🟢 |       28.0ms<br>29.6ms<br>+5.6% 🔴 |       2.712s<br>2.922s<br>+7.7% 🔴 |       1.429s<br>1.517s<br>+6.2% 🔴 |
| airdrop            |     557.5ms<br>590.7ms<br>+5.9% 🔴 |      6.34ms<br>5.59ms<br>-11.9% 🟢 |       5.90ms<br>6.12ms<br>+3.7% 🔴 |     368.0ms<br>387.4ms<br>+5.3% 🔴 |     177.3ms<br>191.6ms<br>+8.1% 🔴 |
| bswap64            |       21.8ms<br>23.3ms<br>+6.9% 🔴 |     645.9µs<br>669.0µs<br>+3.6% 🔴 |     895.7µs<br>935.0µs<br>+4.4% 🔴 |       12.9ms<br>14.0ms<br>+8.2% 🔴 |       7.35ms<br>7.74ms<br>+5.3% 🔴 |
| bswap64_opt        |       26.5ms<br>28.1ms<br>+6.2% 🔴 |     560.3µs<br>562.7µs<br>+0.4% 🔴 |     819.3µs<br>816.0µs<br>-0.4% 🟢 |       15.9ms<br>16.6ms<br>+4.9% 🔴 |       9.22ms<br>10.1ms<br>+9.4% 🔴 |
| eip4788            |       12.7ms<br>12.5ms<br>-1.8% 🟢 |     293.2µs<br>315.3µs<br>+7.5% 🔴 |     584.3µs<br>593.0µs<br>+1.5% 🔴 |       7.60ms<br>7.30ms<br>-3.9% 🟢 |       4.23ms<br>4.27ms<br>+0.9% 🔴 |
| eip2935            |       12.2ms<br>12.2ms<br>-0.3% 🟢 |    405.6µs<br>297.4µs<br>-26.7% 🟢 |    792.1µs<br>564.4µs<br>-28.7% 🟢 |       7.01ms<br>7.12ms<br>+1.6% 🔴 |       3.99ms<br>4.17ms<br>+4.6% 🔴 |
| curve_stableswap   |     437.2ms<br>449.9ms<br>+2.9% 🔴 |       4.56ms<br>4.78ms<br>+4.8% 🔴 |             4.98ms<br>4.98ms<br>= |     273.1ms<br>280.4ms<br>+2.7% 🔴 |     154.5ms<br>159.7ms<br>+3.4% 🔴 |
| onchain_lm_v2      |      2.075s<br>1.771s<br>-14.7% 🟢 |     242.1ms<br>243.7ms<br>+0.7% 🔴 |       17.0ms<br>16.2ms<br>-4.8% 🟢 |     1.118s<br>900.0ms<br>-19.5% 🟢 |    697.8ms<br>611.0ms<br>-12.4% 🟢 |
| burntpix           |       6.234s<br>5.988s<br>-3.9% 🟢 |       42.6ms<br>42.8ms<br>+0.5% 🔴 |      58.2ms<br>51.2ms<br>-11.9% 🟢 |       3.985s<br>3.894s<br>-2.3% 🟢 |       2.148s<br>2.000s<br>-6.9% 🟢 |
| 0x184e2e0d92…      |      2.747s<br>3.359s<br>+22.3% 🔴 |       30.4ms<br>29.4ms<br>-3.1% 🟢 |       32.5ms<br>29.6ms<br>-9.1% 🟢 |       1.668s<br>1.772s<br>+6.2% 🔴 |      1.016s<br>1.528s<br>+50.4% 🔴 |
| 0x26f3fa5857…      |      2.910s<br>3.699s<br>+27.1% 🔴 |       27.3ms<br>29.2ms<br>+6.8% 🔴 |      31.6ms<br>38.1ms<br>+20.8% 🔴 |      1.684s<br>2.203s<br>+30.8% 🔴 |      1.167s<br>1.429s<br>+22.5% 🔴 |
| 0x7497bfab49…      |       3.078s<br>2.906s<br>-5.6% 🟢 |       25.9ms<br>27.1ms<br>+4.4% 🔴 |       29.9ms<br>29.5ms<br>-1.5% 🟢 |       1.798s<br>1.707s<br>-5.1% 🟢 |       1.223s<br>1.143s<br>-6.5% 🟢 |
| 0x8819f74c38…      |       3.733s<br>3.522s<br>-5.7% 🟢 |       27.9ms<br>29.2ms<br>+4.5% 🔴 |       33.5ms<br>32.6ms<br>-2.5% 🟢 |       2.295s<br>2.128s<br>-7.3% 🟢 |       1.377s<br>1.332s<br>-3.3% 🟢 |
| 0x9806ed1505…      |       2.864s<br>2.855s<br>-0.3% 🟢 |       22.9ms<br>24.0ms<br>+4.8% 🔴 |       26.5ms<br>25.6ms<br>-3.5% 🟢 |       1.809s<br>1.793s<br>-0.9% 🟢 |       1.005s<br>1.013s<br>+0.8% 🔴 |
| 0xcc74d4c66f…      |       2.831s<br>2.842s<br>+0.4% 🔴 |       24.0ms<br>24.2ms<br>+1.0% 🔴 |       28.5ms<br>30.8ms<br>+8.2% 🔴 |       1.768s<br>1.774s<br>+0.3% 🔴 |       1.011s<br>1.013s<br>+0.2% 🔴 |
| 0xd450e90507…      |       3.132s<br>3.142s<br>+0.3% 🔴 |       24.5ms<br>25.9ms<br>+5.8% 🔴 |       30.9ms<br>28.7ms<br>-7.2% 🟢 |       1.900s<br>1.906s<br>+0.3% 🔴 |       1.176s<br>1.181s<br>+0.4% 🔴 |
| 0xfbbee2ff80…      |       2.805s<br>2.765s<br>-1.4% 🟢 |       23.0ms<br>23.5ms<br>+2.2% 🔴 |       28.3ms<br>26.9ms<br>-5.2% 🟢 |       1.741s<br>1.721s<br>-1.1% 🟢 |      1.013s<br>993.4ms<br>-1.9% 🟢 |
| 0xfc5900eac5…      |       1.859s<br>1.893s<br>+1.8% 🔴 |       18.3ms<br>18.7ms<br>+2.1% 🔴 |       19.9ms<br>20.1ms<br>+1.3% 🔴 |       1.151s<br>1.172s<br>+1.8% 🔴 |     669.4ms<br>681.3ms<br>+1.8% 🔴 |
| **TOTAL**          | **46.312s<br>47.664s<br>+2.9% 🔴** | **609.8ms<br>615.8ms<br>+1.0% 🔴** | **446.6ms<br>439.2ms<br>-1.6% 🟢** | **28.312s<br>28.869s<br>+2.0% 🔴** | **16.942s<br>17.740s<br>+4.7% 🔴** |

</details>

### Jump resolution

| benchmark   |   local |   nonadj |      pcr |       fixpt |       unres |   total |
|:------------|--------:|---------:|---------:|------------:|------------:|--------:|
| weth        |       = |        = |     +1 🟢 |       +11 🟢 |   -100.0% 🟢 |       = |
| **TOTAL**   |   **=** |    **=** | **+1 🟢** | **+0.7% 🟢** | **-1.1% 🟢** |   **=** |

<details><summary>Full jump resolution</summary>

| benchmark          |                 local |              nonadj |                pcr |                       fixpt |                       unres |                   total |
|:-------------------|----------------------:|--------------------:|-------------------:|----------------------------:|----------------------------:|------------------------:|
| fibonacci-calldata |           2<br>2<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |             2<br>2<br>= |
| factorial          |           2<br>2<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |             2<br>2<br>= |
| counter            |         11<br>11<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |           11<br>11<br>= |
| snailtracer        |       502<br>502<br>= |       17<br>17<br>= |        0<br>0<br>= |                 0<br>0<br>= |               62<br>62<br>= |         564<br>564<br>= |
| weth               |         55<br>55<br>= |         0<br>0<br>= |     0<br>1<br>+1 🟢 |            0<br>11<br>+11 🟢 |        11<br>0<br>-100.0% 🟢 |           66<br>66<br>= |
| hash_10k           |           6<br>6<br>= |         0<br>0<br>= |        0<br>0<br>= |                 2<br>2<br>= |                 0<br>0<br>= |             8<br>8<br>= |
| erc20_transfer     |       114<br>114<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |               18<br>18<br>= |         132<br>132<br>= |
| push0_proxy        |           1<br>1<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |             1<br>1<br>= |
| usdc_proxy         |         54<br>54<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |               14<br>14<br>= |           68<br>68<br>= |
| fiat_token         |       452<br>452<br>= |         6<br>6<br>= |        0<br>0<br>= |                 0<br>0<br>= |               68<br>68<br>= |         520<br>520<br>= |
| uniswap_v2_pair    |       257<br>257<br>= |       30<br>30<br>= |        0<br>0<br>= |                 0<br>0<br>= |               37<br>37<br>= |         294<br>294<br>= |
| univ2_router       |       474<br>474<br>= |       27<br>27<br>= |        0<br>0<br>= |                 0<br>0<br>= |               26<br>26<br>= |         500<br>500<br>= |
| seaport            |     1026<br>1026<br>= |       39<br>39<br>= |        0<br>0<br>= |                 0<br>0<br>= |             153<br>153<br>= |       1179<br>1179<br>= |
| airdrop            |       217<br>217<br>= |         7<br>7<br>= |        0<br>0<br>= |                 0<br>0<br>= |               35<br>35<br>= |         252<br>252<br>= |
| bswap64            |         14<br>14<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |           14<br>14<br>= |
| bswap64_opt        |           8<br>8<br>= |         0<br>0<br>= |        0<br>0<br>= |                 2<br>2<br>= |                 0<br>0<br>= |           10<br>10<br>= |
| eip4788            |           4<br>4<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |             4<br>4<br>= |
| eip2935            |           4<br>4<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 0<br>0<br>= |             4<br>4<br>= |
| curve_stableswap   |         42<br>42<br>= |         5<br>5<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 9<br>9<br>= |           51<br>51<br>= |
| onchain_lm_v2      |           0<br>0<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |                 2<br>2<br>= |             2<br>2<br>= |
| burntpix           |       365<br>365<br>= |         2<br>2<br>= |        0<br>0<br>= |           1009<br>1009<br>= |               31<br>31<br>= |       1405<br>1405<br>= |
| 0x184e2e0d92…      |       627<br>627<br>= |         1<br>1<br>= |        0<br>0<br>= |                 0<br>0<br>= |               45<br>45<br>= |         672<br>672<br>= |
| 0x26f3fa5857…      |       488<br>488<br>= |       16<br>16<br>= |        0<br>0<br>= |                 0<br>0<br>= |               22<br>22<br>= |         510<br>510<br>= |
| 0x7497bfab49…      |       496<br>496<br>= |       16<br>16<br>= |        0<br>0<br>= |                 0<br>0<br>= |               24<br>24<br>= |         520<br>520<br>= |
| 0x8819f74c38…      |       625<br>625<br>= |       13<br>13<br>= |        0<br>0<br>= |                 0<br>0<br>= |               49<br>49<br>= |         674<br>674<br>= |
| 0x9806ed1505…      |       315<br>315<br>= |         3<br>3<br>= |        0<br>0<br>= |             296<br>296<br>= |             113<br>113<br>= |         724<br>724<br>= |
| 0xcc74d4c66f…      |       636<br>636<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |               73<br>73<br>= |         709<br>709<br>= |
| 0xd450e90507…      |       582<br>582<br>= |       73<br>73<br>= |        0<br>0<br>= |                 0<br>0<br>= |               67<br>67<br>= |         649<br>649<br>= |
| 0xfbbee2ff80…      |       630<br>630<br>= |         0<br>0<br>= |        0<br>0<br>= |                 0<br>0<br>= |               73<br>73<br>= |         703<br>703<br>= |
| 0xfc5900eac5…      |       163<br>163<br>= |         2<br>2<br>= |        0<br>0<br>= |             333<br>333<br>= |               82<br>82<br>= |         578<br>578<br>= |
| **TOTAL**          | **8172<br>8172<br>=** | **257<br>257<br>=** | **0<br>1<br>+1 🟢** | **1642<br>1653<br>+0.7% 🟢** | **1014<br>1003<br>-1.1% 🟢** | **10828<br>10828<br>=** |

</details>

