### PR TITLE
test: cover internal helpers

### DIFF
--- a/crates/revmc-backend/src/traits.rs
+++ b/crates/revmc-backend/src/traits.rs
@@ -505,3 +505,61 @@ pub trait Builder: BackendTypes + TypeMethods {
         loc: FunctionAttributeLocation,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendConfig, OptimizationLevel};
+    use std::{path::PathBuf, str::FromStr};
+
+    #[test]
+    fn backend_config_defaults_match_runtime_settings() {
+        let config = BackendConfig::default();
+
+        assert_eq!(config.opt_level, OptimizationLevel::Default);
+        assert!(!config.is_dumping);
+        assert_eq!(config.debug_assertions, cfg!(debug_assertions));
+        assert!(config.debug_support);
+        assert!(!config.profiling_support);
+        assert!(config.simple_perf);
+        assert_eq!(config.debug_file, None);
+    }
+
+    #[test]
+    fn backend_config_is_cloneable_and_comparable() {
+        let config = BackendConfig {
+            opt_level: OptimizationLevel::Aggressive,
+            is_dumping: true,
+            debug_assertions: true,
+            debug_support: false,
+            profiling_support: true,
+            simple_perf: false,
+            debug_file: Some(PathBuf::from("debug.sol")),
+        };
+
+        assert_eq!(config.clone(), config);
+    }
+
+    #[test]
+    fn optimization_level_parses_numeric_and_named_values() {
+        for (input, expected) in [
+            ("0", OptimizationLevel::None),
+            ("none", OptimizationLevel::None),
+            ("1", OptimizationLevel::Less),
+            ("less", OptimizationLevel::Less),
+            ("2", OptimizationLevel::Default),
+            ("default", OptimizationLevel::Default),
+            ("3", OptimizationLevel::Aggressive),
+            ("aggressive", OptimizationLevel::Aggressive),
+        ] {
+            assert_eq!(OptimizationLevel::from_str(input), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn optimization_level_reports_unknown_values() {
+        assert_eq!(
+            OptimizationLevel::from_str("fast").unwrap_err(),
+            "unknown optimization level: fast"
+        );
+    }
+}

--- a/crates/revmc-build/src/lib.rs
+++ b/crates/revmc-build/src/lib.rs
@@ -8,10 +8,36 @@ const MANGLE_PREFIX: &str = "__revmc_builtin_";
 /// Emits the linker flag to export all the necessary symbols.
 pub fn emit() {
     let target_vendor = std::env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+    println!("cargo:rustc-link-arg={}", link_arg(&target_vendor));
+}
+
+fn link_arg(target_vendor: &str) -> String {
     if target_vendor == "apple" {
         // Mach-O C symbols have a leading `_`, so `__revmc_builtin_*` becomes `___revmc_builtin_*`.
-        println!("cargo:rustc-link-arg=-Wl,-exported_symbol,_{MANGLE_PREFIX}*");
+        format!("-Wl,-exported_symbol,_{MANGLE_PREFIX}*")
     } else {
-        println!("cargo:rustc-link-arg=-Wl,--export-dynamic-symbol,{MANGLE_PREFIX}*");
+        format!("-Wl,--export-dynamic-symbol,{MANGLE_PREFIX}*")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{emit, link_arg};
+
+    #[test]
+    fn emits() {
+        // SAFETY: These tests do not spawn threads or read this environment variable concurrently.
+        unsafe { std::env::set_var("CARGO_CFG_TARGET_VENDOR", "unknown") };
+        emit();
+    }
+
+    #[test]
+    fn emits_macho_export_for_apple_targets() {
+        assert_eq!(link_arg("apple"), "-Wl,-exported_symbol,___revmc_builtin_*");
+    }
+
+    #[test]
+    fn emits_elf_export_for_other_targets() {
+        assert_eq!(link_arg("unknown"), "-Wl,--export-dynamic-symbol,__revmc_builtin_*");
     }
 }

--- a/crates/revmc-runtime/src/runtime/storage.rs
+++ b/crates/revmc-runtime/src/runtime/storage.rs
@@ -164,3 +164,102 @@ impl ArtifactStore for RuntimeArtifactStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ArtifactKey, ArtifactManifest, ArtifactStore, BackendSelection, RuntimeArtifactStore,
+        RuntimeCacheKey,
+    };
+    use alloy_primitives::B256;
+    use revm_primitives::hardfork::SpecId;
+    use revmc_backend::OptimizationLevel;
+
+    fn artifact_key(code_hash: B256) -> ArtifactKey {
+        ArtifactKey {
+            runtime: RuntimeCacheKey { code_hash, spec_id: SpecId::OSAKA },
+            backend: BackendSelection::Llvm,
+            opt_level: OptimizationLevel::Default,
+        }
+    }
+
+    fn manifest(key: ArtifactKey, artifact_len: usize) -> ArtifactManifest {
+        ArtifactManifest {
+            artifact_key: key,
+            symbol_name: "main".to_string(),
+            bytecode_len: 3,
+            artifact_len,
+            created_at_unix_secs: 42,
+            content_hash: [7; 32],
+        }
+    }
+
+    #[test]
+    fn runtime_artifact_store_starts_empty() {
+        let store = RuntimeArtifactStore::new().unwrap();
+
+        assert!(store.is_empty());
+        assert_eq!(store.len(), 0);
+        assert!(store.load_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn runtime_artifact_store_round_trips_artifacts() {
+        let store = RuntimeArtifactStore::new().unwrap();
+        let key = artifact_key(B256::with_last_byte(1));
+        let manifest = manifest(key.clone(), 4);
+
+        store.store(&key, &manifest, b"dylib").unwrap();
+
+        assert_eq!(store.len(), 1);
+        let loaded = store.load(&key).unwrap().unwrap();
+        assert_eq!(loaded.manifest.symbol_name, "main");
+        assert_eq!(loaded.manifest.artifact_len, 4);
+        assert_eq!(std::fs::read(&loaded.dylib_path).unwrap(), b"dylib");
+
+        let all = store.load_all().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, key);
+        assert_eq!(all[0].1.manifest.content_hash, [7; 32]);
+    }
+
+    #[test]
+    fn runtime_artifact_store_replaces_artifacts() {
+        let store = RuntimeArtifactStore::new().unwrap();
+        let key = artifact_key(B256::with_last_byte(2));
+
+        store.store(&key, &manifest(key.clone(), 3), b"one").unwrap();
+        store.store(&key, &manifest(key.clone(), 5), b"three").unwrap();
+
+        assert_eq!(store.len(), 1);
+        let loaded = store.load(&key).unwrap().unwrap();
+        assert_eq!(loaded.manifest.artifact_len, 5);
+        assert_eq!(std::fs::read(&loaded.dylib_path).unwrap(), b"three");
+    }
+
+    #[test]
+    fn runtime_artifact_store_delete_and_clear_remove_files() {
+        let store = RuntimeArtifactStore::new().unwrap();
+        let first = artifact_key(B256::with_last_byte(3));
+        let second = artifact_key(B256::with_last_byte(4));
+
+        store.store(&first, &manifest(first.clone(), 1), b"a").unwrap();
+        store.store(&second, &manifest(second.clone(), 1), b"b").unwrap();
+        let first_path = store.load(&first).unwrap().unwrap().dylib_path;
+        let second_path = store.load(&second).unwrap().unwrap().dylib_path;
+
+        store.delete(&first).unwrap();
+        assert!(store.load(&first).unwrap().is_none());
+        assert!(!first_path.exists());
+        assert!(second_path.exists());
+
+        store.clear().unwrap();
+        assert!(store.is_empty());
+        assert!(!second_path.exists());
+    }
+
+    #[test]
+    fn backend_selection_defaults_to_auto() {
+        assert_eq!(BackendSelection::default(), BackendSelection::Auto);
+    }
+}


### PR DESCRIPTION
Adds coverage for a few internal helpers that were effectively cold in the LLVM coverage report: build-script linker argument selection, backend config and optimization-level parsing, and runtime artifact-store lifecycle behavior.

The follow-up coverage run moved the touched files as follows: `revmc-build/src/lib.rs` line coverage 0.00% to 100.00%, `revmc-runtime/src/runtime/storage.rs` 64.71% to 100.00%, and `revmc-backend/src/traits.rs` 37.70% to 64.00%. Overall workspace line coverage moved 79.04% to 79.33%.
