### PR TITLE
fix: resolve constant jumpi conditions

### DIFF
--- a/crates/revmc-codegen/src/bytecode/fmt.rs
+++ b/crates/revmc-codegen/src/bytecode/fmt.rs
@@ -538,7 +538,7 @@ mod tests {
             op::PUSH1, 0x01,
             op::PUSH1, 0x00,
             op::SSTORE,
-            op::PUSH1, 0x01,
+            op::CALLDATASIZE,
             op::PUSH1, 0x03,
             op::JUMPI,
             op::PUSH1, 0x00,
@@ -565,7 +565,7 @@ mod tests {
             actual,
             snapbox::str![[r#"
 ; spec_id=Osaka has_dynamic_jumps=false may_suspend=true
-; insts=19 live=19 dead=0 noops=11 suspends=1 blocks=3 block_min=2 block_max=10 block_avg=6.3 block_median=7
+; insts=19 live=19 dead=0 noops=10 suspends=1 blocks=3 block_min=2 block_max=10 block_avg=6.3 block_median=7
 
 bb0:           ; stack_in=0 max_growth=1 predecessors=
   PUSH1 0x03   ; ic= 0 pc= 0 gas=11 noop
@@ -576,21 +576,21 @@ bb1:           ; stack_in=0 max_growth=2 predecessors=bb0,bb1
   PUSH1 0x01   ; ic= 3 pc= 4 noop
   PUSH1 0x00   ; ic= 4 pc= 6 noop
   SSTORE       ; ic= 5 pc= 8
-  PUSH1 0x01   ; ic= 6 pc= 9 gas=16 noop
-  PUSH1 0x03   ; ic= 7 pc=11 noop
-  JUMPI %bb1   ; ic= 8 pc=13
+  CALLDATASIZE ; ic= 6 pc= 9 gas=15
+  PUSH1 0x03   ; ic= 7 pc=10 noop
+  JUMPI %bb1   ; ic= 8 pc=12
 
 bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
-  PUSH1 0x00   ; ic= 9 pc=14 gas=121
-  PUSH1 0x00   ; ic=10 pc=16 noop
-  PUSH1 0x00   ; ic=11 pc=18 noop
-  PUSH1 0x00   ; ic=12 pc=20 noop
-  PUSH1 0x00   ; ic=13 pc=22 noop
-  PUSH1 0x42   ; ic=14 pc=24 noop
-  PUSH2 0xffff ; ic=15 pc=26 noop
-  CALL         ; ic=16 pc=29 suspends
-  POP          ; ic=17 pc=30 gas=2 stack_in=1 max_growth=0
-  STOP         ; ic=18 pc=31
+  PUSH1 0x00   ; ic= 9 pc=13 gas=121
+  PUSH1 0x00   ; ic=10 pc=15 noop
+  PUSH1 0x00   ; ic=11 pc=17 noop
+  PUSH1 0x00   ; ic=12 pc=19 noop
+  PUSH1 0x00   ; ic=13 pc=21 noop
+  PUSH1 0x42   ; ic=14 pc=23 noop
+  PUSH2 0xffff ; ic=15 pc=25 noop
+  CALL         ; ic=16 pc=28 suspends
+  POP          ; ic=17 pc=29 gas=2 stack_in=1 max_growth=0
+  STOP         ; ic=18 pc=30
 
 "#]]
         );
@@ -637,7 +637,7 @@ bb2:           ; stack_in=0 max_growth=7 predecessors=bb1
         assert!(dot.contains("SSTORE"), "missing SSTORE");
         // SSTORE splits gas sections: two [g=] annotations in bb1.
         assert!(dot.contains("[g=7]"), "missing first gas section");
-        assert!(dot.contains("[g=16]"), "missing second gas section");
+        assert!(dot.contains("[g=15]"), "missing second gas section");
         // CALL present in bb2.
         assert!(dot.contains("CALL"), "missing CALL");
         assert!(dot.contains("[g=121]"), "missing CALL gas section");

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -476,10 +476,17 @@ impl<'a> Bytecode<'a> {
         let mut iter = self.insts.iter_mut_enumerated();
         while let Some((i, data)) = iter.next() {
             if !data.can_fall_through() {
+                let static_target = data
+                    .is_static_jump()
+                    .then(|| data.static_jump_target())
+                    .filter(|&target| target > i);
                 let mut end = i;
                 let mut any_new = false;
                 for (j, data) in &mut iter {
                     end = j;
+                    if static_target == Some(j) {
+                        break;
+                    }
                     if data.is_reachable_jumpdest(self.has_dynamic_jumps) {
                         break;
                     }

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -962,6 +962,12 @@ impl InstData {
         self.is_jump() && self.flags.contains(InstFlags::STATIC_JUMP)
     }
 
+    /// Returns `true` if this instruction is a `JUMPI` whose condition is known statically.
+    #[inline]
+    pub(crate) fn has_const_jump_condition(&self) -> bool {
+        self.opcode == op::JUMPI && self.flags.contains(InstFlags::CONST_JUMP_CONDITION)
+    }
+
     /// Returns `true` if this instruction is a `JUMPDEST`.
     #[inline]
     pub(crate) const fn is_jumpdest(&self) -> bool {
@@ -1060,7 +1066,7 @@ impl InstData {
     /// Returns `true` if execution can fall through to the next sequential instruction.
     #[inline]
     pub(crate) fn can_fall_through(&self) -> bool {
-        !self.is_diverging() && self.opcode != op::JUMP
+        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jump_condition()
     }
 
     /// Returns `true` if we know that this instruction will branch or stop execution.
@@ -1104,7 +1110,7 @@ impl InstData {
 bitflags::bitflags! {
     /// [`InstrData`] flags.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub(crate) struct InstFlags: u8 {
+    pub(crate) struct InstFlags: u16 {
         /// The `JUMP`/`JUMPI` target is known at compile time.
         const STATIC_JUMP = 1 << 0;
         /// The jump target is known to be invalid.
@@ -1127,6 +1133,8 @@ bitflags::bitflags! {
         const STACK_SECTION_HEAD = 1 << 6;
         /// Don't generate any code.
         const DEAD_CODE = 1 << 7;
+        /// The `JUMPI` condition is known at compile time.
+        const CONST_JUMP_CONDITION = 1 << 8;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -971,7 +971,7 @@ impl InstData {
 
     /// Returns `true` if this instruction is a `JUMPI` whose condition is known statically.
     #[inline]
-    pub(crate) fn has_const_jump_condition(&self) -> bool {
+    pub(crate) fn has_const_jumpi_condition(&self) -> bool {
         self.opcode == op::JUMPI && self.flags.contains(InstFlags::CONST_JUMP_CONDITION)
     }
 
@@ -1036,6 +1036,12 @@ impl InstData {
         self.data |= Self::JUMPDEST_REACHABLE;
     }
 
+    #[inline]
+    pub(crate) fn clear_jumpdest_reachable(&mut self) {
+        debug_assert_eq!(self.opcode, op::JUMPDEST);
+        self.data &= !Self::JUMPDEST_REACHABLE;
+    }
+
     /// Returns the static target of a `JUMP`/`JUMPI` with [`InstFlags::STATIC_JUMP`].
     #[inline]
     pub(crate) fn static_jump_target(&self) -> Inst {
@@ -1073,7 +1079,7 @@ impl InstData {
     /// Returns `true` if execution can fall through to the next sequential instruction.
     #[inline]
     pub(crate) fn can_fall_through(&self) -> bool {
-        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jump_condition()
+        !self.is_diverging() && self.opcode != op::JUMP && !self.has_const_jumpi_condition()
     }
 
     /// Returns `true` if we know that this instruction will branch or stop execution.
@@ -1126,22 +1132,22 @@ bitflags::bitflags! {
         /// The jump has multiple known targets (see `Bytecode::multi_jump_targets`).
         /// The target value is still on the stack and must be popped and switched on at runtime.
         const MULTI_JUMP = 1 << 2;
+        /// The `JUMPI` condition is known at compile time.
+        const CONST_JUMP_CONDITION = 1 << 3;
 
         /// The instruction is disabled in this EVM version.
         /// Always returns [`InstructionResult::NotActivated`] at runtime.
-        const DISABLED = 1 << 3;
+        const DISABLED = 1 << 4;
         /// The instruction is unknown.
         /// Always returns [`InstructionResult::NotFound`] at runtime.
-        const UNKNOWN = 1 << 4;
+        const UNKNOWN = 1 << 5;
 
         /// Instruction is a no-op: skip generating logic, but keep the gas calculation.
-        const NOOP = 1 << 5;
+        const NOOP = 1 << 6;
         /// This instruction starts a new stack section.
-        const STACK_SECTION_HEAD = 1 << 6;
+        const STACK_SECTION_HEAD = 1 << 7;
         /// Don't generate any code.
-        const DEAD_CODE = 1 << 7;
-        /// The `JUMPI` condition is known at compile time.
-        const CONST_JUMP_CONDITION = 1 << 8;
+        const DEAD_CODE = 1 << 8;
     }
 }
 

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -472,6 +472,7 @@ impl<'a> Bytecode<'a> {
     /// We can simply mark all instructions that are between diverging instructions and
     /// `JUMPDEST`s.
     #[instrument(name = "dce", level = "debug", skip_all)]
+    #[inline(never)]
     fn mark_dead_code(&mut self) {
         let mut iter = self.insts.iter_mut_enumerated();
         while let Some((i, data)) = iter.next() {
@@ -514,6 +515,7 @@ impl<'a> Bytecode<'a> {
 
     /// Constructs the sections in the bytecode.
     #[instrument(name = "sections", level = "debug", skip_all)]
+    #[inline(never)]
     fn construct_sections(&mut self) {
         let mut analysis = SectionsAnalysis::default();
         for inst in self.insts.indices() {
@@ -526,6 +528,7 @@ impl<'a> Bytecode<'a> {
 
     /// Constructs the memory sections in the bytecode.
     #[instrument(name = "memory_sections", level = "debug", skip_all)]
+    #[inline(never)]
     fn construct_memory_sections(&mut self) {
         self.memory_sections = MemorySectionAnalysis::new(self).run(self);
     }

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -475,12 +475,16 @@ impl<'a> Bytecode<'a> {
     #[inline(never)]
     fn mark_dead_code(&mut self) {
         let mut iter = self.insts.iter_mut_enumerated();
+        let mut marked_jump_dead = false;
         while let Some((i, data)) = iter.next() {
             if !data.can_fall_through() {
                 let static_target = data
                     .is_static_jump()
                     .then(|| data.static_jump_target())
                     .filter(|&target| target > i);
+                if static_target == Some(i + 1) {
+                    continue;
+                }
                 let mut end = i;
                 let mut any_new = false;
                 for (j, data) in &mut iter {
@@ -493,6 +497,7 @@ impl<'a> Bytecode<'a> {
                     }
                     if !data.flags.contains(InstFlags::DEAD_CODE) {
                         any_new = true;
+                        marked_jump_dead |= data.is_jump();
                     }
                     data.flags |= InstFlags::DEAD_CODE;
                 }
@@ -501,6 +506,9 @@ impl<'a> Bytecode<'a> {
                     debug!("found dead code: {start}..{end}");
                 }
             }
+        }
+        if marked_jump_dead {
+            self.recompute_has_dynamic_jumps();
         }
     }
 
@@ -1206,5 +1214,30 @@ mod tests {
         let bc = Bytecode::test(&code);
         let data = bc.inst(Inst::from_usize(0));
         assert_eq!(bc.get_push_value(data), U256::from(0x42FF));
+    }
+
+    #[test]
+    fn false_jumpi_fallthrough_terminator_marks_following_dead_code() {
+        let mut bc = Bytecode::test(&[
+            op::PUSH0,
+            op::CALLDATASIZE,
+            op::JUMPI,
+            op::STOP,
+            op::CALLDATALOAD,
+            op::JUMP,
+        ]);
+        let jumpi = Inst::from_usize(2);
+        let fallthrough = jumpi + 1;
+        let dynamic_jump = Inst::from_usize(5);
+
+        bc.inst_mut(jumpi).flags |= InstFlags::STATIC_JUMP | InstFlags::CONST_JUMP_CONDITION;
+        bc.inst_mut(jumpi).set_static_jump_target(fallthrough);
+        bc.has_dynamic_jumps = true;
+        bc.mark_dead_code();
+
+        assert!(!bc.inst(fallthrough).is_dead_code());
+        assert!(bc.inst(Inst::from_usize(4)).is_dead_code());
+        assert!(bc.inst(dynamic_jump).is_dead_code());
+        assert!(!bc.has_dynamic_jumps);
     }
 }

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -419,24 +419,19 @@ impl<'a> Bytecode<'a> {
     /// Runs a list of analysis passes on the instructions.
     #[instrument(level = "debug", skip_all)]
     pub(crate) fn analyze(&mut self) -> Result<()> {
-        self.recompute_has_dynamic_jumps();
-        self.mark_dead_code();
-        self.rebuild_cfg();
+        self.refresh_cfg();
 
         self.block_analysis_local();
-        self.mark_dead_code();
-        self.rebuild_cfg();
+        self.refresh_cfg();
 
         let local_snapshots = self.snapshots.clone();
 
         self.block_analysis(&local_snapshots);
-        self.mark_dead_code();
-        self.rebuild_cfg();
+        self.refresh_cfg();
 
         if self.config.contains(AnalysisConfig::DEDUP) {
             self.dedup_blocks(&local_snapshots);
-            self.mark_dead_code();
-            self.rebuild_cfg();
+            self.refresh_cfg();
         }
         drop(local_snapshots);
 
@@ -463,6 +458,55 @@ impl<'a> Bytecode<'a> {
         Ok(())
     }
 
+    /// Recomputes the `has_dynamic_jumps` flag based on the current instruction set.
+    #[instrument(name = "dyn_jumps", level = "debug", skip_all)]
+    #[inline(never)]
+    pub(crate) fn recompute_has_dynamic_jumps(&mut self) {
+        let mut unresolved = self.insts.iter().filter(|inst| {
+            inst.is_jump() && !inst.flags.contains(InstFlags::STATIC_JUMP) && !inst.is_dead_code()
+        });
+        self.has_dynamic_jumps = unresolved.next().is_some();
+        if self.has_dynamic_jumps {
+            debug!(n = 1 + unresolved.count(), "unresolved dynamic jumps remain");
+        }
+    }
+
+    #[instrument(name = "jumpdests", level = "debug", skip_all)]
+    #[inline(never)]
+    pub(crate) fn recompute_reachable_jumpdests(&mut self) {
+        for data in &mut self.insts.raw {
+            if data.opcode == op::JUMPDEST {
+                data.clear_jumpdest_reachable();
+            }
+        }
+
+        let mut targets = Vec::new();
+        for (inst, data) in self.insts.iter_enumerated() {
+            if !data.is_static_jump()
+                || data.flags.contains(InstFlags::INVALID_JUMP)
+                || data.is_dead_code()
+            {
+                continue;
+            }
+            if data.flags.contains(InstFlags::MULTI_JUMP) {
+                if let Some(multi_targets) = self.multi_jump_targets.get(&inst) {
+                    targets.extend(multi_targets.iter().copied());
+                }
+            } else {
+                targets.push(data.static_jump_target());
+            }
+        }
+
+        for mut target in targets {
+            while let Some(&next) = self.redirects.get(&target) {
+                target = next;
+            }
+            if self.insts[target].opcode == op::JUMPDEST {
+                self.insts[target].set_jumpdest_reachable();
+            }
+        }
+    }
+
     /// Mark unreachable instructions as `DEAD_CODE` to not generate any code for them.
     ///
     /// This pass is technically unnecessary as the backend will very likely optimize any
@@ -474,6 +518,16 @@ impl<'a> Bytecode<'a> {
     #[instrument(name = "dce", level = "debug", skip_all)]
     #[inline(never)]
     fn mark_dead_code(&mut self) {
+        loop {
+            if !self.mark_dead_code_once() {
+                break;
+            }
+            self.recompute_has_dynamic_jumps();
+            self.recompute_reachable_jumpdests();
+        }
+    }
+
+    fn mark_dead_code_once(&mut self) -> bool {
         let mut iter = self.insts.iter_mut_enumerated();
         let mut marked_jump_dead = false;
         while let Some((i, data)) = iter.next() {
@@ -507,9 +561,7 @@ impl<'a> Bytecode<'a> {
                 }
             }
         }
-        if marked_jump_dead {
-            self.recompute_has_dynamic_jumps();
-        }
+        marked_jump_dead
     }
 
     /// Calculates whether the bytecode suspend suspend execution.
@@ -1239,5 +1291,41 @@ mod tests {
         assert!(bc.inst(Inst::from_usize(4)).is_dead_code());
         assert!(bc.inst(dynamic_jump).is_dead_code());
         assert!(!bc.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn dead_fallthrough_jump_does_not_keep_jumpdest_reachable() {
+        let mut bc = Bytecode::test(&[
+            op::PUSH1,
+            5,
+            op::PUSH1,
+            1,
+            op::JUMPI,
+            op::PUSH1,
+            8,
+            op::JUMP,
+            op::JUMPDEST,
+            op::STOP,
+            op::JUMPDEST,
+            op::STOP,
+        ]);
+        let jumpi = Inst::from_usize(2);
+        let dead_jump = Inst::from_usize(4);
+        let live_target = Inst::from_usize(5);
+        let stale_target = Inst::from_usize(7);
+
+        bc.inst_mut(jumpi).flags |= InstFlags::STATIC_JUMP | InstFlags::CONST_JUMP_CONDITION;
+        bc.inst_mut(jumpi).set_static_jump_target(live_target);
+        bc.inst_mut(dead_jump).flags |= InstFlags::STATIC_JUMP;
+        bc.inst_mut(dead_jump).set_static_jump_target(stale_target);
+        bc.inst_mut(live_target).set_jumpdest_reachable();
+        bc.inst_mut(stale_target).set_jumpdest_reachable();
+
+        bc.mark_dead_code();
+
+        assert!(bc.inst(dead_jump).is_dead_code());
+        assert!(bc.inst(live_target).is_jumpdest_reachable());
+        assert!(!bc.inst(stale_target).is_jumpdest_reachable());
+        assert!(bc.inst(stale_target).is_dead_code());
     }
 }

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -287,16 +287,16 @@ impl BlockData {
     }
 }
 
-/// Resolved jump target after fixpoint.
+/// Resolved jump including compile-time condition information.
 #[derive(Clone, Debug)]
-struct JumpTarget {
-    target: JumpTargetKind,
+struct JumpResolution {
+    target: JumpTarget,
     condition: JumpCondition,
 }
 
 /// Resolved jump target kind after fixpoint.
 #[derive(Clone, Debug)]
-enum JumpTargetKind {
+enum JumpTarget {
     /// Not yet observed.
     Bottom,
     /// One or more known constant target instruction indices.
@@ -315,25 +315,25 @@ enum JumpCondition {
     AlwaysFalse,
 }
 
-impl JumpTarget {
-    fn new(target: JumpTargetKind) -> Self {
+impl JumpResolution {
+    fn new(target: JumpTarget) -> Self {
         Self { target, condition: JumpCondition::Unknown }
     }
 
     fn bottom() -> Self {
-        Self::new(JumpTargetKind::Bottom)
+        Self::new(JumpTarget::Bottom)
     }
 
     fn invalid() -> Self {
-        Self::new(JumpTargetKind::Invalid)
+        Self::new(JumpTarget::Invalid)
     }
 
     fn top() -> Self {
-        Self::new(JumpTargetKind::Top)
+        Self::new(JumpTarget::Top)
     }
 
     fn resolved(targets: SmallVec<[Inst; 4]>) -> Self {
-        Self::new(JumpTargetKind::Resolved(targets))
+        Self::new(JumpTarget::Resolved(targets))
     }
 
     /// Creates a resolved target with a single constant.
@@ -344,7 +344,7 @@ impl JumpTarget {
     /// Returns the single resolved target, if exactly one.
     fn as_single(&self) -> Option<Inst> {
         match &self.target {
-            JumpTargetKind::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
+            JumpTarget::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
             _ => None,
         }
     }
@@ -355,11 +355,11 @@ impl JumpTarget {
     }
 
     fn is_top(&self) -> bool {
-        matches!(self.target, JumpTargetKind::Top)
+        matches!(self.target, JumpTarget::Top)
     }
 
     fn is_resolved(&self) -> bool {
-        matches!(self.target, JumpTargetKind::Resolved(_) | JumpTargetKind::Invalid)
+        matches!(self.target, JumpTarget::Resolved(_) | JumpTarget::Invalid)
     }
 }
 
@@ -472,7 +472,7 @@ impl Bytecode<'_> {
     /// Commits resolved jump targets by setting flags and data on the corresponding instructions.
     ///
     /// Returns the number of newly resolved jumps.
-    fn commit_resolved_jumps(&mut self, resolved: &[(Inst, JumpTarget)]) -> u32 {
+    fn commit_resolved_jumps(&mut self, resolved: &[(Inst, JumpResolution)]) -> u32 {
         let has_top_jump = resolved.iter().any(|(_, target)| target.is_top());
 
         let mut newly_resolved = 0u32;
@@ -487,7 +487,7 @@ impl Bytecode<'_> {
             }
 
             match &target.target {
-                JumpTargetKind::Resolved(targets) => {
+                JumpTarget::Resolved(targets) => {
                     self.insts[jump_inst]
                         .flags
                         .remove(InstFlags::INVALID_JUMP | InstFlags::MULTI_JUMP);
@@ -516,7 +516,7 @@ impl Bytecode<'_> {
                         newly_resolved += 1;
                     }
                 }
-                JumpTargetKind::Invalid => {
+                JumpTarget::Invalid => {
                     self.multi_jump_targets.remove(&jump_inst);
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
                     self.insts[jump_inst].flags.remove(InstFlags::MULTI_JUMP);
@@ -525,7 +525,7 @@ impl Bytecode<'_> {
                     }
                     trace!(%jump_inst, "resolved invalid jump");
                 }
-                JumpTargetKind::Bottom if !has_top_jump => {
+                JumpTarget::Bottom if !has_top_jump => {
                     // Truly unreachable: no unresolved jumps remain, so this
                     // code cannot be reached at runtime. Mark as invalid.
                     self.multi_jump_targets.remove(&jump_inst);
@@ -536,13 +536,13 @@ impl Bytecode<'_> {
                     }
                     trace!(%jump_inst, "unreachable jump");
                 }
-                JumpTargetKind::Bottom => {
+                JumpTarget::Bottom => {
                     // Unreachable according to the analysis, but there are
                     // unresolved (Top) jumps that might reach this code at
                     // runtime. Leave as-is.
                     trace!(%jump_inst, "unreachable jump (not marking, has_top_jump)");
                 }
-                JumpTargetKind::Top => {
+                JumpTarget::Top => {
                     trace!(%jump_inst, "unresolved jump (Top)");
                 }
             }
@@ -709,7 +709,7 @@ impl Bytecode<'_> {
     fn run_abstract_interp(
         &mut self,
         local_snapshots: &Snapshots,
-    ) -> (Vec<(Inst, JumpTarget)>, usize) {
+    ) -> (Vec<(Inst, JumpResolution)>, usize) {
         let num_blocks = self.cfg.blocks.len();
 
         // Initialize block states. Entry block starts with an empty stack.
@@ -739,7 +739,7 @@ impl Bytecode<'_> {
         }
 
         // After convergence, resolve each dynamic jump from its snapshot operand.
-        let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
+        let mut jump_targets: Vec<(Inst, JumpResolution)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
             let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
@@ -766,7 +766,11 @@ impl Bytecode<'_> {
         (jump_targets, count)
     }
 
-    fn resolve_jump_snapshot(&self, jump_inst: Inst, const_sets: &ConstSetInterner) -> JumpTarget {
+    fn resolve_jump_snapshot(
+        &self,
+        jump_inst: Inst,
+        const_sets: &ConstSetInterner,
+    ) -> JumpResolution {
         let snap = &self.snapshots.inputs[jump_inst];
         let condition = if self.insts[jump_inst].opcode == op::JUMPI {
             snap.first()
@@ -777,7 +781,8 @@ impl Bytecode<'_> {
         };
 
         if condition == JumpCondition::AlwaysFalse {
-            return JumpTarget::single(jump_inst + 1).with_condition(JumpCondition::AlwaysFalse);
+            return JumpResolution::single(jump_inst + 1)
+                .with_condition(JumpCondition::AlwaysFalse);
         }
 
         match snap.last() {
@@ -786,21 +791,25 @@ impl Bytecode<'_> {
             }
             None => {
                 trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                JumpTarget::bottom()
+                JumpResolution::bottom()
             }
         }
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
-    fn resolve_jump_operand(&self, operand: AbsValue, const_sets: &ConstSetInterner) -> JumpTarget {
+    fn resolve_jump_operand(
+        &self,
+        operand: AbsValue,
+        const_sets: &ConstSetInterner,
+    ) -> JumpResolution {
         match operand {
             AbsValue::Const(imm) => {
                 let val = imm.get(&self.u256_interner.borrow());
                 match usize::try_from(val) {
                     Ok(target_pc) if self.is_valid_jump(target_pc) => {
-                        JumpTarget::single(self.pc_to_inst(target_pc))
+                        JumpResolution::single(self.pc_to_inst(target_pc))
                     }
-                    _ => JumpTarget::invalid(),
+                    _ => JumpResolution::invalid(),
                 }
             }
             AbsValue::ConstSet(set_idx) => {
@@ -816,17 +825,17 @@ impl Bytecode<'_> {
                         _ => {
                             // Mixed valid + invalid: can't resolve since at runtime
                             // the value might be any member of the set.
-                            return JumpTarget::top();
+                            return JumpResolution::top();
                         }
                     }
                 }
                 if !targets.is_empty() {
-                    JumpTarget::resolved(targets)
+                    JumpResolution::resolved(targets)
                 } else {
-                    JumpTarget::invalid()
+                    JumpResolution::invalid()
                 }
             }
-            AbsValue::Top => JumpTarget::top(),
+            AbsValue::Top => JumpResolution::top(),
         }
     }
 
@@ -912,7 +921,7 @@ impl Bytecode<'_> {
     /// resolved jumps and operand snapshots in suspect blocks.
     fn invalidate_suspect_jumps(
         &mut self,
-        jump_targets: &mut [(Inst, JumpTarget)],
+        jump_targets: &mut [(Inst, JumpResolution)],
         block_states: &IndexVec<Block, BlockState>,
         discovered_edges: &IndexVec<Block, SmallVec<[Block; 4]>>,
         local_snapshots: &Snapshots,
@@ -947,7 +956,7 @@ impl Bytecode<'_> {
         }
 
         for (inst, target) in jump_targets.iter_mut() {
-            if matches!(target.target, JumpTargetKind::Resolved(_))
+            if matches!(target.target, JumpTarget::Resolved(_))
                 && target.condition == JumpCondition::AlwaysFalse
                 && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
             {
@@ -959,7 +968,7 @@ impl Bytecode<'_> {
             if let Some(bid) = self.cfg.inst_to_block[*inst]
                 && suspect[bid.index()]
             {
-                *target = JumpTarget::top();
+                *target = JumpResolution::top();
             }
         }
 

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -866,16 +866,21 @@ impl Bytecode<'_> {
         }
     }
 
-    fn is_const_zero(&self, value: AbsValue) -> bool {
-        value.as_const().is_some_and(|imm| imm.get(&self.u256_interner.borrow()).is_zero())
-    }
-
-    fn local_jumpi_condition_is_zero(&self, jump_inst: Inst, local_snapshots: &Snapshots) -> bool {
-        self.insts[jump_inst].opcode == op::JUMPI
-            && local_snapshots.inputs[jump_inst]
-                .first()
-                .copied()
-                .is_some_and(|value| self.is_const_zero(value))
+    fn local_jumpi_condition(&self, jump_inst: Inst, local_snapshots: &Snapshots) -> JumpCondition {
+        if self.insts[jump_inst].opcode != op::JUMPI {
+            return JumpCondition::Unknown;
+        }
+        let Some(condition) = local_snapshots.inputs[jump_inst].first().copied() else {
+            return JumpCondition::Unknown;
+        };
+        let Some(imm) = condition.as_const() else {
+            return JumpCondition::Unknown;
+        };
+        if imm.get(&self.u256_interner.borrow()).is_zero() {
+            JumpCondition::AlwaysFalse
+        } else {
+            JumpCondition::AlwaysTrue
+        }
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -956,19 +961,18 @@ impl Bytecode<'_> {
         }
 
         for (inst, target) in jump_targets.iter_mut() {
-            if matches!(target.target, JumpTarget::Resolved(_))
-                && target.condition == JumpCondition::AlwaysFalse
-                && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
-            {
-                continue;
-            }
-            if !target.is_resolved() {
-                continue;
-            }
             if let Some(bid) = self.cfg.inst_to_block[*inst]
                 && suspect[bid.index()]
             {
-                *target = JumpResolution::top();
+                let condition = self.local_jumpi_condition(*inst, local_snapshots);
+                if condition == JumpCondition::AlwaysFalse {
+                    *target = JumpResolution::single(*inst + 1).with_condition(condition);
+                    continue;
+                }
+                target.condition = condition;
+                if target.is_resolved() {
+                    *target = JumpResolution::top().with_condition(condition);
+                }
             }
         }
 
@@ -2246,6 +2250,91 @@ mod tests_edge_cases {
             !rj.flags.contains(InstFlags::STATIC_JUMP),
             "unsound: JUMPI return should not be resolved"
         );
+    }
+
+    /// A suspect JUMPI block must not keep a fixpoint-derived constant
+    /// condition when block-local analysis cannot prove it.
+    #[test]
+    fn suspect_jumpi_top_target_invalidates_const_condition() {
+        let bytecode = analyze_asm(
+            "
+            ; Branch to an opaque caller or fall through to a known caller.
+            PUSH0                       ; pc=0
+            CALLDATALOAD                ; pc=1
+            PUSH %opaque_caller         ; pc=2
+            JUMPI                       ; pc=4
+            ; Known caller reaches fn_entry with condition=1 and a Top target.
+            PUSH1 0x01                  ; pc=5: condition
+            PUSH0                       ; pc=7
+            MLOAD                       ; pc=8: target = Top
+            PUSH %fn_entry              ; pc=9
+            JUMP                        ; pc=11
+            ; Opaque caller could reach fn_entry with condition=0.
+        opaque_caller:
+            JUMPDEST                    ; pc=12
+            PUSH0                       ; pc=13: condition
+            PUSH %taken                 ; pc=14: target
+            PUSH0                       ; pc=16
+            MLOAD                       ; pc=17: jump destination = Top
+            JUMP                        ; pc=18
+        fn_entry:
+            JUMPDEST                    ; pc=19
+            JUMPI                       ; pc=20
+            STOP                        ; pc=21
+        taken:
+            JUMPDEST                    ; pc=22
+            STOP                        ; pc=23
+        ",
+        );
+
+        let (_, jumpi) = bytecode
+            .iter_insts()
+            .find(|(i, d)| bytecode.pc(*i) == 20 && d.opcode == op::JUMPI)
+            .unwrap();
+        assert!(
+            !jumpi.has_const_jumpi_condition(),
+            "suspect JUMPI should not keep a non-local const condition"
+        );
+        assert!(
+            !jumpi.flags.contains(InstFlags::STATIC_JUMP),
+            "suspect JUMPI target should remain dynamic"
+        );
+    }
+
+    /// A block-local false JUMPI condition is sound even in a suspect block.
+    #[test]
+    fn suspect_jumpi_top_target_keeps_local_false_condition() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATALOAD
+            PUSH %opaque
+            JUMPI
+            PUSH %fn_entry
+            JUMP
+        opaque:
+            JUMPDEST
+            PUSH0
+            MLOAD
+            JUMP
+        fn_entry:
+            JUMPDEST
+            PUSH0
+            PUSH0
+            MLOAD
+            JUMPI
+            STOP
+        taken:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (jump_inst, jumpi) =
+            bytecode.iter_insts().rev().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jumpi.has_const_jumpi_condition());
+        assert!(jumpi.flags.contains(InstFlags::STATIC_JUMP));
+        assert_eq!(jumpi.static_jump_target(), jump_inst + 1);
     }
 
     /// A third caller reaches the function entry with a known callee (static

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -289,11 +289,18 @@ impl BlockData {
 
 /// Resolved jump target after fixpoint.
 #[derive(Clone, Debug)]
-enum JumpTarget {
+struct JumpTarget {
+    target: JumpTargetKind,
+    condition: JumpCondition,
+}
+
+/// Resolved jump target kind after fixpoint.
+#[derive(Clone, Debug)]
+enum JumpTargetKind {
     /// Not yet observed.
     Bottom,
     /// One or more known constant target instruction indices.
-    Resolved(SmallVec<[Inst; 4]>, JumpCondition),
+    Resolved(SmallVec<[Inst; 4]>),
     /// Known constant but invalid target.
     Invalid,
     /// Unknown target.
@@ -309,28 +316,50 @@ enum JumpCondition {
 }
 
 impl JumpTarget {
+    fn new(target: JumpTargetKind) -> Self {
+        Self { target, condition: JumpCondition::Unknown }
+    }
+
+    fn bottom() -> Self {
+        Self::new(JumpTargetKind::Bottom)
+    }
+
+    fn invalid() -> Self {
+        Self::new(JumpTargetKind::Invalid)
+    }
+
+    fn top() -> Self {
+        Self::new(JumpTargetKind::Top)
+    }
+
+    fn resolved(targets: SmallVec<[Inst; 4]>) -> Self {
+        Self::new(JumpTargetKind::Resolved(targets))
+    }
+
     /// Creates a resolved target with a single constant.
     fn single(inst: Inst) -> Self {
-        Self::Resolved(SmallVec::from_elem(inst, 1), JumpCondition::Unknown)
+        Self::resolved(SmallVec::from_elem(inst, 1))
     }
 
     /// Returns the single resolved target, if exactly one.
     fn as_single(&self) -> Option<Inst> {
-        match self {
-            Self::Resolved(targets, _) if targets.len() == 1 => Some(targets[0]),
+        match &self.target {
+            JumpTargetKind::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
             _ => None,
         }
     }
 
-    fn with_condition(self, condition: JumpCondition) -> Self {
-        match self {
-            Self::Resolved(targets, _) => Self::Resolved(targets, condition),
-            target => target,
-        }
+    fn with_condition(mut self, condition: JumpCondition) -> Self {
+        self.condition = condition;
+        self
+    }
+
+    fn is_top(&self) -> bool {
+        matches!(self.target, JumpTargetKind::Top)
     }
 
     fn is_resolved(&self) -> bool {
-        matches!(self, Self::Resolved(_, _) | Self::Invalid)
+        matches!(self.target, JumpTargetKind::Resolved(_) | JumpTargetKind::Invalid)
     }
 }
 
@@ -419,7 +448,9 @@ impl Bytecode<'_> {
         self.init_snapshots();
         let (resolved, count) = self.run_abstract_interp(local_snapshots);
 
-        if count > 0 {
+        let has_const_condition =
+            resolved.iter().any(|(_, target)| target.condition != JumpCondition::Unknown);
+        if count > 0 || has_const_condition {
             let newly_resolved = self.commit_resolved_jumps(&resolved);
             debug!(newly_resolved, "resolved jumps");
         }
@@ -442,21 +473,25 @@ impl Bytecode<'_> {
     ///
     /// Returns the number of newly resolved jumps.
     fn commit_resolved_jumps(&mut self, resolved: &[(Inst, JumpTarget)]) -> u32 {
-        let has_top_jump = resolved.iter().any(|(_, t)| matches!(t, JumpTarget::Top));
+        let has_top_jump = resolved.iter().any(|(_, target)| target.is_top());
 
         let mut newly_resolved = 0u32;
         for &(jump_inst, ref target) in resolved {
-            // Skip if already resolved by block_analysis_local.
-            if self.insts[jump_inst].flags.contains(InstFlags::STATIC_JUMP) {
+            let was_static = self.insts[jump_inst].flags.contains(InstFlags::STATIC_JUMP);
+            if was_static && target.condition == JumpCondition::Unknown {
                 continue;
             }
 
-            match *target {
-                JumpTarget::Resolved(ref targets, condition) => {
-                    if condition != JumpCondition::Unknown {
-                        self.insts[jump_inst].flags |= InstFlags::CONST_JUMP_CONDITION;
-                    }
-                    if condition != JumpCondition::AlwaysFalse {
+            if target.condition != JumpCondition::Unknown {
+                self.insts[jump_inst].flags |= InstFlags::CONST_JUMP_CONDITION;
+            }
+
+            match &target.target {
+                JumpTargetKind::Resolved(targets) => {
+                    self.insts[jump_inst]
+                        .flags
+                        .remove(InstFlags::INVALID_JUMP | InstFlags::MULTI_JUMP);
+                    if target.condition != JumpCondition::AlwaysFalse {
                         for &target_inst in targets {
                             debug_assert_eq!(
                                 self.insts[target_inst].opcode,
@@ -467,6 +502,7 @@ impl Bytecode<'_> {
                         }
                     }
                     if targets.len() == 1 {
+                        self.multi_jump_targets.remove(&jump_inst);
                         self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
                         self.insts[jump_inst].set_static_jump_target(targets[0]);
                         trace!(%jump_inst, target_inst = %targets[0], "resolved jump");
@@ -476,32 +512,74 @@ impl Bytecode<'_> {
                         self.multi_jump_targets.insert(jump_inst, targets.clone());
                         trace!(%jump_inst, n_targets = targets.len(), "resolved multi-target jump");
                     }
-                    newly_resolved += 1;
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                 }
-                JumpTarget::Invalid => {
+                JumpTargetKind::Invalid => {
+                    self.multi_jump_targets.remove(&jump_inst);
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
-                    newly_resolved += 1;
+                    self.insts[jump_inst].flags.remove(InstFlags::MULTI_JUMP);
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                     trace!(%jump_inst, "resolved invalid jump");
                 }
-                JumpTarget::Bottom if !has_top_jump => {
+                JumpTargetKind::Bottom if !has_top_jump => {
                     // Truly unreachable: no unresolved jumps remain, so this
                     // code cannot be reached at runtime. Mark as invalid.
+                    self.multi_jump_targets.remove(&jump_inst);
                     self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP;
-                    newly_resolved += 1;
+                    self.insts[jump_inst].flags.remove(InstFlags::MULTI_JUMP);
+                    if !was_static {
+                        newly_resolved += 1;
+                    }
                     trace!(%jump_inst, "unreachable jump");
                 }
-                JumpTarget::Bottom => {
+                JumpTargetKind::Bottom => {
                     // Unreachable according to the analysis, but there are
                     // unresolved (Top) jumps that might reach this code at
                     // runtime. Leave as-is.
                     trace!(%jump_inst, "unreachable jump (not marking, has_top_jump)");
                 }
-                JumpTarget::Top => {
+                JumpTargetKind::Top => {
                     trace!(%jump_inst, "unresolved jump (Top)");
                 }
             }
         }
+        self.recompute_reachable_jumpdests();
         newly_resolved
+    }
+
+    fn recompute_reachable_jumpdests(&mut self) {
+        for data in &mut self.insts.raw {
+            if data.opcode == op::JUMPDEST {
+                data.clear_jumpdest_reachable();
+            }
+        }
+
+        let mut targets = Vec::new();
+        for (inst, data) in self.insts.iter_enumerated() {
+            if !data.is_static_jump()
+                || data.flags.contains(InstFlags::INVALID_JUMP)
+                || data.is_dead_code()
+            {
+                continue;
+            }
+            if data.flags.contains(InstFlags::MULTI_JUMP) {
+                if let Some(multi_targets) = self.multi_jump_targets.get(&inst) {
+                    targets.extend(multi_targets.iter().copied());
+                }
+            } else {
+                targets.push(data.static_jump_target());
+            }
+        }
+
+        for target in targets {
+            if self.insts[target].opcode == op::JUMPDEST {
+                self.insts[target].set_jumpdest_reachable();
+            }
+        }
     }
 
     /// Rebuild the basic-block CFG from the current instruction state.
@@ -639,10 +717,14 @@ impl Bytecode<'_> {
             index_vec![BlockState::Bottom; num_blocks];
         block_states[Block::from_usize(0)] = BlockState::Known(Vec::new());
 
-        // Collect unresolved jumps.
+        // Collect unresolved jumps, plus static JUMPI instructions whose condition
+        // may become constant only after CFG fixpoint.
         let mut jump_insts: Vec<Inst> = Vec::new();
         for (i, inst) in self.insts.iter_enumerated() {
-            if inst.is_jump() && !inst.flags.contains(InstFlags::STATIC_JUMP) {
+            if inst.is_jump()
+                && (!inst.flags.contains(InstFlags::STATIC_JUMP)
+                    || (inst.opcode == op::JUMPI && !inst.has_const_jumpi_condition()))
+            {
                 jump_insts.push(i);
             }
         }
@@ -661,7 +743,7 @@ impl Bytecode<'_> {
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
             let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
-            if matches!(target, JumpTarget::Top) {
+            if target.is_top() {
                 has_top_jump = true;
             }
             jump_targets.push((jump_inst, target));
@@ -695,10 +777,7 @@ impl Bytecode<'_> {
         };
 
         if condition == JumpCondition::AlwaysFalse {
-            return JumpTarget::Resolved(
-                SmallVec::from_elem(jump_inst + 1, 1),
-                JumpCondition::AlwaysFalse,
-            );
+            return JumpTarget::single(jump_inst + 1).with_condition(JumpCondition::AlwaysFalse);
         }
 
         match snap.last() {
@@ -707,7 +786,7 @@ impl Bytecode<'_> {
             }
             None => {
                 trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                JumpTarget::Bottom
+                JumpTarget::bottom()
             }
         }
     }
@@ -721,7 +800,7 @@ impl Bytecode<'_> {
                     Ok(target_pc) if self.is_valid_jump(target_pc) => {
                         JumpTarget::single(self.pc_to_inst(target_pc))
                     }
-                    _ => JumpTarget::Invalid,
+                    _ => JumpTarget::invalid(),
                 }
             }
             AbsValue::ConstSet(set_idx) => {
@@ -737,17 +816,17 @@ impl Bytecode<'_> {
                         _ => {
                             // Mixed valid + invalid: can't resolve since at runtime
                             // the value might be any member of the set.
-                            return JumpTarget::Top;
+                            return JumpTarget::top();
                         }
                     }
                 }
                 if !targets.is_empty() {
-                    JumpTarget::Resolved(targets, JumpCondition::Unknown)
+                    JumpTarget::resolved(targets)
                 } else {
-                    JumpTarget::Invalid
+                    JumpTarget::invalid()
                 }
             }
-            AbsValue::Top => JumpTarget::Top,
+            AbsValue::Top => JumpTarget::top(),
         }
     }
 
@@ -868,7 +947,8 @@ impl Bytecode<'_> {
         }
 
         for (inst, target) in jump_targets.iter_mut() {
-            if matches!(target, JumpTarget::Resolved(_, JumpCondition::AlwaysFalse))
+            if matches!(target.target, JumpTargetKind::Resolved(_))
+                && target.condition == JumpCondition::AlwaysFalse
                 && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
             {
                 continue;
@@ -879,7 +959,7 @@ impl Bytecode<'_> {
             if let Some(bid) = self.cfg.inst_to_block[*inst]
                 && suspect[bid.index()]
             {
-                *target = JumpTarget::Top;
+                *target = JumpTarget::top();
             }
         }
 
@@ -1839,6 +1919,133 @@ mod tests_edge_cases {
     }
 
     #[test]
+    fn jumpi_with_zero_condition_cfg_only_falls_through() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            PUSH %target
+            JUMPI
+            PUSH1 0xAA
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        let jump_block = bytecode.cfg.inst_to_block[jump_inst].unwrap();
+        let fallthrough_block = bytecode.cfg.inst_to_block[jump_inst + 1].unwrap();
+        let target_inst = bytecode
+            .iter_all_insts()
+            .rev()
+            .find(|(_, data)| data.opcode == op::JUMPDEST)
+            .unwrap()
+            .0;
+
+        assert!(jump.has_const_jumpi_condition());
+        assert_eq!(jump.static_jump_target(), jump_inst + 1);
+        assert_eq!(bytecode.cfg.blocks[jump_block].succs.as_slice(), &[fallthrough_block]);
+        assert!(
+            bytecode.cfg.inst_to_block[target_inst].is_none(),
+            "never-taken JUMPI target should be dead"
+        );
+    }
+
+    #[test]
+    fn jumpi_with_zero_condition_from_predecessor_rewrites_local_static_cfg() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            PUSH %branch
+            JUMP
+        branch:
+            JUMPDEST
+            PUSH %target
+            JUMPI
+            PUSH1 0xAA
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        let jump_block = bytecode.cfg.inst_to_block[jump_inst].unwrap();
+        let fallthrough_block = bytecode.cfg.inst_to_block[jump_inst + 1].unwrap();
+        let target_inst = bytecode
+            .iter_all_insts()
+            .rev()
+            .find(|(_, data)| data.opcode == op::JUMPDEST)
+            .unwrap()
+            .0;
+
+        assert!(jump.has_const_jumpi_condition());
+        assert_eq!(jump.static_jump_target(), jump_inst + 1);
+        assert_eq!(bytecode.cfg.blocks[jump_block].succs.as_slice(), &[fallthrough_block]);
+        assert!(
+            bytecode.cfg.inst_to_block[target_inst].is_none(),
+            "locally resolved but never-taken JUMPI target should be dead"
+        );
+    }
+
+    #[test]
+    fn jumpi_with_true_condition_cfg_only_jumps_to_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x01
+            PUSH %target
+            JUMPI
+            PUSH1 0xAA
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        let jump_block = bytecode.cfg.inst_to_block[jump_inst].unwrap();
+        let target_block = bytecode.cfg.inst_to_block[jump.static_jump_target()].unwrap();
+
+        assert!(jump.has_const_jumpi_condition());
+        assert_ne!(jump.static_jump_target(), jump_inst + 1);
+        assert_eq!(bytecode.cfg.blocks[jump_block].succs.as_slice(), &[target_block]);
+        assert!(
+            bytecode.cfg.inst_to_block[jump_inst + 1].is_none(),
+            "always-taken JUMPI fallthrough should be dead"
+        );
+    }
+
+    #[test]
+    fn jumpi_with_true_condition_invalid_target_has_no_fallthrough() {
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x01
+            PUSH1 0xFF
+            JUMPI
+            STOP
+        ",
+        );
+
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        let jump_block = bytecode.cfg.inst_to_block[jump_inst].unwrap();
+
+        assert!(jump.has_const_jumpi_condition());
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP | InstFlags::INVALID_JUMP));
+        assert!(bytecode.cfg.blocks[jump_block].succs.is_empty());
+        assert!(
+            bytecode.cfg.inst_to_block[jump_inst + 1].is_none(),
+            "always-taken invalid JUMPI fallthrough should be dead"
+        );
+    }
+
+    #[test]
     fn jumpi_with_true_condition_keeps_unknown_target_dynamic() {
         let bytecode = analyze_asm(
             "
@@ -1854,6 +2061,8 @@ mod tests_edge_cases {
 
         let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
         assert!(!jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(jump.has_const_jumpi_condition());
+        assert!(!jump.can_fall_through());
         assert!(bytecode.has_dynamic_jumps);
     }
 

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -770,11 +770,7 @@ impl Bytecode<'_> {
         (jump_targets, count)
     }
 
-    fn resolve_jump(
-        &self,
-        jump_inst: Inst,
-        const_sets: &ConstSetInterner,
-    ) -> JumpResolution {
+    fn resolve_jump(&self, jump_inst: Inst, const_sets: &ConstSetInterner) -> JumpResolution {
         let snap = &self.snapshots.inputs[jump_inst];
         let condition = if self.insts[jump_inst].opcode == op::JUMPI {
             snap.first()

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -293,25 +293,44 @@ enum JumpTarget {
     /// Not yet observed.
     Bottom,
     /// One or more known constant target instruction indices.
-    Resolved(SmallVec<[Inst; 4]>),
+    Resolved(SmallVec<[Inst; 4]>, JumpCondition),
     /// Known constant but invalid target.
     Invalid,
     /// Unknown target.
     Top,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum JumpCondition {
+    #[default]
+    Unknown,
+    AlwaysTrue,
+    AlwaysFalse,
+}
+
 impl JumpTarget {
     /// Creates a resolved target with a single constant.
     fn single(inst: Inst) -> Self {
-        Self::Resolved(SmallVec::from_elem(inst, 1))
+        Self::Resolved(SmallVec::from_elem(inst, 1), JumpCondition::Unknown)
     }
 
     /// Returns the single resolved target, if exactly one.
     fn as_single(&self) -> Option<Inst> {
         match self {
-            Self::Resolved(targets) if targets.len() == 1 => Some(targets[0]),
+            Self::Resolved(targets, _) if targets.len() == 1 => Some(targets[0]),
             _ => None,
         }
+    }
+
+    fn with_condition(self, condition: JumpCondition) -> Self {
+        match self {
+            Self::Resolved(targets, _) => Self::Resolved(targets, condition),
+            target => target,
+        }
+    }
+
+    fn is_resolved(&self) -> bool {
+        matches!(self, Self::Resolved(_, _) | Self::Invalid)
     }
 }
 
@@ -367,9 +386,7 @@ impl Bytecode<'_> {
                 continue;
             }
 
-            let Some(&operand) = self.snapshots.inputs[term_inst].last() else { continue };
-            debug_assert!(!matches!(operand, AbsValue::ConstSet(_)));
-            let target = self.resolve_jump_operand(operand, &empty_sets);
+            let target = self.resolve_jump_snapshot(term_inst, &empty_sets);
             let Some(target_inst) = target.as_single() else { continue };
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
@@ -435,14 +452,19 @@ impl Bytecode<'_> {
             }
 
             match *target {
-                JumpTarget::Resolved(ref targets) => {
-                    for &target_inst in targets {
-                        debug_assert_eq!(
-                            self.insts[target_inst].opcode,
-                            op::JUMPDEST,
-                            "block_analysis resolved to non-JUMPDEST"
-                        );
-                        self.insts[target_inst].set_jumpdest_reachable();
+                JumpTarget::Resolved(ref targets, condition) => {
+                    if condition != JumpCondition::Unknown {
+                        self.insts[jump_inst].flags |= InstFlags::CONST_JUMP_CONDITION;
+                    }
+                    if condition != JumpCondition::AlwaysFalse {
+                        for &target_inst in targets {
+                            debug_assert_eq!(
+                                self.insts[target_inst].opcode,
+                                op::JUMPDEST,
+                                "block_analysis resolved to non-JUMPDEST"
+                            );
+                            self.insts[target_inst].set_jumpdest_reachable();
+                        }
                     }
                     if targets.len() == 1 {
                         self.insts[jump_inst].flags |= InstFlags::STATIC_JUMP;
@@ -592,6 +614,7 @@ impl Bytecode<'_> {
             } else if term.is_static_jump()
                 && !term.flags.contains(InstFlags::INVALID_JUMP)
                 && let Some(target_block) = resolve(term.static_jump_target())
+                && !cfg.blocks[bid].succs.contains(&target_block)
             {
                 cfg.blocks[target_block].preds.push(bid);
                 cfg.blocks[bid].succs.push(target_block);
@@ -637,14 +660,7 @@ impl Bytecode<'_> {
         let mut jump_targets: Vec<(Inst, JumpTarget)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
-            let target = match self.snapshots.inputs[jump_inst].last() {
-                Some(&operand) => self.resolve_jump_operand(operand, &const_sets),
-                None => {
-                    // No snapshot means the block was never interpreted (unreachable).
-                    trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
-                    JumpTarget::Bottom
-                }
-            };
+            let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
             if matches!(target, JumpTarget::Top) {
                 has_top_jump = true;
             }
@@ -663,12 +679,37 @@ impl Bytecode<'_> {
             );
         }
 
-        let count = jump_targets
-            .iter()
-            .filter(|(_, t)| matches!(t, JumpTarget::Resolved(_) | JumpTarget::Invalid))
-            .count();
+        let count = jump_targets.iter().filter(|(_, target)| target.is_resolved()).count();
 
         (jump_targets, count)
+    }
+
+    fn resolve_jump_snapshot(&self, jump_inst: Inst, const_sets: &ConstSetInterner) -> JumpTarget {
+        let snap = &self.snapshots.inputs[jump_inst];
+        let condition = if self.insts[jump_inst].opcode == op::JUMPI {
+            snap.first()
+                .map(|&value| self.resolve_jump_condition(value, const_sets))
+                .unwrap_or_default()
+        } else {
+            JumpCondition::Unknown
+        };
+
+        if condition == JumpCondition::AlwaysFalse {
+            return JumpTarget::Resolved(
+                SmallVec::from_elem(jump_inst + 1, 1),
+                JumpCondition::AlwaysFalse,
+            );
+        }
+
+        match snap.last() {
+            Some(&operand) => {
+                self.resolve_jump_operand(operand, const_sets).with_condition(condition)
+            }
+            None => {
+                trace!(%jump_inst, pc = self.pc(jump_inst), "jump in unreached block");
+                JumpTarget::Bottom
+            }
+        }
     }
 
     /// Resolves a jump target from the snapshot operand recorded during the fixpoint.
@@ -701,13 +742,52 @@ impl Bytecode<'_> {
                     }
                 }
                 if !targets.is_empty() {
-                    JumpTarget::Resolved(targets)
+                    JumpTarget::Resolved(targets, JumpCondition::Unknown)
                 } else {
                     JumpTarget::Invalid
                 }
             }
             AbsValue::Top => JumpTarget::Top,
         }
+    }
+
+    fn resolve_jump_condition(
+        &self,
+        condition: AbsValue,
+        const_sets: &ConstSetInterner,
+    ) -> JumpCondition {
+        let consts = match condition {
+            AbsValue::Const(imm) => Either::Left(std::iter::once(imm)),
+            AbsValue::ConstSet(set_idx) => Either::Right(const_sets.get(set_idx).iter().copied()),
+            AbsValue::Top => return JumpCondition::Unknown,
+        };
+        let interner = self.u256_interner.borrow();
+        let mut saw_zero = false;
+        let mut saw_nonzero = false;
+        for imm in consts {
+            if imm.get(&interner).is_zero() {
+                saw_zero = true;
+            } else {
+                saw_nonzero = true;
+            }
+        }
+        match (saw_zero, saw_nonzero) {
+            (true, false) => JumpCondition::AlwaysFalse,
+            (false, true) => JumpCondition::AlwaysTrue,
+            _ => JumpCondition::Unknown,
+        }
+    }
+
+    fn is_const_zero(&self, value: AbsValue) -> bool {
+        value.as_const().is_some_and(|imm| imm.get(&self.u256_interner.borrow()).is_zero())
+    }
+
+    fn local_jumpi_condition_is_zero(&self, jump_inst: Inst, local_snapshots: &Snapshots) -> bool {
+        self.insts[jump_inst].opcode == op::JUMPI
+            && local_snapshots.inputs[jump_inst]
+                .first()
+                .copied()
+                .is_some_and(|value| self.is_const_zero(value))
     }
 
     /// Adds discovered dynamic-jump target edges for a block.
@@ -788,7 +868,12 @@ impl Bytecode<'_> {
         }
 
         for (inst, target) in jump_targets.iter_mut() {
-            if !matches!(target, JumpTarget::Resolved(_) | JumpTarget::Invalid) {
+            if matches!(target, JumpTarget::Resolved(_, JumpCondition::AlwaysFalse))
+                && self.local_jumpi_condition_is_zero(*inst, local_snapshots)
+            {
+                continue;
+            }
+            if !target.is_resolved() {
                 continue;
             }
             if let Some(bid) = self.cfg.inst_to_block[*inst]
@@ -1637,6 +1722,11 @@ mod tests_edge_cases {
         ",
         );
         // The JUMPI should be resolved as static.
+        let (jump_inst, jump) =
+            bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert_eq!(bytecode.inst(jump.static_jump_target()).opcode, op::JUMPDEST);
+        assert_ne!(jump.static_jump_target(), jump_inst + 1);
         assert!(!bytecode.has_dynamic_jumps);
     }
 
@@ -1706,6 +1796,67 @@ mod tests_edge_cases {
         assert!(jump_inst.is_some(), "expected an invalid jump");
     }
 
+    #[test]
+    fn jumpi_with_zero_condition_ignores_unknown_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_zero_condition_ignores_valid_target() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            PUSH %target
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!jump.flags.contains(InstFlags::INVALID_JUMP));
+        assert_eq!(jump.static_jump_target(), Inst::from_usize(3));
+        assert!(!bytecode.has_dynamic_jumps);
+    }
+
+    #[test]
+    fn jumpi_with_true_condition_keeps_unknown_target_dynamic() {
+        let bytecode = analyze_asm(
+            "
+            PUSH1 0x01
+            CALLDATASIZE
+            JUMPI
+            STOP
+        target:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (_, jump) = bytecode.iter_insts().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(!jump.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(bytecode.has_dynamic_jumps);
+    }
+
     /// Constant propagation through a diamond CFG (if-then-else merge).
     /// Both branches push the same constant, so the merge should preserve it.
     #[test]
@@ -1713,7 +1864,7 @@ mod tests_edge_cases {
         let bytecode = analyze_asm(
             "
             PUSH1 0x42              ; push same const on both paths
-            PUSH0                   ; condition (always false)
+            CALLDATASIZE            ; condition
             PUSH %then_pc           ; then target
             JUMPI                   ; branch
             ; Else: push same const.
@@ -1744,7 +1895,7 @@ mod tests_edge_cases {
     fn diamond_cfg_different_const() {
         let bytecode = analyze_asm(
             "
-            PUSH0                   ; condition
+            CALLDATASIZE            ; condition
             PUSH %then_pc
             JUMPI                   ; branch
             ; Else: push 0xAA.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -384,6 +384,7 @@ impl Bytecode<'_> {
     ///
     /// Also initializes `self.snapshots`.
     #[instrument(name = "local_jumps", level = "debug", skip_all)]
+    #[inline(never)]
     pub(crate) fn block_analysis_local(&mut self) {
         self.init_snapshots();
 
@@ -415,7 +416,7 @@ impl Bytecode<'_> {
                 continue;
             }
 
-            let target = self.resolve_jump_snapshot(term_inst, &empty_sets);
+            let target = self.resolve_jump(term_inst, &empty_sets);
             let Some(target_inst) = target.as_single() else { continue };
 
             // Log non-adjacent resolutions (not simple PUSH+JUMP).
@@ -444,6 +445,7 @@ impl Bytecode<'_> {
     ///
     /// Also computes and stores per-instruction stack snapshots for constant propagation.
     #[instrument(name = "ba", level = "debug", skip_all)]
+    #[inline(never)]
     pub(crate) fn block_analysis(&mut self, local_snapshots: &Snapshots) {
         self.init_snapshots();
         let (resolved, count) = self.run_abstract_interp(local_snapshots);
@@ -459,6 +461,7 @@ impl Bytecode<'_> {
     }
 
     /// Recomputes the `has_dynamic_jumps` flag based on the current instruction set.
+    #[inline(never)]
     pub(crate) fn recompute_has_dynamic_jumps(&mut self) {
         let mut unresolved = self.insts.iter().filter(|inst| {
             inst.is_jump() && !inst.flags.contains(InstFlags::STATIC_JUMP) && !inst.is_dead_code()
@@ -584,6 +587,7 @@ impl Bytecode<'_> {
 
     /// Rebuild the basic-block CFG from the current instruction state.
     #[instrument(level = "debug", skip_all)]
+    #[inline(never)]
     pub(crate) fn rebuild_cfg(&mut self) {
         let finish_block = |cfg: &mut Cfg, start: usize, end: usize| {
             debug_assert!(start < end, "empty block range: {start}..{end}");
@@ -742,7 +746,7 @@ impl Bytecode<'_> {
         let mut jump_targets: Vec<(Inst, JumpResolution)> = Vec::new();
         let mut has_top_jump = false;
         for &jump_inst in &jump_insts {
-            let target = self.resolve_jump_snapshot(jump_inst, &const_sets);
+            let target = self.resolve_jump(jump_inst, &const_sets);
             if target.is_top() {
                 has_top_jump = true;
             }
@@ -766,7 +770,7 @@ impl Bytecode<'_> {
         (jump_targets, count)
     }
 
-    fn resolve_jump_snapshot(
+    fn resolve_jump(
         &self,
         jump_inst: Inst,
         const_sets: &ConstSetInterner,

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -2337,6 +2337,48 @@ mod tests_edge_cases {
         assert_eq!(jumpi.static_jump_target(), jump_inst + 1);
     }
 
+    /// A block-local true JUMPI condition is also sound in a suspect block, but
+    /// an unknown target must stay dynamic and must not retain a fallthrough.
+    #[test]
+    fn suspect_jumpi_top_target_keeps_local_true_condition() {
+        let bytecode = analyze_asm(
+            "
+            PUSH0
+            CALLDATALOAD
+            PUSH %opaque
+            JUMPI
+            PUSH %fn_entry
+            JUMP
+        opaque:
+            JUMPDEST
+            PUSH0
+            MLOAD
+            JUMP
+        fn_entry:
+            JUMPDEST
+            PUSH1 0x01
+            PUSH0
+            MLOAD
+            JUMPI
+            STOP
+        taken:
+            JUMPDEST
+            STOP
+        ",
+        );
+
+        let (jump_inst, jumpi) =
+            bytecode.iter_insts().rev().find(|(_, data)| data.opcode == op::JUMPI).unwrap();
+        assert!(jumpi.has_const_jumpi_condition());
+        assert!(!jumpi.flags.contains(InstFlags::STATIC_JUMP));
+        assert!(!jumpi.can_fall_through());
+        assert!(bytecode.has_dynamic_jumps);
+        assert!(
+            bytecode.cfg.inst_to_block[jump_inst + 1].is_none(),
+            "always-taken dynamic JUMPI fallthrough should be dead"
+        );
+    }
+
     /// A third caller reaches the function entry with a known callee (static
     /// PUSH+JUMP) but an opaque return address (from MLOAD). The function's
     /// return jump must not be resolved because the return address is Top.

--- a/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/block_analysis.rs
@@ -460,18 +460,6 @@ impl Bytecode<'_> {
         self.recompute_has_dynamic_jumps();
     }
 
-    /// Recomputes the `has_dynamic_jumps` flag based on the current instruction set.
-    #[inline(never)]
-    pub(crate) fn recompute_has_dynamic_jumps(&mut self) {
-        let mut unresolved = self.insts.iter().filter(|inst| {
-            inst.is_jump() && !inst.flags.contains(InstFlags::STATIC_JUMP) && !inst.is_dead_code()
-        });
-        self.has_dynamic_jumps = unresolved.next().is_some();
-        if self.has_dynamic_jumps {
-            debug!(n = 1 + unresolved.count(), "unresolved dynamic jumps remain");
-        }
-    }
-
     /// Commits resolved jump targets by setting flags and data on the corresponding instructions.
     ///
     /// Returns the number of newly resolved jumps.
@@ -554,41 +542,39 @@ impl Bytecode<'_> {
         newly_resolved
     }
 
-    fn recompute_reachable_jumpdests(&mut self) {
-        for data in &mut self.insts.raw {
-            if data.opcode == op::JUMPDEST {
-                data.clear_jumpdest_reachable();
-            }
-        }
+    /// Refresh reachability and CFG-derived state after control-flow changes.
+    #[instrument(level = "debug", name = "re_cfg", skip_all)]
+    #[inline(never)]
+    pub(crate) fn refresh_cfg(&mut self) {
+        self.recompute_has_dynamic_jumps();
+        self.recompute_reachable_jumpdests(); // Depends on has_dynamic_jumps
+        self.mark_dead_code(); // Depends on reachable jumpdests
+        self.compress_redirects();
+        self.rebuild_cfg();
+    }
 
-        let mut targets = Vec::new();
-        for (inst, data) in self.insts.iter_enumerated() {
-            if !data.is_static_jump()
-                || data.flags.contains(InstFlags::INVALID_JUMP)
-                || data.is_dead_code()
-            {
-                continue;
+    #[instrument(level = "debug", name = "redirects", skip_all)]
+    fn compress_redirects(&mut self) {
+        // Compress redirect chains so that earlier redirects (e.g. t2 -> t1) are
+        // updated when their target gets deduped in a later round (t1 -> t0).
+        // Without this, rebuild_cfg resolves edges only one hop, leaving stale
+        // intermediate targets in DedupKey.succs (preventing valid merges) and
+        // in translate.rs inst_entries (causing InvalidJump on valid bytecode).
+        for inst in self.redirects.keys().copied().collect::<Vec<_>>() {
+            let mut target = self.redirects[&inst];
+            let original = target;
+            while let Some(&next) = self.redirects.get(&target) {
+                target = next;
             }
-            if data.flags.contains(InstFlags::MULTI_JUMP) {
-                if let Some(multi_targets) = self.multi_jump_targets.get(&inst) {
-                    targets.extend(multi_targets.iter().copied());
-                }
-            } else {
-                targets.push(data.static_jump_target());
-            }
-        }
-
-        for target in targets {
-            if self.insts[target].opcode == op::JUMPDEST {
-                self.insts[target].set_jumpdest_reachable();
+            if target != original {
+                self.redirects.insert(inst, target);
             }
         }
     }
 
     /// Rebuild the basic-block CFG from the current instruction state.
-    #[instrument(level = "debug", skip_all)]
-    #[inline(never)]
-    pub(crate) fn rebuild_cfg(&mut self) {
+    #[instrument(level = "debug", name = "cfg", skip_all)]
+    fn rebuild_cfg(&mut self) {
         let finish_block = |cfg: &mut Cfg, start: usize, end: usize| {
             debug_assert!(start < end, "empty block range: {start}..{end}");
             let bid = cfg.blocks.push(BlockData {

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -111,8 +111,8 @@ impl<'a> Bytecode<'a> {
                 continue;
             }
 
-            // Skip unresolved dynamic JUMPs — any target is possible at runtime.
-            if term.opcode == op::JUMP && !term.flags.contains(InstFlags::STATIC_JUMP) {
+            // Skip unresolved dynamic jumps — any target is possible at runtime.
+            if term.is_jump() && !term.flags.contains(InstFlags::STATIC_JUMP) {
                 continue;
             }
 
@@ -233,6 +233,7 @@ mod tests {
     use crate::bytecode::{
         AnalysisConfig, InstFlags, passes::block_analysis::tests::analyze_asm_with,
     };
+    use revm_bytecode::opcode as op;
 
     #[test]
     fn dedup_identical_revert_blocks() {
@@ -522,6 +523,117 @@ mod tests {
         assert!(
             bytecode.redirects.is_empty(),
             "should not dedup blocks ending in unresolved dynamic JUMP",
+        );
+    }
+
+    #[test]
+    fn dedup_skips_const_true_dynamic_jumpi_tail() {
+        // Two non-JUMPDEST byte-identical tails ending in const-true `JUMPI` with
+        // unresolved dynamic targets must NOT be deduped. The constant condition
+        // makes the terminator non-fallthrough, but the target is still arbitrary.
+        let bytecode = analyze_asm_with(
+            "
+            CALLDATASIZE
+            PUSH %path_b
+            JUMPI
+
+            ; tail A
+            PUSH1 0x01
+            PUSH0
+            CALLDATALOAD
+            JUMPI
+            STOP
+
+        path_b:
+            JUMPDEST
+            PUSH0
+            PUSH %after_b
+            JUMPI
+
+            ; tail B
+            PUSH1 0x01
+            PUSH0
+            CALLDATALOAD
+            JUMPI
+            STOP
+
+        after_b:
+            JUMPDEST
+            INVALID
+        ",
+            AnalysisConfig::DEDUP,
+        );
+
+        let dynamic_jumpis = bytecode
+            .iter_insts()
+            .filter(|(_, data)| {
+                data.opcode == op::JUMPI
+                    && data.has_const_jumpi_condition()
+                    && !data.flags.contains(InstFlags::STATIC_JUMP)
+            })
+            .count();
+        assert_eq!(dynamic_jumpis, 2, "expected two const-true dynamic JUMPI tails");
+        assert!(
+            bytecode.redirects.is_empty(),
+            "should not dedup blocks ending in unresolved dynamic JUMPI",
+        );
+    }
+
+    #[test]
+    fn dedup_allows_const_true_static_jumpi_tail() {
+        // The dynamic-target guard should not block const-true JUMPI tails whose
+        // target is known and whose CFG successors match.
+        let bytecode = analyze_asm_with(
+            "
+            CALLDATASIZE
+            PUSH %path_b
+            JUMPI
+
+            ; tail A
+            PUSH1 0x01
+            PUSH %target
+            JUMPI
+            STOP
+
+        path_b:
+            JUMPDEST
+            PUSH0
+            PUSH %after_b
+            JUMPI
+
+            ; tail B
+            PUSH1 0x01
+            PUSH %target
+            JUMPI
+            STOP
+
+        after_b:
+            JUMPDEST
+            INVALID
+
+        target:
+            JUMPDEST
+            STOP
+        ",
+            AnalysisConfig::DEDUP,
+        );
+
+        let static_jumpis = bytecode
+            .iter_insts()
+            .filter(|(_, data)| {
+                data.opcode == op::JUMPI
+                    && data.has_const_jumpi_condition()
+                    && data.flags.contains(InstFlags::STATIC_JUMP)
+            })
+            .count();
+        assert!(
+            static_jumpis >= 2,
+            "expected at least two const-condition static JUMPI instructions",
+        );
+        assert_eq!(
+            bytecode.redirects.len(),
+            1,
+            "same-target const-true static JUMPI tails should be deduped",
         );
     }
 

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -61,22 +61,7 @@ impl<'a> Bytecode<'a> {
             if deduped == 0 {
                 break;
             }
-            // Compress redirect chains so that earlier redirects (e.g. t2 -> t1) are
-            // updated when their target gets deduped in a later round (t1 -> t0).
-            // Without this, rebuild_cfg resolves edges only one hop, leaving stale
-            // intermediate targets in DedupKey.succs (preventing valid merges) and
-            // in translate.rs inst_entries (causing InvalidJump on valid bytecode).
-            for inst in self.redirects.keys().copied().collect::<Vec<_>>() {
-                let mut target = self.redirects[&inst];
-                let original = target;
-                while let Some(&next) = self.redirects.get(&target) {
-                    target = next;
-                }
-                if target != original {
-                    self.redirects.insert(inst, target);
-                }
-            }
-            self.rebuild_cfg();
+            self.refresh_cfg();
         }
         debug!(deduped = total_deduped, "finished");
     }

--- a/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
@@ -432,7 +432,7 @@ mod tests {
             PUSH0
             PUSH 64
             MSTORE
-            PUSH 1
+            CALLDATASIZE
             PUSH %large
             JUMPI
             PUSH %join

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -965,11 +965,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         if opcode == op::JUMPI {
                             let cond_word = self.pop();
                             self.materialize_live_stack();
-                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                            let next = self.inst_entries[inst + 1];
-                            let switch_block = self.bcx.create_block("multi_jump");
-                            self.bcx.brif(cond, switch_block, next);
-                            self.bcx.switch_to_block(switch_block);
+                            if !data.has_const_jump_condition() {
+                                let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                                let next = self.inst_entries[inst + 1];
+                                let switch_block = self.bcx.create_block("multi_jump");
+                                self.bcx.brif(cond, switch_block, next);
+                                self.bcx.switch_to_block(switch_block);
+                            }
                         } else {
                             self.materialize_live_stack();
                         }
@@ -990,9 +992,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         // Pop and discard the target; it's always on the stack.
                         self.pop_ignore(1);
                         let target_inst = data.static_jump_target();
-                        debug_assert_eq!(
-                            *self.bytecode.inst(target_inst),
-                            op::JUMPDEST,
+                        debug_assert!(
+                            *self.bytecode.inst(target_inst) == op::JUMPDEST
+                                || (opcode == op::JUMPI && target_inst == inst + 1),
                             "jumping to non-JUMPDEST; target_inst={target_inst}",
                         );
                         self.inst_entries[target_inst]
@@ -1010,9 +1012,13 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let cond_word = self.pop();
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
-                        let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                        let next = self.inst_entries[inst + 1];
-                        self.bcx.brif(cond, target, next);
+                        if data.has_const_jump_condition() {
+                            self.bcx.br(target);
+                        } else {
+                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                            let next = self.inst_entries[inst + 1];
+                            self.bcx.brif(cond, target, next);
+                        }
                     } else {
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -948,6 +948,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }
             op::JUMP | op::JUMPI => {
                 let is_invalid = data.flags.contains(InstFlags::INVALID_JUMP);
+                let has_const_jumpi_condition = data.has_const_jumpi_condition();
                 if is_invalid && opcode == op::JUMP {
                     // Pop and discard the target; it's always on the stack.
                     self.pop_ignore(1);
@@ -963,9 +964,12 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let targets = self.bytecode.multi_jump_targets(inst).unwrap();
 
                         if opcode == op::JUMPI {
-                            let cond_word = self.pop();
-                            self.materialize_live_stack();
-                            if !data.has_const_jump_condition() {
+                            if has_const_jumpi_condition {
+                                self.pop_ignore(1);
+                                self.materialize_live_stack();
+                            } else {
+                                let cond_word = self.pop();
+                                self.materialize_live_stack();
                                 let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
                                 let next = self.inst_entries[inst + 1];
                                 let switch_block = self.bcx.create_block("multi_jump");
@@ -1008,18 +1012,17 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         self.dynamic_jump_table
                     };
 
-                    if opcode == op::JUMPI {
+                    if opcode == op::JUMPI && !has_const_jumpi_condition {
                         let cond_word = self.pop();
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
-                        if data.has_const_jump_condition() {
-                            self.bcx.br(target);
-                        } else {
-                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                            let next = self.inst_entries[inst + 1];
-                            self.bcx.brif(cond, target, next);
-                        }
+                        let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                        let next = self.inst_entries[inst + 1];
+                        self.bcx.brif(cond, target, next);
                     } else {
+                        if opcode == op::JUMPI {
+                            self.pop_ignore(1);
+                        }
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
                         self.bcx.br(target);

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -963,20 +963,18 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let target_value = self.pop();
                         let targets = self.bytecode.multi_jump_targets(inst).unwrap();
 
-                        if opcode == op::JUMPI {
-                            if has_const_jumpi_condition {
-                                self.pop_ignore(1);
-                                self.materialize_live_stack();
-                            } else {
-                                let cond_word = self.pop();
-                                self.materialize_live_stack();
-                                let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                                let next = self.inst_entries[inst + 1];
-                                let switch_block = self.bcx.create_block("multi_jump");
-                                self.bcx.brif(cond, switch_block, next);
-                                self.bcx.switch_to_block(switch_block);
-                            }
+                        if opcode == op::JUMPI && !has_const_jumpi_condition {
+                            let cond_word = self.pop();
+                            self.materialize_live_stack();
+                            let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
+                            let next = self.inst_entries[inst + 1];
+                            let switch_block = self.bcx.create_block("multi_jump");
+                            self.bcx.brif(cond, switch_block, next);
+                            self.bcx.switch_to_block(switch_block);
                         } else {
+                            if opcode == op::JUMPI {
+                                self.pop_ignore(1);
+                            }
                             self.materialize_live_stack();
                         }
 

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -996,7 +996,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let target_inst = data.static_jump_target();
                         debug_assert!(
                             *self.bytecode.inst(target_inst) == op::JUMPDEST
-                                || (opcode == op::JUMPI && target_inst == inst + 1),
+                                || (opcode == op::JUMPI && has_const_jumpi_condition),
                             "jumping to non-JUMPDEST; target_inst={target_inst}",
                         );
                         self.inst_entries[target_inst]

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -2028,6 +2028,36 @@ tests! {
             ),
         }),
 
+        dedup_false_jumpi_non_jumpdest_fallthrough(@raw {
+            bytecode: &asm("
+                CALLDATASIZE
+                PUSH %path2
+                JUMPI
+
+                PUSH0
+                PUSH %done
+                JUMPI
+                PUSH0
+                PUSH0
+                REVERT
+
+            path2:
+                JUMPDEST
+                PUSH0
+                PUSH %done
+                JUMPI
+                PUSH0
+                PUSH0
+                REVERT
+
+            done:
+                JUMPDEST
+                STOP
+            "),
+            expected_return: InstructionResult::Revert,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+
         // Disabled opcodes must not poison stack sections.
         //
         // When a disabled opcode (e.g. TSTORE before Cancun) follows executable instructions


### PR DESCRIPTION
This resolves `JUMPI` instructions whose condition is known at compile time and updates the CFG so always-false branches fall through while always-true branches behave like normal static jumps.

It keeps this PR scoped to constant conditional jumps: the broader dynamic jump analysis work is split into a separate stacked branch.
