### PR TITLE
chore: align dependencies with reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,11 +57,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -115,14 +115,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -150,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
+checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -168,12 +170,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc4b83cb672156663e6094d098beb509965b7fe684bb3d6e44bb9ca2e9ae714"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-sol-types",
@@ -333,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
+checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,21 +45,21 @@ revmc-context = { version = "0.1.0", path = "crates/revmc-context", default-feat
 revmc-llvm = { version = "0.1.0", path = "crates/revmc-llvm", default-features = false }
 revmc-runtime = { version = "0.1.0", path = "crates/revmc-runtime", default-features = false }
 
-alloy-primitives = { version = "1.5", default-features = false }
+alloy-primitives = { version = "1.5.6", default-features = false }
 ruint = { version = "1.17", default-features = false }
-alloy-evm = { version = "0.33", default-features = false }
+alloy-evm = { version = "0.34.0", default-features = false }
 
-revm-bytecode = { version = "10.0", default-features = false, features = ["parse"] }
-revm-context = { version = "16.0", default-features = false }
-revm-context-interface = { version = "17.0", default-features = false }
-revm-database = { version = "13.0", default-features = false }
-revm-database-interface = { version = "11.0", default-features = false }
-revm-handler = { version = "18.0", default-features = false }
-revm-inspector = { version = "19.0", default-features = false }
-revm-interpreter = { version = "35.0", default-features = false }
-revm-primitives = { version = "23.0", default-features = false }
-revm-state = { version = "11.0", default-features = false }
-revm-statetest-types = { version = "17.0", default-features = false }
+revm-bytecode = { version = "10.0.0", default-features = false, features = ["parse"] }
+revm-context = { version = "16.0.0", default-features = false }
+revm-context-interface = { version = "17.0.0", default-features = false }
+revm-database = { version = "13.0.0", default-features = false }
+revm-database-interface = { version = "11.0.0", default-features = false }
+revm-handler = { version = "18.0.0", default-features = false }
+revm-inspector = { version = "19.0.0", default-features = false }
+revm-interpreter = { version = "35.0.0", default-features = false }
+revm-primitives = { version = "23.0.0", default-features = false }
+revm-state = { version = "11.0.0", default-features = false }
+revm-statetest-types = { version = "17.0.0", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"


### PR DESCRIPTION
Aligns revmc's shared Alloy and revm dependency graph with the versions currently used by Reth.

This bumps the `alloy-evm` workspace dependency to `0.34.0`, refreshes the related Alloy lockfile packages, and makes revm workspace version bounds explicit to match Reth's declarations.

Validation:
- `cargo fmt --all --check`
- `PATH="/opt/homebrew/opt/llvm/bin:$PATH" LLVM_SYS_221_PREFIX=/opt/homebrew/opt/llvm cargo +1.95.0 cl`
- `PATH="/opt/homebrew/opt/llvm/bin:$PATH" LLVM_SYS_221_PREFIX=/opt/homebrew/opt/llvm cargo +1.95.0 nextest run --workspace`
