### PR TITLE
fix: resolve constant jumpi conditions

### DIFF
--- a/crates/revmc-codegen/src/bytecode/fmt.rs
+++ b/crates/revmc-codegen/src/bytecode/fmt.rs
@@ -538,7 +538,7 @@ mod tests {
             op::PUSH1, 0x01,
             op::PUSH1, 0x00,
             op::SSTORE,
-            op::PUSH1, 0x01,
+            op::CALLDATASIZE,
             op::PUSH1, 0x03,
             op::JUMPI,
             op::PUSH1, 0x00,
@@ -565,7 +565,7 @@ mod tests {
             actual,
             snapbox::str![[r#"
 ; spec_id=Osaka has_dynamic_jumps=false may_suspend=true
-; insts=19 live=19 dead=0 noops=11 suspends=1 blocks=3 block_min=2 block_max=10 block_avg=6.3 block_median=7
+; insts=19 live=19 dead=0 noops=10 suspends=1 blocks=3 block_min=2 block_max=10 block_avg=6.3 block_median=7
 
 bb0:           ; stack_in=0 max_growth=1 predecessors=
   PUSH1 0x03   ; ic= 0 pc= 0 gas=11 noop
@@ -576,21 +576,21 @@ bb1:           ; stack_in=0 max_growth=2 predecessors=bb0,bb1
   PUSH1 0x01   ; ic= 3 pc= 4 noop
   PUSH1 0x00   ; ic= 4 pc= 6 noop
   SSTORE       ; ic= 5 pc= 8
-  PUSH1 0x01   ; ic= 6 pc= 9 gas=16 noop
-  PUSH1 0x03   ; ic= 7 pc=11 noop
-  JUMPI %bb1   ; ic= 8 pc=13
+  CALLDATASIZE ; ic= 6 pc= 9 gas=15
+  PUSH1 0x03   ; ic= 7 pc=10 noop
+  JUMPI %bb1   ; ic= 8 pc=12
 
 bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
-  PUSH1 0x00   ; ic= 9 pc=14 gas=121
-  PUSH1 0x00   ; ic=10 pc=16 noop
-  PUSH1 0x00   ; ic=11 pc=18 noop
-  PUSH1 0x00   ; ic=12 pc=20 noop
-  PUSH1 0x00   ; ic=13 pc=22 noop
-  PUSH1 0x42   ; ic=14 pc=24 noop
-  PUSH2 0xffff ; ic=15 pc=26 noop
-  CALL         ; ic=16 pc=29 suspends
-  POP          ; ic=17 pc=30 gas=2 stack_in=1 max_growth=0
-  STOP         ; ic=18 pc=31
+  PUSH1 0x00   ; ic= 9 pc=13 gas=121
+  PUSH1 0x00   ; ic=10 pc=15 noop
+  PUSH1 0x00   ; ic=11 pc=17 noop
+  PUSH1 0x00   ; ic=12 pc=19 noop
+  PUSH1 0x00   ; ic=13 pc=21 noop
+  PUSH1 0x42   ; ic=14 pc=23 noop
+  PUSH2 0xffff ; ic=15 pc=25 noop
+  CALL         ; ic=16 pc=28 suspends
+  POP          ; ic=17 pc=29 gas=2 stack_in=1 max_growth=0
+  STOP         ; ic=18 pc=30
 
 "#]]
         );
@@ -637,7 +637,7 @@ bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
         assert!(dot.contains("SSTORE"), "missing SSTORE");
         // SSTORE splits gas sections: two [g=] annotations in bb1.
         assert!(dot.contains("[g=7]"), "missing first gas section");
-        assert!(dot.contains("[g=16]"), "missing second gas section");
+        assert!(dot.contains("[g=15]"), "missing second gas section");
         // CALL present in bb2.
         assert!(dot.contains("CALL"), "missing CALL");
         assert!(dot.contains("[g=121]"), "missing CALL gas section");

--- a/crates/revmc-codegen/src/bytecode/fmt.rs
+++ b/crates/revmc-codegen/src/bytecode/fmt.rs
@@ -100,7 +100,9 @@ impl Bytecode<'_> {
                 let mut text = String::from("  ");
                 let opcode = self.opcode(inst);
                 write!(text, "{opcode}").unwrap();
-                if data.flags.contains(InstFlags::INVALID_JUMP) {
+                if data.flags.contains(InstFlags::NOT_TAKEN_JUMP) {
+                    text.push_str(" %fallthrough");
+                } else if data.flags.contains(InstFlags::INVALID_JUMP) {
                     text.push_str(" %invalid");
                 } else if data.flags.contains(InstFlags::MULTI_JUMP) {
                     if let Some(targets) = self.multi_jump_targets(inst) {
@@ -157,6 +159,9 @@ impl Bytecode<'_> {
                 }
                 if flags.contains(InstFlags::MULTI_JUMP) {
                     comment.push_str(" multi_jump");
+                }
+                if flags.contains(InstFlags::NOT_TAKEN_JUMP) {
+                    comment.push_str(" not_taken_jump");
                 }
                 if data.may_suspend() {
                     comment.push_str(" suspends");
@@ -610,7 +615,8 @@ bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
                 let cleaned = before_comment
                     .replace(" %bb", " ; %bb")
                     .replace(" %dynamic", " ; %dynamic")
-                    .replace(" %invalid", " ; %invalid");
+                    .replace(" %invalid", " ; %invalid")
+                    .replace(" %fallthrough", " ; %fallthrough");
                 if comment.is_empty() {
                     format!("{cleaned}\n")
                 } else {

--- a/crates/revmc-codegen/src/bytecode/fmt.rs
+++ b/crates/revmc-codegen/src/bytecode/fmt.rs
@@ -100,9 +100,7 @@ impl Bytecode<'_> {
                 let mut text = String::from("  ");
                 let opcode = self.opcode(inst);
                 write!(text, "{opcode}").unwrap();
-                if data.flags.contains(InstFlags::NOT_TAKEN_JUMP) {
-                    text.push_str(" %fallthrough");
-                } else if data.flags.contains(InstFlags::INVALID_JUMP) {
+                if data.flags.contains(InstFlags::INVALID_JUMP) {
                     text.push_str(" %invalid");
                 } else if data.flags.contains(InstFlags::MULTI_JUMP) {
                     if let Some(targets) = self.multi_jump_targets(inst) {
@@ -159,9 +157,6 @@ impl Bytecode<'_> {
                 }
                 if flags.contains(InstFlags::MULTI_JUMP) {
                     comment.push_str(" multi_jump");
-                }
-                if flags.contains(InstFlags::NOT_TAKEN_JUMP) {
-                    comment.push_str(" not_taken_jump");
                 }
                 if data.may_suspend() {
                     comment.push_str(" suspends");
@@ -615,8 +610,7 @@ bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
                 let cleaned = before_comment
                     .replace(" %bb", " ; %bb")
                     .replace(" %dynamic", " ; %dynamic")
-                    .replace(" %invalid", " ; %invalid")
-                    .replace(" %fallthrough", " ; %fallthrough");
+                    .replace(" %invalid", " ; %invalid");
                 if comment.is_empty() {
                     format!("{cleaned}\n")
                 } else {

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -476,10 +476,17 @@ impl<'a> Bytecode<'a> {
         let mut iter = self.insts.iter_mut_enumerated();
         while let Some((i, data)) = iter.next() {
             if !data.can_fall_through() {
+                let static_target = data
+                    .is_static_jump()
+                    .then(|| data.static_jump_target())
+                    .filter(|&target| target > i);
                 let mut end = i;
                 let mut any_new = false;
                 for (j, data) in &mut iter {
                     end = j;
+                    if static_target == Some(j) {
+                        break;
+                    }
                     if data.is_reachable_jumpdest(self.has_dynamic_jumps) {
                         break;
                     }

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -549,7 +549,6 @@ impl<'a> Bytecode<'a> {
 
     /// Returns the value of a PUSH instruction, right-padding truncated EOF immediates with zeros
     /// per EVM spec.
-    #[cfg(test)]
     pub(crate) fn get_push_value(&self, data: &InstData) -> U256 {
         debug_assert!(matches!(data.opcode, op::PUSH0..=op::PUSH32));
         data.imm().get(&self.u256_interner.borrow())

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -962,6 +962,12 @@ impl InstData {
         self.is_jump() && self.flags.contains(InstFlags::STATIC_JUMP)
     }
 
+    /// Returns `true` if this instruction is a `JUMPI` whose condition is known statically.
+    #[inline]
+    pub(crate) fn has_const_jump_condition(&self) -> bool {
+        self.opcode == op::JUMPI && self.flags.contains(InstFlags::CONST_JUMP_CONDITION)
+    }
+
     /// Returns `true` if this instruction is a `JUMPDEST`.
     #[inline]
     pub(crate) const fn is_jumpdest(&self) -> bool {
@@ -1060,7 +1066,7 @@ impl InstData {
     /// Returns `true` if execution can fall through to the next sequential instruction.
     #[inline]
     pub(crate) fn can_fall_through(&self) -> bool {
-        !self.is_diverging() && self.opcode != op::JUMP
+        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jump_condition()
     }
 
     /// Returns `true` if we know that this instruction will branch or stop execution.
@@ -1104,7 +1110,7 @@ impl InstData {
 bitflags::bitflags! {
     /// [`InstrData`] flags.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub(crate) struct InstFlags: u8 {
+    pub(crate) struct InstFlags: u16 {
         /// The `JUMP`/`JUMPI` target is known at compile time.
         const STATIC_JUMP = 1 << 0;
         /// The jump target is known to be invalid.
@@ -1127,6 +1133,8 @@ bitflags::bitflags! {
         const STACK_SECTION_HEAD = 1 << 6;
         /// Don't generate any code.
         const DEAD_CODE = 1 << 7;
+        /// The `JUMPI` condition is known at compile time.
+        const CONST_JUMP_CONDITION = 1 << 8;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -970,8 +970,8 @@ impl InstData {
 
     /// Returns `true` if this instruction is a `JUMPI` whose condition is known statically.
     #[inline]
-    pub(crate) fn has_const_jump_condition(&self) -> bool {
-        self.opcode == op::JUMPI && self.flags.contains(InstFlags::CONST_JUMP_CONDITION)
+    pub(crate) fn has_const_jumpi_condition(&self) -> bool {
+        self.opcode == op::JUMPI && self.flags.contains(InstFlags::CONST_JUMPI_CONDITION)
     }
 
     /// Returns `true` if this instruction is a `JUMPDEST`.
@@ -1035,6 +1035,13 @@ impl InstData {
         self.data |= Self::JUMPDEST_REACHABLE;
     }
 
+    /// Clears the reachable static jump target marker from this `JUMPDEST`.
+    #[inline]
+    pub(crate) fn clear_jumpdest_reachable(&mut self) {
+        debug_assert_eq!(self.opcode, op::JUMPDEST);
+        self.data &= !Self::JUMPDEST_REACHABLE;
+    }
+
     /// Returns the static target of a `JUMP`/`JUMPI` with [`InstFlags::STATIC_JUMP`].
     #[inline]
     pub(crate) fn static_jump_target(&self) -> Inst {
@@ -1072,7 +1079,7 @@ impl InstData {
     /// Returns `true` if execution can fall through to the next sequential instruction.
     #[inline]
     pub(crate) fn can_fall_through(&self) -> bool {
-        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jump_condition()
+        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jumpi_condition()
     }
 
     /// Returns `true` if we know that this instruction will branch or stop execution.
@@ -1125,22 +1132,22 @@ bitflags::bitflags! {
         /// The jump has multiple known targets (see `Bytecode::multi_jump_targets`).
         /// The target value is still on the stack and must be popped and switched on at runtime.
         const MULTI_JUMP = 1 << 2;
+        /// The `JUMPI` condition is known at compile time.
+        const CONST_JUMPI_CONDITION = 1 << 3;
 
         /// The instruction is disabled in this EVM version.
         /// Always returns [`InstructionResult::NotActivated`] at runtime.
-        const DISABLED = 1 << 3;
+        const DISABLED = 1 << 4;
         /// The instruction is unknown.
         /// Always returns [`InstructionResult::NotFound`] at runtime.
-        const UNKNOWN = 1 << 4;
+        const UNKNOWN = 1 << 5;
 
         /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
-        const NOOP = 1 << 5;
+        const NOOP = 1 << 6;
         /// This instruction starts a new stack section.
-        const STACK_SECTION_HEAD = 1 << 6;
+        const STACK_SECTION_HEAD = 1 << 7;
         /// Don't generate any code.
-        const DEAD_CODE = 1 << 7;
-        /// The `JUMPI` condition is known at compile time.
-        const CONST_JUMP_CONDITION = 1 << 8;
+        const DEAD_CODE = 1 << 8;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -899,8 +899,7 @@ pub(crate) struct InstData {
     /// - `PC`: program counter of this instruction.
     /// - `JUMPDEST`: program counter in low 31 bits, reachable flag in high bit
     ///   ([`InstData::JUMPDEST_REACHABLE`]).
-    /// - `JUMP | JUMPI` with [`InstFlags::STATIC_JUMP`]: target instruction index, except for
-    ///   `JUMPI` with [`InstFlags::NOT_TAKEN_JUMP`].
+    /// - `JUMP | JUMPI` with [`InstFlags::STATIC_JUMP`]: target instruction index.
     /// - otherwise: unused.
     pub(crate) data: u32,
     /// The gas section this instruction belongs to.
@@ -1027,7 +1026,6 @@ impl InstData {
     #[inline]
     pub(crate) fn static_jump_target(&self) -> Inst {
         debug_assert!(self.is_static_jump());
-        debug_assert!(!self.flags.contains(InstFlags::NOT_TAKEN_JUMP));
         Inst::from_usize(self.data as usize)
     }
 
@@ -1105,7 +1103,7 @@ impl InstData {
 bitflags::bitflags! {
     /// [`InstrData`] flags.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub(crate) struct InstFlags: u16 {
+    pub(crate) struct InstFlags: u8 {
         /// The `JUMP`/`JUMPI` target is known at compile time.
         const STATIC_JUMP = 1 << 0;
         /// The jump target is known to be invalid.
@@ -1114,22 +1112,20 @@ bitflags::bitflags! {
         /// The jump has multiple known targets (see `Bytecode::multi_jump_targets`).
         /// The target value is still on the stack and must be popped and switched on at runtime.
         const MULTI_JUMP = 1 << 2;
-        /// The `JUMPI` condition is known to be false, so control always falls through.
-        const NOT_TAKEN_JUMP = 1 << 3;
 
         /// The instruction is disabled in this EVM version.
         /// Always returns [`InstructionResult::NotActivated`] at runtime.
-        const DISABLED = 1 << 4;
+        const DISABLED = 1 << 3;
         /// The instruction is unknown.
         /// Always returns [`InstructionResult::NotFound`] at runtime.
-        const UNKNOWN = 1 << 5;
+        const UNKNOWN = 1 << 4;
 
         /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
-        const NOOP = 1 << 6;
+        const NOOP = 1 << 5;
         /// This instruction starts a new stack section.
-        const STACK_SECTION_HEAD = 1 << 7;
+        const STACK_SECTION_HEAD = 1 << 6;
         /// Don't generate any code.
-        const DEAD_CODE = 1 << 8;
+        const DEAD_CODE = 1 << 7;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -899,7 +899,8 @@ pub(crate) struct InstData {
     /// - `PC`: program counter of this instruction.
     /// - `JUMPDEST`: program counter in low 31 bits, reachable flag in high bit
     ///   ([`InstData::JUMPDEST_REACHABLE`]).
-    /// - `JUMP | JUMPI` with [`InstFlags::STATIC_JUMP`]: target instruction index.
+    /// - `JUMP | JUMPI` with [`InstFlags::STATIC_JUMP`]: target instruction index, except for
+    ///   `JUMPI` with [`InstFlags::NOT_TAKEN_JUMP`].
     /// - otherwise: unused.
     pub(crate) data: u32,
     /// The gas section this instruction belongs to.
@@ -1026,6 +1027,7 @@ impl InstData {
     #[inline]
     pub(crate) fn static_jump_target(&self) -> Inst {
         debug_assert!(self.is_static_jump());
+        debug_assert!(!self.flags.contains(InstFlags::NOT_TAKEN_JUMP));
         Inst::from_usize(self.data as usize)
     }
 
@@ -1103,7 +1105,7 @@ impl InstData {
 bitflags::bitflags! {
     /// [`InstrData`] flags.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub(crate) struct InstFlags: u8 {
+    pub(crate) struct InstFlags: u16 {
         /// The `JUMP`/`JUMPI` target is known at compile time.
         const STATIC_JUMP = 1 << 0;
         /// The jump target is known to be invalid.
@@ -1112,20 +1114,22 @@ bitflags::bitflags! {
         /// The jump has multiple known targets (see `Bytecode::multi_jump_targets`).
         /// The target value is still on the stack and must be popped and switched on at runtime.
         const MULTI_JUMP = 1 << 2;
+        /// The `JUMPI` condition is known to be false, so control always falls through.
+        const NOT_TAKEN_JUMP = 1 << 3;
 
         /// The instruction is disabled in this EVM version.
         /// Always returns [`InstructionResult::NotActivated`] at runtime.
-        const DISABLED = 1 << 3;
+        const DISABLED = 1 << 4;
         /// The instruction is unknown.
         /// Always returns [`InstructionResult::NotFound`] at runtime.
-        const UNKNOWN = 1 << 4;
+        const UNKNOWN = 1 << 5;
 
         /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
-        const NOOP = 1 << 5;
+        const NOOP = 1 << 6;
         /// This instruction starts a new stack section.
-        const STACK_SECTION_HEAD = 1 << 6;
+        const STACK_SECTION_HEAD = 1 << 7;
         /// Don't generate any code.
-        const DEAD_CODE = 1 << 7;
+        const DEAD_CODE = 1 << 8;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -329,6 +329,8 @@ enum JumpTarget {
     ResolvedWithInvalid(SmallVec<[Inst; 4]>),
     /// Known constant but invalid target.
     Invalid,
+    /// Conditional jump with a condition known to be zero.
+    NotTaken,
     /// Unknown target.
     Top,
 }
@@ -348,6 +350,13 @@ impl JumpTarget {
     }
 
     fn is_resolved(&self) -> bool {
+        matches!(
+            self,
+            Self::Resolved(_) | Self::ResolvedWithInvalid(_) | Self::Invalid | Self::NotTaken
+        )
+    }
+
+    fn depends_on_reached_entry_state(&self) -> bool {
         matches!(self, Self::Resolved(_) | Self::ResolvedWithInvalid(_) | Self::Invalid)
     }
 }
@@ -439,10 +448,14 @@ impl Bytecode<'_> {
             }
 
             let target = self.resolve_jump_snapshot(term_inst, &local_sets);
-            let Some(target_inst) = target.as_single() else { continue };
+            let target_inst = target.as_single();
+            if !matches!(target, JumpTarget::NotTaken) && target_inst.is_none() {
+                continue;
+            }
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
             if trace_logs
+                && let Some(target_inst) = target_inst
                 && let is_adjacent = (term_inst > 0 && {
                     let prev_inst = term_inst - 1;
                     let prev = &self.insts[prev_inst];
@@ -543,6 +556,13 @@ impl Bytecode<'_> {
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
                     newly_resolved += 1;
                     trace!(%jump_inst, "resolved invalid jump");
+                }
+                JumpTarget::NotTaken => {
+                    debug_assert_eq!(self.insts[jump_inst].opcode, op::JUMPI);
+                    self.insts[jump_inst].flags |=
+                        InstFlags::STATIC_JUMP | InstFlags::NOT_TAKEN_JUMP;
+                    newly_resolved += 1;
+                    trace!(%jump_inst, "resolved not-taken conditional jump");
                 }
                 JumpTarget::Bottom if !has_top_jump => {
                     // Truly unreachable: no unresolved jumps remain, so this
@@ -674,6 +694,7 @@ impl Bytecode<'_> {
                 }
             } else if term.is_static_jump()
                 && !term.flags.contains(InstFlags::INVALID_JUMP)
+                && !term.flags.contains(InstFlags::NOT_TAKEN_JUMP)
                 && let Some(target_block) = resolve(term.static_jump_target())
             {
                 cfg.blocks[target_block].preds.push(bid);
@@ -759,7 +780,7 @@ impl Bytecode<'_> {
             && let Some(&condition) = snap.first()
             && self.is_const_zero(condition)
         {
-            return JumpTarget::Invalid;
+            return JumpTarget::NotTaken;
         }
 
         match snap.last() {
@@ -811,6 +832,14 @@ impl Bytecode<'_> {
 
     fn is_const_zero(&self, value: AbsValue) -> bool {
         value.as_const().is_some_and(|imm| imm.get(&self.u256_interner.borrow()).is_zero())
+    }
+
+    fn local_jumpi_condition_is_zero(&self, jump_inst: Inst, local_snapshots: &Snapshots) -> bool {
+        self.insts[jump_inst].opcode == op::JUMPI
+            && local_snapshots.inputs[jump_inst]
+                .first()
+                .copied()
+                .is_some_and(|value| self.is_const_zero(value))
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -897,7 +926,12 @@ impl Bytecode<'_> {
 
         if invalidate_targets {
             for (inst, target) in jump_targets.iter_mut() {
-                if !target.is_resolved() {
+                if matches!(target, JumpTarget::NotTaken)
+                    && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
+                {
+                    continue;
+                }
+                if !target.depends_on_reached_entry_state() {
                     continue;
                 }
                 if let Some(bid) = self.cfg.inst_to_block[*inst]
@@ -1888,7 +1922,8 @@ mod tests_edge_cases {
 
         let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
-        assert!(jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert!(jump.flags.contains(InstFlags::NOT_TAKEN_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1908,7 +1943,8 @@ mod tests_edge_cases {
 
         let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
-        assert!(jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert!(jump.flags.contains(InstFlags::NOT_TAKEN_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1938,7 +1974,7 @@ mod tests_edge_cases {
         let bytecode = analyze_asm(
             "
             PUSH1 0x42              ; push same const on both paths
-            PUSH0                   ; condition (always false)
+            CALLDATASIZE            ; condition
             PUSH %then_pc           ; then target
             JUMPI                   ; branch
             ; Else: push same const.
@@ -1969,7 +2005,7 @@ mod tests_edge_cases {
     fn diamond_cfg_different_const() {
         let bytecode = analyze_asm(
             "
-            PUSH0                   ; condition
+            CALLDATASIZE            ; condition
             PUSH %then_pc
             JUMPI                   ; branch
             ; Else: push 0xAA.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -438,9 +438,7 @@ impl Bytecode<'_> {
                 continue;
             }
 
-            let Some(&operand) = self.snapshots.inputs[term_inst].last() else { continue };
-            debug_assert!(!matches!(operand, AbsValue::ConstSet(_)));
-            let target = self.resolve_jump_operand(operand, &local_sets);
+            let target = self.resolve_jump_snapshot(term_inst, &local_sets);
             let Some(target_inst) = target.as_single() else { continue };
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
@@ -722,22 +720,7 @@ impl Bytecode<'_> {
         let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
-            let snap = &self.snapshots.inputs[jump_inst];
-            let target = if self.insts[jump_inst].opcode == op::JUMPI
-                && let Some(&condition) = snap.first()
-                && self.is_const_zero(condition)
-            {
-                JumpTarget::Invalid
-            } else {
-                match snap.last() {
-                    Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
-                    None => {
-                        // No snapshot means the block was never interpreted (unreachable).
-                        trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                        JumpTarget::Bottom
-                    }
-                }
-            };
+            let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
             if matches!(target, JumpTarget::Top) {
                 has_top_jump = true;
             }
@@ -768,6 +751,24 @@ impl Bytecode<'_> {
         let count = jump_targets.iter().filter(|(_, target)| target.is_resolved()).count();
 
         (jump_targets, count)
+    }
+
+    fn resolve_jump_snapshot(&self, jump_inst: Inst, const_sets: &ConstSetInterner) -> JumpTarget {
+        let snap = &self.snapshots.inputs[jump_inst];
+        if self.insts[jump_inst].opcode == op::JUMPI
+            && let Some(&condition) = snap.first()
+            && self.is_const_zero(condition)
+        {
+            return JumpTarget::Invalid;
+        }
+
+        match snap.last() {
+            Some(&operand) => self.resolve_jump_operand(operand, const_sets),
+            None => {
+                trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
+                JumpTarget::Bottom
+            }
+        }
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
@@ -1889,6 +1890,45 @@ mod tests_edge_cases {
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
         assert!(jump.flags.contains(InstFlags::INVALID_JUMP));
         assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_zero_condition_ignores_valid_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            PUSH %target
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_true_condition_keeps_unknown_target_dynamic() {
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x01
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
+        assert!(!jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(bytecode.has_dynamic_jumps);
     }
 
     /// Constant propagation through a diamond CFG (if-then-else merge).

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -166,17 +166,25 @@ impl ConstSetInterner {
 /// Instructions that access deeper than this (e.g. Amsterdam DUPN/SWAPN up to depth 236)
 /// treat the out-of-range slot as `Top` rather than aborting block interpretation.
 const MAX_ABS_STACK_DEPTH: usize = 64;
+const MAX_BLOCK_CONTEXTS: usize = 2;
 
 /// Abstract state at the entry of a block.
 #[derive(Clone, Debug)]
 enum BlockState {
     /// Block has not been reached yet.
     Bottom,
-    /// Block has been reached with a known stack state (top-aligned).
-    Known(Vec<AbsValue>),
+    /// Block has been reached with one or more known stack states.
+    Known(SmallVec<[Vec<AbsValue>; 2]>),
 }
 
 impl BlockState {
+    fn states(&self) -> &[Vec<AbsValue>] {
+        match self {
+            Self::Bottom => &[],
+            Self::Known(states) => states,
+        }
+    }
+
     /// Join another incoming state into this one. Returns `true` if the state changed.
     ///
     /// When stack heights differ, the stacks are top-aligned and the shorter one is
@@ -184,47 +192,70 @@ impl BlockState {
     /// the "no selector match" fallthrough leaves an extra item on the stack that the
     /// fallback ignores.
     fn join(&mut self, incoming: &[AbsValue], sets: &mut ConstSetInterner) -> bool {
+        fn clamp_state(incoming: &[AbsValue]) -> Vec<AbsValue> {
+            let start = incoming.len().saturating_sub(MAX_ABS_STACK_DEPTH);
+            incoming[start..].to_vec()
+        }
+
+        fn join_state(
+            existing: &mut Vec<AbsValue>,
+            incoming: &[AbsValue],
+            sets: &mut ConstSetInterner,
+        ) -> bool {
+            let new_len = existing.len().max(incoming.len());
+            let mut changed = false;
+
+            // Clamp to MAX_ABS_STACK_DEPTH by only joining the top portion;
+            // elements below that are unreachable by any EVM instruction and
+            // discarding them preserves soundness.
+            let join_len = new_len.min(MAX_ABS_STACK_DEPTH);
+
+            // Resize existing to join_len: pad at bottom with Top or truncate.
+            if existing.len() < join_len {
+                let pad = join_len - existing.len();
+                existing.splice(0..0, std::iter::repeat_n(AbsValue::Top, pad));
+                changed = true;
+            } else if existing.len() > join_len {
+                existing.drain(..existing.len() - join_len);
+                changed = true;
+            }
+
+            // Join element-wise, top-aligned. Both stacks have their top at the end.
+            // `incoming` may be longer than join_len — we only look at its top portion.
+            let incoming_start = incoming.len().saturating_sub(join_len);
+            let incoming_top = &incoming[incoming_start..];
+            // incoming_top.len() <= join_len. If shorter, bottom positions get Top.
+            let pad = join_len - incoming_top.len();
+            for i in 0..join_len {
+                let inc = if i < pad { AbsValue::Top } else { incoming_top[i - pad] };
+                let joined = sets.join(existing[i], inc);
+                if joined != existing[i] {
+                    existing[i] = joined;
+                    changed = true;
+                }
+            }
+
+            changed
+        }
+
         match self {
             Self::Bottom => {
-                let start = incoming.len().saturating_sub(MAX_ABS_STACK_DEPTH);
-                *self = Self::Known(incoming[start..].to_vec());
+                *self = Self::Known(SmallVec::from_elem(clamp_state(incoming), 1));
                 true
             }
-            Self::Known(existing) => {
-                let new_len = existing.len().max(incoming.len());
-                let mut changed = false;
-
-                // Clamp to MAX_ABS_STACK_DEPTH by only joining the top portion;
-                // elements below that are unreachable by any EVM instruction and
-                // discarding them preserves soundness.
-                let join_len = new_len.min(MAX_ABS_STACK_DEPTH);
-
-                // Resize existing to join_len: pad at bottom with Top or truncate.
-                if existing.len() < join_len {
-                    let pad = join_len - existing.len();
-                    existing.splice(0..0, std::iter::repeat_n(AbsValue::Top, pad));
-                    changed = true;
-                } else if existing.len() > join_len {
-                    existing.drain(..existing.len() - join_len);
-                    changed = true;
+            Self::Known(states) => {
+                if let Some(existing) =
+                    states.iter_mut().find(|state| state.len() == incoming.len())
+                {
+                    return join_state(existing, incoming, sets);
                 }
 
-                // Join element-wise, top-aligned. Both stacks have their top at the end.
-                // `incoming` may be longer than join_len — we only look at its top portion.
-                let incoming_start = incoming.len().saturating_sub(join_len);
-                let incoming_top = &incoming[incoming_start..];
-                // incoming_top.len() <= join_len. If shorter, bottom positions get Top.
-                let pad = join_len - incoming_top.len();
-                for i in 0..join_len {
-                    let inc = if i < pad { AbsValue::Top } else { incoming_top[i - pad] };
-                    let joined = sets.join(existing[i], inc);
-                    if joined != existing[i] {
-                        existing[i] = joined;
-                        changed = true;
-                    }
+                if states.len() < MAX_BLOCK_CONTEXTS {
+                    states.push(clamp_state(incoming));
+                    return true;
                 }
 
-                changed
+                join_state(&mut states[0], incoming, sets)
             }
         }
     }
@@ -324,11 +355,45 @@ pub(crate) struct Cfg {
 }
 
 impl Bytecode<'_> {
+    fn record_input_snapshot(
+        &mut self,
+        inst: Inst,
+        operands: &[AbsValue],
+        const_sets: &mut ConstSetInterner,
+    ) {
+        let snap = &mut self.snapshots.inputs[inst];
+        if snap.is_empty() {
+            snap.extend_from_slice(operands);
+            return;
+        }
+
+        debug_assert_eq!(snap.len(), operands.len());
+        for (slot, &operand) in snap.iter_mut().zip(operands) {
+            *slot = const_sets.join(*slot, operand);
+        }
+    }
+
+    fn record_output_snapshot(
+        &mut self,
+        inst: Inst,
+        value: AbsValue,
+        const_sets: &mut ConstSetInterner,
+    ) {
+        match &mut self.snapshots.outputs[inst] {
+            Some(existing) => *existing = const_sets.join(*existing, value),
+            slot @ None => *slot = Some(value),
+        }
+    }
+
     /// Ensures `self.snapshots` is sized for the current instruction count.
     fn init_snapshots(&mut self) {
         let n = self.insts.len();
         self.snapshots.inputs.resize(n, SmallVec::new());
         self.snapshots.outputs.resize(n, None);
+        for input in &mut self.snapshots.inputs {
+            input.clear();
+        }
+        self.snapshots.outputs.raw.fill(None);
     }
 
     /// Block-local jump resolution: interpret each block independently to discover
@@ -339,7 +404,7 @@ impl Bytecode<'_> {
     pub(crate) fn block_analysis_local(&mut self) {
         self.init_snapshots();
 
-        let empty_sets = ConstSetInterner::new();
+        let mut local_sets = ConstSetInterner::new();
         let mut resolved = Vec::new();
         let mut stack = Vec::new();
         let trace_logs = enabled!(tracing::Level::TRACE);
@@ -354,7 +419,7 @@ impl Bytecode<'_> {
             // Interpret the block with `Top` as inputs.
             stack.clear();
             stack.resize(section.inputs as usize, AbsValue::Top);
-            if !self.interpret_block(block.insts(), &mut stack) {
+            if !self.interpret_block(block.insts(), &mut stack, &mut local_sets, None, &mut None) {
                 continue;
             }
 
@@ -369,7 +434,7 @@ impl Bytecode<'_> {
 
             let Some(&operand) = self.snapshots.inputs[term_inst].last() else { continue };
             debug_assert!(!matches!(operand, AbsValue::ConstSet(_)));
-            let target = self.resolve_jump_operand(operand, &empty_sets);
+            let target = self.resolve_jump_operand(operand, &local_sets);
             let Some(target_inst) = target.as_single() else { continue };
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
@@ -614,7 +679,7 @@ impl Bytecode<'_> {
         // Initialize block states. Entry block starts with an empty stack.
         let mut block_states: IndexVec<Block, BlockState> =
             index_vec![BlockState::Bottom; num_blocks];
-        block_states[Block::from_usize(0)] = BlockState::Known(Vec::new());
+        block_states[Block::from_usize(0)] = BlockState::Known(SmallVec::from_elem(Vec::new(), 1));
 
         // Collect unresolved jumps.
         let mut jump_insts: Vec<Inst> = Vec::new();
@@ -654,13 +719,21 @@ impl Bytecode<'_> {
         // Invalidate resolutions that may be unsound due to incomplete analysis.
         // When the fixpoint didn't converge, partially-discovered ConstSets may be
         // incomplete, so we must conservatively invalidate them too.
-        if has_top_jump || !converged {
+        let has_bottom_jump =
+            jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Bottom));
+        if has_top_jump || has_bottom_jump || !converged {
             self.invalidate_suspect_jumps(
                 &mut jump_targets,
-                &block_states,
                 &discovered_edges,
                 local_snapshots,
+                has_top_jump || !converged,
             );
+        }
+
+        for bid in self.cfg.blocks.indices() {
+            if matches!(block_states[bid], BlockState::Bottom) {
+                self.snapshots.restore_from(self.cfg.blocks[bid].insts(), local_snapshots);
+            }
         }
 
         let count = jump_targets
@@ -718,6 +791,7 @@ impl Bytecode<'_> {
         const_sets: &ConstSetInterner,
         discovered: &mut IndexVec<Block, SmallVec<[Block; 4]>>,
         disc_preds: &mut IndexVec<Block, SmallVec<[Block; 4]>>,
+        context_targets: &mut SmallVec<[Block; 4]>,
     ) {
         let consts = match operand {
             AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
@@ -731,11 +805,14 @@ impl Bytecode<'_> {
                 continue;
             }
             let ti = self.pc_to_inst(target_pc);
-            if let Some(tb) = self.cfg.inst_to_block[ti]
-                && !discovered[bid].contains(&tb)
-            {
-                discovered[bid].push(tb);
-                disc_preds[tb].push(bid);
+            if let Some(tb) = self.cfg.inst_to_block[ti] {
+                if !context_targets.contains(&tb) {
+                    context_targets.push(tb);
+                }
+                if !discovered[bid].contains(&tb) {
+                    discovered[bid].push(tb);
+                    disc_preds[tb].push(bid);
+                }
             }
         }
     }
@@ -754,18 +831,16 @@ impl Bytecode<'_> {
     fn invalidate_suspect_jumps(
         &mut self,
         jump_targets: &mut [(Inst, JumpTarget)],
-        block_states: &IndexVec<Block, BlockState>,
         discovered_edges: &IndexVec<Block, SmallVec<[Block; 4]>>,
         local_snapshots: &Snapshots,
+        invalidate_targets: bool,
     ) {
         let num_blocks = self.cfg.blocks.len();
 
         // Seed: every reachable JUMPDEST block is suspect when Top jumps exist.
         let mut suspect: BitVec = BitVec::repeat(false, num_blocks);
         for bid in self.cfg.blocks.indices() {
-            if !matches!(block_states[bid], BlockState::Bottom)
-                && self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest()
-            {
+            if self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest() {
                 suspect.set(bid.index(), true);
             }
         }
@@ -787,14 +862,16 @@ impl Bytecode<'_> {
             }
         }
 
-        for (inst, target) in jump_targets.iter_mut() {
-            if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
-                continue;
-            }
-            if let Some(bid) = self.cfg.inst_to_block[*inst]
-                && suspect[bid.index()]
-            {
-                *target = JumpTarget::Top;
+        if invalidate_targets {
+            for (inst, target) in jump_targets.iter_mut() {
+                if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
+                    continue;
+                }
+                if let Some(bid) = self.cfg.inst_to_block[*inst]
+                    && suspect[bid.index()]
+                {
+                    *target = JumpTarget::Top;
+                }
             }
         }
 
@@ -845,37 +922,48 @@ impl Bytecode<'_> {
 
             // Copy input state into reusable buffer.
             stack_buf.clear();
-            match &block_states[bid] {
-                BlockState::Known(s) => stack_buf.extend_from_slice(s),
-                BlockState::Bottom => continue,
-            };
+            let states = block_states[bid].states().to_vec();
+            for state in states {
+                // Copy input state into reusable buffer.
+                stack_buf.clear();
+                stack_buf.extend_from_slice(&state);
 
-            let block = &self.cfg.blocks[bid];
-            if !self.interpret_block(block.insts(), &mut stack_buf) {
-                continue;
-            }
-            let block = &self.cfg.blocks[bid];
-
-            // Discover dynamic-jump target edges from the snapshot recorded above.
-            let term_inst = block.terminator();
-            let term = &self.insts[term_inst];
-            if term.is_jump()
-                && !term.flags.contains(InstFlags::STATIC_JUMP)
-                && let Some(&operand) = self.snapshots.inputs[term_inst].last()
-            {
-                self.discover_jump_edges(
-                    operand,
-                    bid,
+                let block = &self.cfg.blocks[bid];
+                let term_inst = block.terminator();
+                let mut jump_operand = None;
+                if !self.interpret_block(
+                    block.insts(),
+                    &mut stack_buf,
                     const_sets,
-                    &mut discovered,
-                    &mut disc_preds,
-                );
-            }
+                    Some(term_inst),
+                    &mut jump_operand,
+                ) {
+                    continue;
+                }
+                let block = &self.cfg.blocks[bid];
 
-            // Propagate to static CFG successors and discovered dynamic-jump targets.
-            for &succ in block.succs.iter().chain(&discovered[bid]) {
-                if block_states[succ].join(&stack_buf, const_sets) {
-                    worklist.push(succ);
+                // Discover dynamic-jump target edges from the snapshot recorded above.
+                let term = &self.insts[term_inst];
+                let mut context_targets = SmallVec::<[Block; 4]>::new();
+                if term.is_jump()
+                    && !term.flags.contains(InstFlags::STATIC_JUMP)
+                    && let Some(operand) = jump_operand
+                {
+                    self.discover_jump_edges(
+                        operand,
+                        bid,
+                        const_sets,
+                        &mut discovered,
+                        &mut disc_preds,
+                        &mut context_targets,
+                    );
+                }
+
+                // Propagate to static CFG successors and discovered dynamic-jump targets.
+                for &succ in block.succs.iter().chain(&context_targets) {
+                    if block_states[succ].join(&stack_buf, const_sets) {
+                        worklist.push(succ);
+                    }
                 }
             }
         }
@@ -897,28 +985,39 @@ impl Bytecode<'_> {
         &mut self,
         insts: impl IntoIterator<Item = Inst>,
         stack: &mut Vec<AbsValue>,
+        const_sets: &mut ConstSetInterner,
+        capture_inst: Option<Inst>,
+        captured_jump_operand: &mut Option<AbsValue>,
     ) -> bool {
         for i in insts {
-            let inst = &self.insts[i];
-            if inst.is_dead_code() {
+            if self.insts[i].is_dead_code() {
                 continue;
             }
 
-            let (inp, out) = inst.stack_io();
+            let opcode = self.insts[i].opcode;
+            let (inp, out) = self.insts[i].stack_io();
             let inp = inp as usize;
             let out = out as usize;
 
             // Record pre-instruction input operand snapshot (in stack order, TOS last).
             if inp > 0 {
+                if capture_inst == Some(i) {
+                    *captured_jump_operand = stack.last().copied();
+                }
                 let start = stack.len().saturating_sub(inp);
-                let snap = &mut self.snapshots.inputs[i];
-                snap.clear();
-                snap.extend_from_slice(&stack[start..]);
+                if stack.len() < inp {
+                    let mut operands = SmallVec::<[AbsValue; 4]>::new();
+                    operands.resize(inp - stack.len(), AbsValue::Top);
+                    operands.extend_from_slice(stack);
+                    self.record_input_snapshot(i, &operands, const_sets);
+                } else {
+                    self.record_input_snapshot(i, &stack[start..], const_sets);
+                }
             }
 
-            match inst.opcode {
+            match opcode {
                 op::PUSH0..=op::PUSH32 => {
-                    stack.push(AbsValue::Const(inst.imm()));
+                    stack.push(AbsValue::Const(self.insts[i].imm()));
                 }
                 op::POP => {
                     if stack.pop().is_none() {
@@ -926,14 +1025,14 @@ impl Bytecode<'_> {
                     }
                 }
                 op::DUP1..=op::DUP16 => {
-                    let depth = (inst.opcode - op::DUP1 + 1) as usize;
+                    let depth = (opcode - op::DUP1 + 1) as usize;
                     if stack.len() < depth {
                         return false;
                     }
                     stack.push(stack[stack.len() - depth]);
                 }
                 op::SWAP1..=op::SWAP16 => {
-                    let depth = (inst.opcode - op::SWAP1 + 1) as usize;
+                    let depth = (opcode - op::SWAP1 + 1) as usize;
                     let len = stack.len();
                     if len < depth + 1 {
                         return false;
@@ -941,7 +1040,7 @@ impl Bytecode<'_> {
                     stack.swap(len - 1, len - 1 - depth);
                 }
                 op::DUPN => {
-                    let depth = crate::decode_single(inst.imm_byte());
+                    let depth = crate::decode_single(self.insts[i].imm_byte());
                     match depth {
                         Some(n) => {
                             let n = n as usize;
@@ -958,7 +1057,7 @@ impl Bytecode<'_> {
                     }
                 }
                 op::SWAPN => {
-                    let depth = crate::decode_single(inst.imm_byte());
+                    let depth = crate::decode_single(self.insts[i].imm_byte());
                     match depth {
                         Some(n) => {
                             let n = n as usize;
@@ -977,7 +1076,7 @@ impl Bytecode<'_> {
                     }
                 }
                 op::EXCHANGE => {
-                    let pair = crate::decode_pair(inst.imm_byte());
+                    let pair = crate::decode_pair(self.insts[i].imm_byte());
                     match pair {
                         Some((n, m)) => {
                             let (n, m) = (n as usize, m as usize);
@@ -1007,13 +1106,13 @@ impl Bytecode<'_> {
 
                         // Check gas cost before doing the actual fold.
                         let gas =
-                            super::const_fold::const_fold_gas(inst.opcode, inputs_slice, &interner);
+                            super::const_fold::const_fold_gas(opcode, inputs_slice, &interner);
                         if let Some(cost) = gas
                             && self.compiler_gas_used.saturating_add(cost)
                                 <= self.compiler_gas_limit
                         {
                             let folded = super::const_fold::try_const_fold(
-                                inst,
+                                &self.insts[i],
                                 inputs_slice,
                                 &mut interner,
                                 self.code.len(),
@@ -1044,13 +1143,14 @@ impl Bytecode<'_> {
 
             // Record post-instruction output snapshot.
             // Skip SWAP/SWAPN/EXCHANGE: they modify two positions and have no single "output".
-            if out > 0 && !matches!(inst.opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
-            {
-                self.snapshots.outputs[i] = stack.last().copied();
+            if out > 0 && !matches!(opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE) {
+                if let Some(&value) = stack.last() {
+                    self.record_output_snapshot(i, value, const_sets);
+                }
             }
 
             #[cfg(test)]
-            if inst.opcode == crate::TEST_SUSPEND {
+            if opcode == crate::TEST_SUSPEND {
                 stack.fill(AbsValue::Top);
             }
         }
@@ -1118,7 +1218,7 @@ pub(crate) mod tests {
         let bytecode = analyze_hex(
             "60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063b28175c4146046578063c0406226146052575b6000565b3460005760506076565b005b34600057605c6081565b604051808215151515815260200191505060405180910390f35b600c6000819055505b565b600060896076565b600d600181905550600e600281905550600190505b905600a165627a7a723058202a8a75d7d795b5bcb9042fb18b283daa90b999a11ddec892f5487322",
         );
-        assert!(bytecode.has_dynamic_jumps());
+        assert!(!bytecode.has_dynamic_jumps());
     }
 
     #[test]
@@ -1126,7 +1226,7 @@ pub(crate) mod tests {
         let bytecode = analyze_hex(
             "608060405234801561001057600080fd5b506004361061002b5760003560e01c806373027f6d14610030575b600080fd5b61004a600480360381019061004591906101a9565b61004c565b005b6000808273ffffffffffffffffffffffffffffffffffffffff166040516024016040516020818303038152906040527fb28175c4000000000000000000000000000000000000000000000000000000007bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffff83818316178352505050506040516100f69190610247565b6000604051808303816000865af19150503d8060008114610133576040519150601f19603f3d011682016040523d82523d6000602084013e610138565b606091505b509150915081600155505050565b600080fd5b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b60006101768261014b565b9050919050565b6101868161016b565b811461019157600080fd5b50565b6000813590506101a38161017d565b92915050565b6000602082840312156101bf576101be610146565b5b60006101cd84828501610194565b91505092915050565b600081519050919050565b600081905092915050565b60005b8381101561020a5780820151818401526020810190506101ef565b60008484015250505050565b6000610221826101d6565b61022b81856101e1565b935061023b8185602086016101ec565b80840191505092915050565b60006102538284610216565b91508190509291505056fea2646970667358221220b4673c55c7b0268d7d118059e6509196d2185bb7fe040a7d3900f902c8542ea464736f6c63430008180033",
         );
-        assert!(bytecode.has_dynamic_jumps());
+        assert!(!bytecode.has_dynamic_jumps());
     }
 
     #[test]
@@ -1137,7 +1237,7 @@ pub(crate) mod tests {
             "3033146033575b303303600e57005b601b5f35806001555f608d565b5f80808080305af1600255602e60016089565b600355005b603a5f6089565b8015608757604a600182035f608d565b5f80808080305af1156083576001606191035f608d565b5f80808080305af115608357607f60016078816089565b016001608d565b6006565b5f80fd5b005b5c90565b5d56",
             "60065f601d565b5f5560106001601d565b6001555f80808080335af1005b5c9056",
         ];
-        let has_dynamic = [false, false, true, false];
+        let has_dynamic = [false, false, false, false];
         for (hex, &expected) in contracts.iter().zip(&has_dynamic) {
             let bytecode = analyze_hex(hex);
             assert_eq!(bytecode.has_dynamic_jumps(), expected, "contract: {hex}");
@@ -1467,12 +1567,9 @@ pub(crate) mod tests {
         ",
         );
 
-        // The wrapper return JUMP (pc=30) remains dynamic because the outer
-        // return address is lost to Top during the top-aligned join.
-        // Because an unresolved Top jump exists, the conservative invalidation
-        // also invalidates the inner return JUMP — any reachable JUMPDEST
-        // (including inner's entry) is suspect.
-        assert!(bytecode.has_dynamic_jumps, "expected dynamic jumps to remain");
+        // Different stack-depth contexts preserve the wrapper's outer return
+        // address while still resolving the shared inner return.
+        assert!(!bytecode.has_dynamic_jumps, "expected all jumps to be resolved");
     }
 
     /// Regression test: deep DUPN on Amsterdam must not cause the abstract interpreter to

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -346,6 +346,10 @@ impl JumpTarget {
             _ => None,
         }
     }
+
+    fn is_resolved(&self) -> bool {
+        matches!(self, Self::Resolved(_) | Self::ResolvedWithInvalid(_) | Self::Invalid)
+    }
 }
 
 /// CFG for abstract interpretation.
@@ -761,17 +765,7 @@ impl Bytecode<'_> {
             }
         }
 
-        let count = jump_targets
-            .iter()
-            .filter(|(_, t)| {
-                matches!(
-                    t,
-                    JumpTarget::Resolved(_)
-                        | JumpTarget::ResolvedWithInvalid(_)
-                        | JumpTarget::Invalid
-                )
-            })
-            .count();
+        let count = jump_targets.iter().filter(|(_, target)| target.is_resolved()).count();
 
         (jump_targets, count)
     }
@@ -902,12 +896,7 @@ impl Bytecode<'_> {
 
         if invalidate_targets {
             for (inst, target) in jump_targets.iter_mut() {
-                if !matches!(
-                    target,
-                    JumpTarget::Resolved(_)
-                        | JumpTarget::ResolvedWithInvalid(_)
-                        | JumpTarget::Invalid
-                ) {
+                if !target.is_resolved() {
                     continue;
                 }
                 if let Some(bid) = self.cfg.inst_to_block[*inst]

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -293,25 +293,44 @@ enum JumpTarget {
     /// Not yet observed.
     Bottom,
     /// One or more known constant target instruction indices.
-    Resolved(SmallVec<[Inst; 4]>),
+    Resolved(SmallVec<[Inst; 4]>, JumpCondition),
     /// Known constant but invalid target.
     Invalid,
     /// Unknown target.
     Top,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum JumpCondition {
+    #[default]
+    Unknown,
+    AlwaysTrue,
+    AlwaysFalse,
+}
+
 impl JumpTarget {
     /// Creates a resolved target with a single constant.
     fn single(inst: Inst) -> Self {
-        Self::Resolved(SmallVec::from_elem(inst, 1))
+        Self::Resolved(SmallVec::from_elem(inst, 1), JumpCondition::Unknown)
     }
 
     /// Returns the single resolved target, if exactly one.
     fn as_single(&self) -> Option<Inst> {
         match self {
-            Self::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
+            Self::Resolved(targets, _) if targets.len() == 1 => Some(targets[0]),
             _ => None,
         }
+    }
+
+    fn with_condition(self, condition: JumpCondition) -> Self {
+        match self {
+            Self::Resolved(targets, _) => Self::Resolved(targets, condition),
+            target => target,
+        }
+    }
+
+    fn is_resolved(&self) -> bool {
+        matches!(self, Self::Resolved(_, _) | Self::Invalid)
     }
 }
 
@@ -367,9 +386,7 @@ impl Bytecode<'_> {
                 continue;
             }
 
-            let Some(&operand) = self.snapshots.inputs[term_inst].last() else { continue };
-            debug_assert!(!matches!(operand, AbsValue::ConstSet(_)));
-            let target = self.resolve_jump_operand(operand, &empty_sets);
+            let target = self.resolve_jump_snapshot(term_inst, &empty_sets);
             let Some(target_inst) = target.as_single() else { continue };
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
@@ -435,14 +452,19 @@ impl Bytecode<'_> {
             }
 
             match *target {
-                JumpTarget::Resolved(ref targets) => {
-                    for &target_inst in targets {
-                        debug_assert_eq!(
-                            self.insts[target_inst].opcode,
-                            op::JUMPDEST,
-                            "block_analysis resolved to non-JUMPDEST"
-                        );
-                        self.insts[target_inst].set_jumpdest_reachable();
+                JumpTarget::Resolved(ref targets, condition) => {
+                    if condition != JumpCondition::Unknown {
+                        self.insts[jump_inst].flags |= InstFlags::CONST_JUMP_CONDITION;
+                    }
+                    if condition != JumpCondition::AlwaysFalse {
+                        for &target_inst in targets {
+                            debug_assert_eq!(
+                                self.insts[target_inst].opcode,
+                                op::JUMPDEST,
+                                "block_analysis resolved to non-JUMPDEST"
+                            );
+                            self.insts[target_inst].set_jumpdest_reachable();
+                        }
                     }
                     if targets.len() == 1 {
                         self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
@@ -592,6 +614,7 @@ impl Bytecode<'_> {
             } else if term.is_static_jump()
                 && !term.flags.contains(InstFlags::INVALID_JUMP)
                 && let Some(target_block) = resolve(term.static_jump_target())
+                && !cfg.blocks[bid].succs.contains(&target_block)
             {
                 cfg.blocks[target_block].preds.push(bid);
                 cfg.blocks[bid].succs.push(target_block);
@@ -637,14 +660,7 @@ impl Bytecode<'_> {
         let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
-            let target = match self.snapshots.inputs[jump_inst].last() {
-                Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
-                None => {
-                    // No snapshot means the block was never interpreted (unreachable).
-                    trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                    JumpTarget::Bottom
-                }
-            };
+            let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
             if matches!(target, JumpTarget::Top) {
                 has_top_jump = true;
             }
@@ -663,12 +679,37 @@ impl Bytecode<'_> {
             );
         }
 
-        let count = jump_targets
-            .iter()
-            .filter(|(_, t)| matches!(t, JumpTarget::Resolved(_) | JumpTarget::Invalid))
-            .count();
+        let count = jump_targets.iter().filter(|(_, target)| target.is_resolved()).count();
 
         (jump_targets, count)
+    }
+
+    fn resolve_jump_snapshot(&self, jump_inst: Inst, const_sets: &ConstSetInterner) -> JumpTarget {
+        let snap = &self.snapshots.inputs[jump_inst];
+        let condition = if self.insts[jump_inst].opcode == op::JUMPI {
+            snap.first()
+                .map(|&value| self.resolve_jump_condition(value, const_sets))
+                .unwrap_or_default()
+        } else {
+            JumpCondition::Unknown
+        };
+
+        if condition == JumpCondition::AlwaysFalse {
+            return JumpTarget::Resolved(
+                SmallVec::from_elem(jump_inst + 1, 1),
+                JumpCondition::AlwaysFalse,
+            );
+        }
+
+        match snap.last() {
+            Some(&operand) => {
+                self.resolve_jump_operand(operand, const_sets).with_condition(condition)
+            }
+            None => {
+                trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
+                JumpTarget::Bottom
+            }
+        }
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
@@ -701,13 +742,52 @@ impl Bytecode<'_> {
                     }
                 }
                 if !targets.is_empty() {
-                    JumpTarget::Resolved(targets)
+                    JumpTarget::Resolved(targets, JumpCondition::Unknown)
                 } else {
                     JumpTarget::Invalid
                 }
             }
             AbsValue::Top => JumpTarget::Top,
         }
+    }
+
+    fn resolve_jump_condition(
+        &self,
+        condition: AbsValue,
+        const_sets: &ConstSetInterner,
+    ) -> JumpCondition {
+        let consts = match condition {
+            AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
+            AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
+            AbsValue::Top => return JumpCondition::Unknown,
+        };
+        let interner = self.u256_interner.borrow();
+        let mut saw_zero = false;
+        let mut saw_nonzero = false;
+        for imm in consts {
+            if imm.get(&interner).is_zero() {
+                saw_zero = true;
+            } else {
+                saw_nonzero = true;
+            }
+        }
+        match (saw_zero, saw_nonzero) {
+            (true, false) => JumpCondition::AlwaysFalse,
+            (false, true) => JumpCondition::AlwaysTrue,
+            _ => JumpCondition::Unknown,
+        }
+    }
+
+    fn is_const_zero(&self, value: AbsValue) -> bool {
+        value.as_const().is_some_and(|imm| imm.get(&self.u256_interner.borrow()).is_zero())
+    }
+
+    fn local_jumpi_condition_is_zero(&self, jump_inst: Inst, local_snapshots: &Snapshots) -> bool {
+        self.insts[jump_inst].opcode == op::JUMPI
+            && local_snapshots.inputs[jump_inst]
+                .first()
+                .copied()
+                .is_some_and(|value| self.is_const_zero(value))
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -788,7 +868,12 @@ impl Bytecode<'_> {
         }
 
         for (inst, target) in jump_targets.iter_mut() {
-            if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
+            if matches!(target, JumpTarget::Resolved(_, JumpCondition::AlwaysFalse))
+                && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
+            {
+                continue;
+            }
+            if !target.is_resolved() {
                 continue;
             }
             if let Some(bid) = self.cfg.inst_to_block[*inst]
@@ -1637,6 +1722,11 @@ mod tests_edge_cases {
         ",
         );
         // The JUMPI should be resolved as static.
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert_eq!(bytecode.inst(jump.static_jump_target()).opcode, op::JUMPDEST);
+        assert_ne!(jump.static_jump_target(), jump_inst + 1);
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1706,6 +1796,67 @@ mod tests_edge_cases {
         assert!(jump_inst.is_some(), "expected an invalid jump");
     }
 
+    #[test]
+    fn jumpi_with_zero_condition_ignores_unknown_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_zero_condition_ignores_valid_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            PUSH %target
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_true_condition_keeps_unknown_target_dynamic() {
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x01
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(!jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(bytecode.has_dynamic_jumps);
+    }
+
     /// Constant propagation through a diamond CFG (if-then-else merge).
     /// Both branches push the same constant, so the merge should preserve it.
     #[test]
@@ -1713,7 +1864,7 @@ mod tests_edge_cases {
         let bytecode = analyze_asm(
             "
             PUSH1 0x42              ; push same const on both paths
-            PUSH0                   ; condition (always false)
+            CALLDATASIZE            ; condition
             PUSH %then_pc           ; then target
             JUMPI                   ; branch
             ; Else: push same const.
@@ -1744,7 +1895,7 @@ mod tests_edge_cases {
     fn diamond_cfg_different_const() {
         let bytecode = analyze_asm(
             "
-            PUSH0                   ; condition
+            CALLDATASIZE            ; condition
             PUSH %then_pc
             JUMPI                   ; branch
             ; Else: push 0xAA.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -320,11 +320,18 @@ impl BlockData {
 
 /// Resolved jump target after fixpoint.
 #[derive(Clone, Debug)]
-enum JumpTarget {
+struct JumpTarget {
+    target: JumpTargetKind,
+    condition: JumpCondition,
+}
+
+/// Resolved jump target kind after fixpoint.
+#[derive(Clone, Debug)]
+enum JumpTargetKind {
     /// Not yet observed.
     Bottom,
     /// One or more known constant target instruction indices.
-    Resolved(SmallVec<[Inst; 4]>, JumpCondition),
+    Resolved(SmallVec<[Inst; 4]>),
     /// One or more known valid targets, plus at least one known invalid target.
     ResolvedWithInvalid(SmallVec<[Inst; 4]>),
     /// Known constant but invalid target.
@@ -342,28 +349,63 @@ enum JumpCondition {
 }
 
 impl JumpTarget {
+    fn new(target: JumpTargetKind) -> Self {
+        Self { target, condition: JumpCondition::Unknown }
+    }
+
+    fn bottom() -> Self {
+        Self::new(JumpTargetKind::Bottom)
+    }
+
+    fn invalid() -> Self {
+        Self::new(JumpTargetKind::Invalid)
+    }
+
+    fn top() -> Self {
+        Self::new(JumpTargetKind::Top)
+    }
+
+    fn resolved(targets: SmallVec<[Inst; 4]>) -> Self {
+        Self::new(JumpTargetKind::Resolved(targets))
+    }
+
+    fn resolved_with_invalid(targets: SmallVec<[Inst; 4]>) -> Self {
+        Self::new(JumpTargetKind::ResolvedWithInvalid(targets))
+    }
+
     /// Creates a resolved target with a single constant.
     fn single(inst: Inst) -> Self {
-        Self::Resolved(SmallVec::from_elem(inst, 1), JumpCondition::Unknown)
+        Self::resolved(SmallVec::from_elem(inst, 1))
     }
 
     /// Returns the single resolved target, if exactly one.
     fn as_single(&self) -> Option<Inst> {
-        match self {
-            Self::Resolved(targets, _) if targets.len() == 1 => Some(targets[0]),
+        match &self.target {
+            JumpTargetKind::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
             _ => None,
         }
     }
 
-    fn is_resolved(&self) -> bool {
-        matches!(self, Self::Resolved(_, _) | Self::ResolvedWithInvalid(_) | Self::Invalid)
+    fn with_condition(mut self, condition: JumpCondition) -> Self {
+        self.condition = condition;
+        self
     }
 
-    fn with_condition(self, condition: JumpCondition) -> Self {
-        match self {
-            Self::Resolved(targets, _) => Self::Resolved(targets, condition),
-            target => target,
-        }
+    fn is_resolved(&self) -> bool {
+        matches!(
+            self.target,
+            JumpTargetKind::Resolved(_)
+                | JumpTargetKind::ResolvedWithInvalid(_)
+                | JumpTargetKind::Invalid
+        )
+    }
+
+    fn is_bottom(&self) -> bool {
+        matches!(self.target, JumpTargetKind::Bottom)
+    }
+
+    fn is_top(&self) -> bool {
+        matches!(self.target, JumpTargetKind::Top)
     }
 }
 
@@ -490,7 +532,9 @@ impl Bytecode<'_> {
         self.init_snapshots();
         let (resolved, count) = self.run_abstract_interp(local_snapshots);
 
-        if count > 0 {
+        let has_const_condition =
+            resolved.iter().any(|(_, target)| target.condition != JumpCondition::Unknown);
+        if count > 0 || has_const_condition {
             let newly_resolved = self.commit_resolved_jumps(&resolved);
             debug!(newly_resolved, "resolved jumps");
         }
@@ -513,21 +557,25 @@ impl Bytecode<'_> {
     ///
     /// Returns the number of newly resolved jumps.
     fn commit_resolved_jumps(&mut self, resolved: &[(Inst, JumpTarget)]) -> u32 {
-        let has_top_jump = resolved.iter().any(|(_, t)| matches!(t, JumpTarget::Top));
+        let has_top_jump = resolved.iter().any(|(_, target)| target.is_top());
 
         let mut newly_resolved = 0u32;
         for &(jump_inst, ref target) in resolved {
-            // Skip if already resolved by block_analysis_local.
-            if self.insts[jump_inst].flags.contains(InstFlags::STATIC_JUMP) {
+            let was_static = self.insts[jump_inst].flags.contains(InstFlags::STATIC_JUMP);
+            if was_static && target.condition == JumpCondition::Unknown {
                 continue;
             }
 
-            match *target {
-                JumpTarget::Resolved(ref targets, condition) => {
-                    if condition != JumpCondition::Unknown {
-                        self.insts[jump_inst].flags |= InstFlags::CONST_JUMP_CONDITION;
-                    }
-                    if condition != JumpCondition::AlwaysFalse {
+            if target.condition != JumpCondition::Unknown {
+                self.insts[jump_inst].flags |= InstFlags::CONST_JUMPI_CONDITION;
+            }
+
+            match &target.target {
+                JumpTargetKind::Resolved(targets) => {
+                    self.insts[jump_inst]
+                        .flags
+                        .remove(InstFlags::INVALID_JUMP | InstFlags::MULTI_JUMP);
+                    if target.condition != JumpCondition::AlwaysFalse {
                         for &target_inst in targets {
                             debug_assert_eq!(
                                 self.insts[target_inst].opcode,
@@ -538,6 +586,7 @@ impl Bytecode<'_> {
                         }
                     }
                     if targets.len() == 1 {
+                        self.multi_jump_targets.remove(&jump_inst);
                         self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
                         self.insts[jump_inst].set_static_jump_target(targets[0]);
                         trace!(%jump_inst, target_inst = %targets[0], "resolved jump");
@@ -547,9 +596,12 @@ impl Bytecode<'_> {
                         self.multi_jump_targets.insert(jump_inst, targets.clone());
                         trace!(%jump_inst, n_targets = targets.len(), "resolved multi-target jump");
                     }
-                    newly_resolved += 1;
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                 }
-                JumpTarget::ResolvedWithInvalid(ref targets) => {
+                JumpTargetKind::ResolvedWithInvalid(targets) => {
+                    self.insts[jump_inst].flags.remove(InstFlags::INVALID_JUMP);
                     for &target_inst in targets {
                         debug_assert_eq!(
                             self.insts[target_inst].opcode,
@@ -560,33 +612,75 @@ impl Bytecode<'_> {
                     }
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::MULTI_JUMP;
                     self.multi_jump_targets.insert(jump_inst, targets.clone());
-                    newly_resolved += 1;
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                     trace!(%jump_inst, n_targets = targets.len(), "resolved multi-target jump with invalid default");
                 }
-                JumpTarget::Invalid => {
+                JumpTargetKind::Invalid => {
+                    self.multi_jump_targets.remove(&jump_inst);
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
-                    newly_resolved += 1;
+                    self.insts[jump_inst].flags.remove(InstFlags::MULTI_JUMP);
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                     trace!(%jump_inst, "resolved invalid jump");
                 }
-                JumpTarget::Bottom if !has_top_jump => {
+                JumpTargetKind::Bottom if !has_top_jump => {
                     // Truly unreachable: no unresolved jumps remain, so this
                     // code cannot be reached at runtime. Mark as invalid.
+                    self.multi_jump_targets.remove(&jump_inst);
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
-                    newly_resolved += 1;
+                    self.insts[jump_inst].flags.remove(InstFlags::MULTI_JUMP);
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                     trace!(%jump_inst, "unreachable jump");
                 }
-                JumpTarget::Bottom => {
+                JumpTargetKind::Bottom => {
                     // Unreachable according to the analysis, but there are
                     // unresolved (Top) jumps that might reach this code at
                     // runtime. Leave as-is.
                     trace!(%jump_inst, "unreachable jump (not marking, has_top_jump)");
                 }
-                JumpTarget::Top => {
+                JumpTargetKind::Top => {
                     trace!(%jump_inst, "unresolved jump (Top)");
                 }
             }
         }
+        self.recompute_reachable_jumpdests();
         newly_resolved
+    }
+
+    fn recompute_reachable_jumpdests(&mut self) {
+        for data in &mut self.insts.raw {
+            if data.opcode == op::JUMPDEST {
+                data.clear_jumpdest_reachable();
+            }
+        }
+
+        let mut targets = Vec::new();
+        for (inst, data) in self.insts.iter_enumerated() {
+            if !data.is_static_jump()
+                || data.flags.contains(InstFlags::INVALID_JUMP)
+                || data.is_dead_code()
+            {
+                continue;
+            }
+            if data.flags.contains(InstFlags::MULTI_JUMP) {
+                if let Some(multi_targets) = self.multi_jump_targets.get(&inst) {
+                    targets.extend(multi_targets.iter().copied());
+                }
+            } else {
+                targets.push(data.static_jump_target());
+            }
+        }
+
+        for target in targets {
+            if self.insts[target].opcode == op::JUMPDEST {
+                self.insts[target].set_jumpdest_reachable();
+            }
+        }
     }
 
     /// Rebuild the basic-block CFG from the current instruction state.
@@ -724,10 +818,14 @@ impl Bytecode<'_> {
             index_vec![BlockState::Bottom; num_blocks];
         block_states[Block::from_usize(0)] = BlockState::Known(SmallVec::from_elem(Vec::new(), 1));
 
-        // Collect unresolved jumps.
+        // Collect unresolved jumps, plus static JUMPI instructions whose condition
+        // may become constant only after CFG fixpoint.
         let mut jump_insts: Vec<Inst> = Vec::new();
         for (i, inst) in self.insts.iter_enumerated() {
-            if inst.is_jump() && !inst.flags.contains(InstFlags::STATIC_JUMP) {
+            if inst.is_jump()
+                && (!inst.flags.contains(InstFlags::STATIC_JUMP)
+                    || (inst.opcode == op::JUMPI && !inst.has_const_jumpi_condition()))
+            {
                 jump_insts.push(i);
             }
         }
@@ -746,7 +844,7 @@ impl Bytecode<'_> {
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
             let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
-            if matches!(target, JumpTarget::Top) {
+            if target.is_top() {
                 has_top_jump = true;
             }
             jump_targets.push((jump_inst, target));
@@ -755,8 +853,7 @@ impl Bytecode<'_> {
         // Invalidate resolutions that may be unsound due to incomplete analysis.
         // When the fixpoint didn't converge, partially-discovered ConstSets may be
         // incomplete, so we must conservatively invalidate them too.
-        let has_bottom_jump =
-            jump_targets.iter().any(|(_, target)| matches!(target, JumpTarget::Bottom));
+        let has_bottom_jump = jump_targets.iter().any(|(_, target)| target.is_bottom());
         if has_top_jump || has_bottom_jump || !converged {
             self.invalidate_suspect_jumps(
                 &mut jump_targets,
@@ -789,10 +886,7 @@ impl Bytecode<'_> {
         };
 
         if condition == JumpCondition::AlwaysFalse {
-            return JumpTarget::Resolved(
-                SmallVec::from_elem(jump_inst + 1, 1),
-                JumpCondition::AlwaysFalse,
-            );
+            return JumpTarget::single(jump_inst + 1).with_condition(JumpCondition::AlwaysFalse);
         }
 
         match snap.last() {
@@ -801,7 +895,7 @@ impl Bytecode<'_> {
             }
             None => {
                 trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                JumpTarget::Bottom
+                JumpTarget::bottom()
             }
         }
     }
@@ -815,7 +909,7 @@ impl Bytecode<'_> {
                     Ok(target_pc) if self.is_valid_jump(target_pc) => {
                         JumpTarget::single(self.pc_to_inst(target_pc))
                     }
-                    _ => JumpTarget::Invalid,
+                    _ => JumpTarget::invalid(),
                 }
             }
             AbsValue::ConstSet(set_idx) => {
@@ -833,14 +927,14 @@ impl Bytecode<'_> {
                     }
                 }
                 if targets.is_empty() {
-                    JumpTarget::Invalid
+                    JumpTarget::invalid()
                 } else if has_invalid {
-                    JumpTarget::ResolvedWithInvalid(targets)
+                    JumpTarget::resolved_with_invalid(targets)
                 } else {
-                    JumpTarget::Resolved(targets, JumpCondition::Unknown)
+                    JumpTarget::resolved(targets)
                 }
             }
-            AbsValue::Top => JumpTarget::Top,
+            AbsValue::Top => JumpTarget::top(),
         }
     }
 
@@ -967,7 +1061,8 @@ impl Bytecode<'_> {
 
         if invalidate_targets {
             for (inst, target) in jump_targets.iter_mut() {
-                if matches!(target, JumpTarget::Resolved(_, JumpCondition::AlwaysFalse))
+                if matches!(target.target, JumpTargetKind::Resolved(_))
+                    && target.condition == JumpCondition::AlwaysFalse
                     && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
                 {
                     continue;
@@ -978,7 +1073,7 @@ impl Bytecode<'_> {
                 if let Some(bid) = self.cfg.inst_to_block[*inst]
                     && suspect[bid.index()]
                 {
-                    *target = JumpTarget::Top;
+                    *target = JumpTarget::top();
                 }
             }
         }
@@ -2535,7 +2630,7 @@ mod tests_edge_cases {
             "
             PUSH1 0x69          ; inst 0: cross-block value
             CALLDATASIZE        ; inst 1: unknown condition
-            PUSH %target        ; inst 2
+            PUSH %opaque        ; inst 2
             JUMPI               ; inst 3
             ; Non-suspect fallthrough block (no JUMPDEST).
             PUSH1 0x0A          ; inst 4
@@ -2548,6 +2643,7 @@ mod tests_edge_cases {
             MSTORE              ; inst 11
             STOP                ; inst 12
             ; Opaque dynamic jump — triggers suspect invalidation.
+        opaque:
             JUMPDEST            ; inst 13
             PUSH0               ; inst 14
             CALLDATALOAD        ; inst 15: Top

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -718,12 +718,20 @@ impl Bytecode<'_> {
         let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
-            let target = match self.snapshots.inputs[jump_inst].last() {
-                Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
-                None => {
-                    // No snapshot means the block was never interpreted (unreachable).
-                    trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                    JumpTarget::Bottom
+            let snap = &self.snapshots.inputs[jump_inst];
+            let target = if self.insts[jump_inst].opcode == op::JUMPI
+                && let Some(&condition) = snap.first()
+                && self.is_const_zero(condition)
+            {
+                JumpTarget::Invalid
+            } else {
+                match snap.last() {
+                    Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
+                    None => {
+                        // No snapshot means the block was never interpreted (unreachable).
+                        trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
+                        JumpTarget::Bottom
+                    }
                 }
             };
             if matches!(target, JumpTarget::Top) {
@@ -804,6 +812,10 @@ impl Bytecode<'_> {
             }
             AbsValue::Top => JumpTarget::Top,
         }
+    }
+
+    fn is_const_zero(&self, value: AbsValue) -> bool {
+        value.as_const().is_some_and(|imm| imm.get(&self.u256_interner.borrow()).is_zero())
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -1867,6 +1879,26 @@ mod tests_edge_cases {
             .find(|(_, d)| d.is_jump() && d.flags.contains(InstFlags::MULTI_JUMP))
             .expect("expected mixed valid/invalid jump to use multi-jump");
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_zero_condition_ignores_unknown_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(jump.flags.contains(InstFlags::INVALID_JUMP));
         assert!(!bytecode.has_dynamic_jumps);
     }
 

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -329,8 +329,9 @@ enum JumpTarget {
     ResolvedWithInvalid(SmallVec<[Inst; 4]>),
     /// Known constant but invalid target.
     Invalid,
-    /// Conditional jump with a condition known to be zero.
-    NotTaken,
+    /// Conditional jump with a condition known to be zero. The only reachable successor is the
+    /// fallthrough instruction.
+    NotTaken(Inst),
     /// Unknown target.
     Top,
 }
@@ -345,6 +346,7 @@ impl JumpTarget {
     fn as_single(&self) -> Option<Inst> {
         match self {
             Self::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
+            Self::NotTaken(target) => Some(*target),
             _ => None,
         }
     }
@@ -352,7 +354,7 @@ impl JumpTarget {
     fn is_resolved(&self) -> bool {
         matches!(
             self,
-            Self::Resolved(_) | Self::ResolvedWithInvalid(_) | Self::Invalid | Self::NotTaken
+            Self::Resolved(_) | Self::ResolvedWithInvalid(_) | Self::Invalid | Self::NotTaken(_)
         )
     }
 
@@ -449,7 +451,7 @@ impl Bytecode<'_> {
 
             let target = self.resolve_jump_snapshot(term_inst, &local_sets);
             let target_inst = target.as_single();
-            if !matches!(target, JumpTarget::NotTaken) && target_inst.is_none() {
+            if target_inst.is_none() {
                 continue;
             }
 
@@ -557,10 +559,10 @@ impl Bytecode<'_> {
                     newly_resolved += 1;
                     trace!(%jump_inst, "resolved invalid jump");
                 }
-                JumpTarget::NotTaken => {
+                JumpTarget::NotTaken(target_inst) => {
                     debug_assert_eq!(self.insts[jump_inst].opcode, op::JUMPI);
-                    self.insts[jump_inst].flags |=
-                        InstFlags::STATIC_JUMP | InstFlags::NOT_TAKEN_JUMP;
+                    self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
+                    self.insts[jump_inst].set_static_jump_target(target_inst);
                     newly_resolved += 1;
                     trace!(%jump_inst, "resolved not-taken conditional jump");
                 }
@@ -694,8 +696,8 @@ impl Bytecode<'_> {
                 }
             } else if term.is_static_jump()
                 && !term.flags.contains(InstFlags::INVALID_JUMP)
-                && !term.flags.contains(InstFlags::NOT_TAKEN_JUMP)
                 && let Some(target_block) = resolve(term.static_jump_target())
+                && !cfg.blocks[bid].succs.contains(&target_block)
             {
                 cfg.blocks[target_block].preds.push(bid);
                 cfg.blocks[bid].succs.push(target_block);
@@ -780,7 +782,7 @@ impl Bytecode<'_> {
             && let Some(&condition) = snap.first()
             && self.is_const_zero(condition)
         {
-            return JumpTarget::NotTaken;
+            return JumpTarget::NotTaken(jump_inst + 1);
         }
 
         match snap.last() {
@@ -926,7 +928,7 @@ impl Bytecode<'_> {
 
         if invalidate_targets {
             for (inst, target) in jump_targets.iter_mut() {
-                if matches!(target, JumpTarget::NotTaken)
+                if matches!(target, JumpTarget::NotTaken(_))
                     && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
                 {
                     continue;
@@ -1802,6 +1804,10 @@ mod tests_edge_cases {
         ",
         );
         // The JUMPI should be resolved as static.
+        let (jump_inst, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert_eq!(bytecode.inst(jump.static_jump_target()).opcode, op::JUMPDEST);
+        assert_ne!(jump.static_jump_target(), jump_inst + 1);
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1922,8 +1928,8 @@ mod tests_edge_cases {
 
         let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
-        assert!(jump.flags.contains(InstFlags::NOT_TAKEN_JUMP));
         assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1943,8 +1949,8 @@ mod tests_edge_cases {
 
         let (_, jump) = bytecode.iter_insts().find(|(_, d)| d.opcode == op::JUMPI).unwrap();
         assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
-        assert!(jump.flags.contains(InstFlags::NOT_TAKEN_JUMP));
         assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
         assert!(!bytecode.has_dynamic_jumps);
     }
 

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -166,7 +166,7 @@ impl ConstSetInterner {
 /// Instructions that access deeper than this (e.g. Amsterdam DUPN/SWAPN up to depth 236)
 /// treat the out-of-range slot as `Top` rather than aborting block interpretation.
 const MAX_ABS_STACK_DEPTH: usize = 64;
-const MAX_BLOCK_CONTEXTS: usize = 2;
+const MAX_BLOCK_CONTEXTS: usize = 8;
 
 /// Abstract state at the entry of a block.
 #[derive(Clone, Debug)]
@@ -325,6 +325,8 @@ enum JumpTarget {
     Bottom,
     /// One or more known constant target instruction indices.
     Resolved(SmallVec<[Inst; 4]>),
+    /// One or more known valid targets, plus at least one known invalid target.
+    ResolvedWithInvalid(SmallVec<[Inst; 4]>),
     /// Known constant but invalid target.
     Invalid,
     /// Unknown target.
@@ -520,6 +522,20 @@ impl Bytecode<'_> {
                         trace!(%jump_inst, n_targets = targets.len(), "resolved multi-target jump");
                     }
                     newly_resolved += 1;
+                }
+                JumpTarget::ResolvedWithInvalid(ref targets) => {
+                    for &target_inst in targets {
+                        debug_assert_eq!(
+                            self.insts[target_inst].opcode,
+                            op::JUMPDEST,
+                            "block_analysis resolved to non-JUMPDEST"
+                        );
+                        self.insts[target_inst].set_jumpdest_reachable();
+                    }
+                    self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::MULTI_JUMP;
+                    self.multi_jump_targets.insert(jump_inst, targets.clone());
+                    newly_resolved += 1;
+                    trace!(%jump_inst, n_targets = targets.len(), "resolved multi-target jump with invalid default");
                 }
                 JumpTarget::Invalid => {
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
@@ -724,6 +740,7 @@ impl Bytecode<'_> {
         if has_top_jump || has_bottom_jump || !converged {
             self.invalidate_suspect_jumps(
                 &mut jump_targets,
+                &block_states,
                 &discovered_edges,
                 local_snapshots,
                 has_top_jump || !converged,
@@ -738,7 +755,14 @@ impl Bytecode<'_> {
 
         let count = jump_targets
             .iter()
-            .filter(|(_, t)| matches!(t, JumpTarget::Resolved(_) | JumpTarget::Invalid))
+            .filter(|(_, t)| {
+                matches!(
+                    t,
+                    JumpTarget::Resolved(_)
+                        | JumpTarget::ResolvedWithInvalid(_)
+                        | JumpTarget::Invalid
+                )
+            })
             .count();
 
         (jump_targets, count)
@@ -760,23 +784,22 @@ impl Bytecode<'_> {
                 let consts = const_sets.get(set_idx);
                 let interner = self.u256_interner.borrow();
                 let mut targets = SmallVec::new();
+                let mut has_invalid = false;
                 for &imm in consts {
                     let val = imm.get(&interner);
                     match usize::try_from(val) {
                         Ok(pc) if self.is_valid_jump(pc) => {
                             targets.push(self.pc_to_inst(pc));
                         }
-                        _ => {
-                            // Mixed valid + invalid: can't resolve since at runtime
-                            // the value might be any member of the set.
-                            return JumpTarget::Top;
-                        }
+                        _ => has_invalid = true,
                     }
                 }
-                if !targets.is_empty() {
-                    JumpTarget::Resolved(targets)
-                } else {
+                if targets.is_empty() {
                     JumpTarget::Invalid
+                } else if has_invalid {
+                    JumpTarget::ResolvedWithInvalid(targets)
+                } else {
+                    JumpTarget::Resolved(targets)
                 }
             }
             AbsValue::Top => JumpTarget::Top,
@@ -831,6 +854,7 @@ impl Bytecode<'_> {
     fn invalidate_suspect_jumps(
         &mut self,
         jump_targets: &mut [(Inst, JumpTarget)],
+        block_states: &IndexVec<Block, BlockState>,
         discovered_edges: &IndexVec<Block, SmallVec<[Block; 4]>>,
         local_snapshots: &Snapshots,
         invalidate_targets: bool,
@@ -840,7 +864,9 @@ impl Bytecode<'_> {
         // Seed: every reachable JUMPDEST block is suspect when Top jumps exist.
         let mut suspect: BitVec = BitVec::repeat(false, num_blocks);
         for bid in self.cfg.blocks.indices() {
-            if self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest() {
+            if !matches!(block_states[bid], BlockState::Bottom)
+                && self.insts[self.cfg.blocks[bid].insts.start].is_jumpdest()
+            {
                 suspect.set(bid.index(), true);
             }
         }
@@ -864,7 +890,12 @@ impl Bytecode<'_> {
 
         if invalidate_targets {
             for (inst, target) in jump_targets.iter_mut() {
-                if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
+                if !matches!(
+                    target,
+                    JumpTarget::Resolved(_)
+                        | JumpTarget::ResolvedWithInvalid(_)
+                        | JumpTarget::Invalid
+                ) {
                     continue;
                 }
                 if let Some(bid) = self.cfg.inst_to_block[*inst]
@@ -1802,6 +1833,41 @@ mod tests_edge_cases {
             .iter_insts()
             .find(|(_, d)| d.is_jump() && d.flags.contains(InstFlags::INVALID_JUMP));
         assert!(jump_inst.is_some(), "expected an invalid jump");
+    }
+
+    /// A finite target set with both valid and invalid PCs can still be compiled
+    /// as a multi-jump: valid cases branch to their target and the switch default
+    /// handles the invalid cases.
+    #[test]
+    fn const_set_with_invalid_target_resolves_to_multi_jump() {
+        let bytecode = analyze_asm(
+            "
+            CALLDATASIZE
+            PUSH %invalid_path
+            JUMPI
+            PUSH %valid
+            PUSH %join
+            JUMP
+        invalid_path:
+            JUMPDEST
+            PUSH1 0xff
+            PUSH %join
+            JUMP
+        join:
+            JUMPDEST
+            JUMP
+        valid:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode
+            .iter_insts()
+            .find(|(_, d)| d.is_jump() && d.flags.contains(InstFlags::MULTI_JUMP))
+            .expect("expected mixed valid/invalid jump to use multi-jump");
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!bytecode.has_dynamic_jumps);
     }
 
     /// Constant propagation through a diamond CFG (if-then-else merge).

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -1143,10 +1143,11 @@ impl Bytecode<'_> {
 
             // Record post-instruction output snapshot.
             // Skip SWAP/SWAPN/EXCHANGE: they modify two positions and have no single "output".
-            if out > 0 && !matches!(opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE) {
-                if let Some(&value) = stack.last() {
-                    self.record_output_snapshot(i, value, const_sets);
-                }
+            if out > 0
+                && !matches!(opcode, op::SWAP1..=op::SWAP16 | op::SWAPN | op::EXCHANGE)
+                && let Some(&value) = stack.last()
+            {
+                self.record_output_snapshot(i, value, const_sets);
             }
 
             #[cfg(test)]

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -461,7 +461,7 @@ mod tests {
         bytecode.config = AnalysisConfig::DEDUP;
         bytecode.analyze().unwrap();
 
-        assert_eq!(bytecode.redirects.len(), 13);
+        assert_eq!(bytecode.redirects.len(), 20);
     }
 
     fn fixture_entry_code(json: &str) -> Vec<u8> {

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -188,7 +188,6 @@ impl<'a> Bytecode<'a> {
                     let is_static = term.is_static_jump()
                         && !term.flags.contains(InstFlags::INVALID_JUMP)
                         && !term.flags.contains(InstFlags::MULTI_JUMP)
-                        && !term.flags.contains(InstFlags::NOT_TAKEN_JUMP)
                         && term.static_jump_target() == dup_first_inst;
                     if is_static {
                         self.insts[term_inst].set_static_jump_target(canonical_first_inst);

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -188,6 +188,7 @@ impl<'a> Bytecode<'a> {
                     let is_static = term.is_static_jump()
                         && !term.flags.contains(InstFlags::INVALID_JUMP)
                         && !term.flags.contains(InstFlags::MULTI_JUMP)
+                        && !term.flags.contains(InstFlags::NOT_TAKEN_JUMP)
                         && term.static_jump_target() == dup_first_inst;
                     if is_static {
                         self.insts[term_inst].set_static_jump_target(canonical_first_inst);

--- a/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
@@ -432,7 +432,7 @@ mod tests {
             PUSH0
             PUSH 64
             MSTORE
-            PUSH 1
+            CALLDATASIZE
             PUSH %large
             JUMPI
             PUSH %join

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -947,15 +947,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::Sstore, &[self.ecx, sp]);
             }
             op::JUMP | op::JUMPI => {
-                if data.flags.contains(InstFlags::NOT_TAKEN_JUMP) {
-                    debug_assert_eq!(opcode, op::JUMPI);
-                    self.pop_ignore(2);
-                    self.materialize_live_stack();
-                    let next = self.inst_entries[inst + 1];
-                    self.bcx.br(next);
-                    goto_return!(no_branch);
-                }
-
                 let is_invalid = data.flags.contains(InstFlags::INVALID_JUMP);
                 if is_invalid && opcode == op::JUMP {
                     // Pop and discard the target; it's always on the stack.
@@ -999,9 +990,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         // Pop and discard the target; it's always on the stack.
                         self.pop_ignore(1);
                         let target_inst = data.static_jump_target();
-                        debug_assert_eq!(
-                            *self.bytecode.inst(target_inst),
-                            op::JUMPDEST,
+                        debug_assert!(
+                            *self.bytecode.inst(target_inst) == op::JUMPDEST
+                                || (opcode == op::JUMPI && target_inst == inst + 1),
                             "jumping to non-JUMPDEST; target_inst={target_inst}",
                         );
                         self.inst_entries[target_inst]

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -965,11 +965,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         if opcode == op::JUMPI {
                             let cond_word = self.pop();
                             self.materialize_live_stack();
-                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                            let next = self.inst_entries[inst + 1];
-                            let switch_block = self.bcx.create_block("multi_jump");
-                            self.bcx.brif(cond, switch_block, next);
-                            self.bcx.switch_to_block(switch_block);
+                            if !data.has_const_jump_condition() {
+                                let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                                let next = self.inst_entries[inst + 1];
+                                let switch_block = self.bcx.create_block("multi_jump");
+                                self.bcx.brif(cond, switch_block, next);
+                                self.bcx.switch_to_block(switch_block);
+                            }
                         } else {
                             self.materialize_live_stack();
                         }
@@ -990,9 +992,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         // Pop and discard the target; it's always on the stack.
                         self.pop_ignore(1);
                         let target_inst = data.static_jump_target();
-                        debug_assert_eq!(
-                            *self.bytecode.inst(target_inst),
-                            op::JUMPDEST,
+                        debug_assert!(
+                            *self.bytecode.inst(target_inst) == op::JUMPDEST
+                                || (opcode == op::JUMPI && target_inst == inst + 1),
                             "jumping to non-JUMPDEST; target_inst={target_inst}",
                         );
                         self.inst_entries[target_inst]
@@ -1010,9 +1012,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let cond_word = self.pop();
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
-                        let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                        let next = self.inst_entries[inst + 1];
-                        self.bcx.brif(cond, target, next);
+                        if data.has_const_jump_condition() {
+                            self.bcx.br(target);
+                        } else {
+                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                            let next = self.inst_entries[inst + 1];
+                            self.bcx.brif(cond, target, next);
+                        }
                     } else {
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -947,6 +947,15 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 self.call_fallible_builtin(Builtin::Sstore, &[self.ecx, sp]);
             }
             op::JUMP | op::JUMPI => {
+                if data.flags.contains(InstFlags::NOT_TAKEN_JUMP) {
+                    debug_assert_eq!(opcode, op::JUMPI);
+                    self.pop_ignore(2);
+                    self.materialize_live_stack();
+                    let next = self.inst_entries[inst + 1];
+                    self.bcx.br(next);
+                    goto_return!(no_branch);
+                }
+
                 let is_invalid = data.flags.contains(InstFlags::INVALID_JUMP);
                 if is_invalid && opcode == op::JUMP {
                     // Pop and discard the target; it's always on the stack.

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -965,7 +965,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         if opcode == op::JUMPI {
                             let cond_word = self.pop();
                             self.materialize_live_stack();
-                            if !data.has_const_jump_condition() {
+                            if !data.has_const_jumpi_condition() {
                                 let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
                                 let next = self.inst_entries[inst + 1];
                                 let switch_block = self.bcx.create_block("multi_jump");
@@ -1012,7 +1012,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let cond_word = self.pop();
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
-                        if data.has_const_jump_condition() {
+                        if data.has_const_jumpi_condition() {
                             self.bcx.br(target);
                         } else {
                             let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -1061,7 +1061,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }
 
             op::PUSH0..=op::PUSH32 => {
-                unreachable!("handled in const_output");
+                let value = self.bytecode.get_push_value(data);
+                let value = self.bcx.iconst_256(value);
+                self.push(value);
             }
 
             op::DUP1..=op::DUP16 => self.dup((opcode - op::DUP1 + 1) as usize),


### PR DESCRIPTION
This makes constant-condition `JUMPI` resolution explicit on top of `main`.

The analysis now carries `JumpCondition` on `JumpTarget::Resolved`, so a known-false condition resolves to the next instruction and a known-true condition resolves to the jump target when the target is known. When that condition is committed to bytecode, the CFG and lowering treat it as a single-successor static jump instead of keeping a synthetic fallthrough edge.

The dead-code pass also keeps non-`JUMPDEST` static successors live, which is needed for the known-false case where the resolved successor is `inst + 1`.
