### PR TITLE
refactor: localize branch helpers

### DIFF
--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -383,13 +383,6 @@ pub trait Builder: BackendTypes + TypeMethods {
         then_value: Self::Value,
         else_value: Self::Value,
     ) -> Self::Value;
-    fn lazy_select(
-        &mut self,
-        cond: Self::Value,
-        ty: Self::Type,
-        then_value: impl FnOnce(&mut Self) -> Self::Value,
-        else_value: impl FnOnce(&mut Self) -> Self::Value,
-    ) -> Self::Value;
 
     fn iadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn isub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -1657,11 +1657,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             return self.build_memory_addr(offset);
         }
 
-        let current_block = self.current_block();
-        let resize_block = self.create_block_after(current_block, "mresize");
-        let contd_block = self.create_block_after(resize_block, "mresize.contd");
-
-        // Otherwise emit the normal checked-resize diamond.
+        // Otherwise emit the normal checked-resize branch.
         // Fast path: offset + len <= mem_len (no overflow).
         let mem_len_field =
             self.get_field(self.ecx, mem::offset_of!(EvmContext<'_>, mem_len), "ecx.mem_len.addr");
@@ -1669,15 +1665,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         let exceeds = self.bcx.icmp(IntCC::UnsignedGreaterThan, min_size, mem_len);
         self.cached_mem_base = None;
 
-        self.bcx.brif(exceeds, resize_block, contd_block);
-
-        // Cold path: call mresize builtin.
-        self.bcx.switch_to_block(resize_block);
-        self.bcx.set_current_block_cold();
-        self.call_fallible_builtin(Builtin::Mresize, &[self.ecx, min_size]);
-        self.bcx.br(contd_block);
-
-        self.bcx.switch_to_block(contd_block);
+        self.if_then(exceeds, |this| {
+            this.bcx.set_current_block_cold();
+            this.call_fallible_builtin(Builtin::Mresize, &[this.ecx, min_size]);
+        });
         self.build_memory_addr(offset)
     }
 
@@ -1924,6 +1915,20 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
     /// Returns the current instruction.
     fn current_inst(&self) -> &InstData {
         self.bytecode.inst(self.current_inst.unwrap())
+    }
+
+    fn if_then(&mut self, cond: B::Value, then: impl FnOnce(&mut Self)) {
+        let current_block = self.current_block();
+        let then_block = self.create_block_after(current_block, "then");
+        let done_block = self.create_block_after(then_block, "contd");
+
+        self.bcx.brif(cond, then_block, done_block);
+
+        self.bcx.switch_to_block(then_block);
+        then(self);
+        self.bcx.br(done_block);
+
+        self.bcx.switch_to_block(done_block);
     }
 
     /// Returns the current block.

--- a/crates/revmc-codegen/src/tests/runner.rs
+++ b/crates/revmc-codegen/src/tests/runner.rs
@@ -501,6 +501,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
         }
         if let Some(modify_ecx) = modify_ecx {
             modify_ecx(ecx);
+            ecx.refresh_memory_cache();
         }
 
         // Interpreter - run via instruction table

--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -1556,37 +1556,6 @@ impl Builder for EvmLlvmBuilder<'_> {
         self.bcx.build_select(cond.into_int_value(), then_value, else_value, "").unwrap()
     }
 
-    fn lazy_select(
-        &mut self,
-        cond: Self::Value,
-        ty: Self::Type,
-        then_value: impl FnOnce(&mut Self) -> Self::Value,
-        else_value: impl FnOnce(&mut Self) -> Self::Value,
-    ) -> Self::Value {
-        let then_block = if let Some(current) = self.current_block() {
-            self.create_block_after(current, "then")
-        } else {
-            self.create_block("then")
-        };
-        let else_block = self.create_block_after(then_block, "else");
-        let done_block = self.create_block_after(else_block, "contd");
-
-        self.brif(cond, then_block, else_block);
-
-        self.switch_to_block(then_block);
-        let then_value = then_value(self);
-        self.br(done_block);
-
-        self.switch_to_block(else_block);
-        let else_value = else_value(self);
-        self.br(done_block);
-
-        self.switch_to_block(done_block);
-        let phi = self.bcx.build_phi(ty, "").unwrap();
-        phi.add_incoming(&[(&then_value, then_block), (&else_value, else_block)]);
-        phi.as_basic_value()
-    }
-
     fn iadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
         self.bcx.build_int_add(lhs.into_int_value(), rhs.into_int_value(), "").unwrap().into()
     }


### PR DESCRIPTION
Move the conditional branch helper out of the backend trait and keep it local to translation, where it is used for the checked memory resize path. This also drops the LLVM-specific lazy helper implementation and refreshes the memory cache in the compiled test runner after tests mutate the execution context.