### PR TITLE
fix: materialize stack for dedup redirects

### DIFF
--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -652,11 +652,6 @@ impl<'a> Bytecode<'a> {
         self.config.contains(AnalysisConfig::INSPECT_STACK) || self.may_suspend()
     }
 
-    /// Returns `true` if any dead-block redirects exist.
-    pub(crate) fn has_redirects(&self) -> bool {
-        !self.redirects.is_empty()
-    }
-
     /// Returns `true` if the instruction is diverging.
     pub(crate) fn is_instr_diverging(&self, inst: Inst) -> bool {
         self.insts[inst].is_diverging()

--- a/crates/revmc-codegen/src/bytecode/passes/dedup.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/dedup.rs
@@ -180,8 +180,8 @@ impl<'a> Bytecode<'a> {
                     // Multi-jump target PCs are not rewritten here: each carries a
                     // distinct PC that callers push as a return address. The targets
                     // were already merged into the canonical block above, and
-                    // `inst_entries` redirects (translate.rs) map the dead
-                    // instruction's IR entry to the canonical one.
+                    // Translator callsites resolve redirects to map dead
+                    // instruction targets to the canonical IR entry.
                 }
             }
         }

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -521,7 +521,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             ($($comment:expr)?) => {
                 // Flush virtual stack before leaving the section.
                 if self.inst_entries.get(inst + 1).is_some() {
-                    let next = self.bytecode.inst(inst + 1);
+                    let next_inst = inst + 1;
+                    let next_inst =
+                        self.bytecode.redirects.get(&next_inst).copied().unwrap_or(next_inst);
+                    let next = self.bytecode.inst(next_inst);
                     if !next.is_dead_code() && next.is_stack_section_head() {
                         self.materialize_live_stack();
                     } else {

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -474,6 +474,28 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         Ok(())
     }
 
+    /// Returns the instruction that is physically next in bytecode order.
+    fn lexical_next_inst(&self, inst: Inst) -> Option<Inst> {
+        let next = inst + 1;
+        self.inst_entries.get(next)?;
+        Some(next)
+    }
+
+    /// Resolves an instruction through dead-block redirects created by dedup.
+    fn effective_inst(&self, inst: Inst) -> Inst {
+        self.bytecode.redirects.get(&inst).copied().unwrap_or(inst)
+    }
+
+    /// Returns the runtime fallthrough target after applying dedup redirects.
+    fn effective_next_inst(&self, inst: Inst) -> Option<Inst> {
+        self.lexical_next_inst(inst).map(|next| self.effective_inst(next))
+    }
+
+    /// Returns the IR block for the runtime fallthrough target.
+    fn effective_next_entry(&self, inst: Inst) -> Option<B::BasicBlock> {
+        self.effective_next_inst(inst).map(|next| self.inst_entries[next])
+    }
+
     #[instrument(level = "debug", skip_all, fields(inst = %self.bytecode.inst(inst).to_op()))]
     fn translate_inst(&mut self, inst: Inst) -> Result<()> {
         self.current_inst = Some(inst);
@@ -493,7 +515,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 !this.bytecode.is_instr_diverging(inst),
                 "attempted to branch to next instruction in a diverging instruction: {data:?}",
             );
-            if let Some(&next) = this.inst_entries.get(inst + 1) {
+            if let Some(next) = this.effective_next_entry(inst) {
                 this.bcx.br(next);
             }
         };
@@ -520,10 +542,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             }};
             ($($comment:expr)?) => {
                 // Flush virtual stack before leaving the section.
-                if self.inst_entries.get(inst + 1).is_some() {
-                    let next_inst = inst + 1;
-                    let next_inst =
-                        self.bytecode.redirects.get(&next_inst).copied().unwrap_or(next_inst);
+                if let Some(next_inst) = self.effective_next_inst(inst) {
                     let next = self.bytecode.inst(next_inst);
                     if !next.is_dead_code() && next.is_stack_section_head() {
                         self.materialize_live_stack();
@@ -970,7 +989,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                             let cond_word = self.pop();
                             self.materialize_live_stack();
                             let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                            let next = self.inst_entries[inst + 1];
+                            let next = self
+                                .effective_next_entry(inst)
+                                .expect("JUMPI must have a fallthrough target");
                             let switch_block = self.bcx.create_block("multi_jump");
                             self.bcx.brif(cond, switch_block, next);
                             self.bcx.switch_to_block(switch_block);
@@ -1018,7 +1039,9 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         // Flush virtual values before leaving the section.
                         self.materialize_live_stack();
                         let cond = self.bcx.icmp_imm(IntCC::NotEqual, cond_word, 0);
-                        let next = self.inst_entries[inst + 1];
+                        let next = self
+                            .effective_next_entry(inst)
+                            .expect("JUMPI must have a fallthrough target");
                         self.bcx.brif(cond, target, next);
                     } else {
                         if opcode == op::JUMPI {
@@ -1371,7 +1394,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
         // Register the next instruction as the resume block.
         let idx = self.resume_blocks.len();
-        self.add_resume_at(self.inst_entries[self.current_inst.unwrap() + 1]);
+        let resume_at = self
+            .effective_next_entry(self.current_inst.unwrap())
+            .expect("suspending instruction must have a resume target");
+        self.add_resume_at(resume_at);
 
         // Register the current block as the suspend block.
         let value = self.bcx.iconst(self.isize_type, idx as i64 + 1);

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -233,11 +233,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         // This is initialized later in `post_entry_block`.
         let stack_len = bcx.new_stack_slot(isize_type, "len.addr");
 
-        // Create all instruction entry blocks.
-        // Dead-code instructions map to `unreachable_block`, except when block deduplication
-        // has a redirect — those are resolved in a second pass once all blocks exist.
+        // Create all instruction entry blocks. Dead-code instructions map to
+        // `unreachable_block`; dedup redirects are resolved at control-flow callsites.
         let unreachable_block = bcx.create_block("unreachable");
-        let mut inst_entries: IndexVec<Inst, _> = bytecode
+        let inst_entries: IndexVec<Inst, _> = bytecode
             .iter_all_insts()
             .map(|(i, data)| {
                 if data.is_dead_code() {
@@ -249,13 +248,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             })
             .collect();
         assert!(!inst_entries.is_empty(), "translating empty bytecode");
-
-        // Apply dedup redirects: map dead duplicate entries to their canonical block.
-        if bytecode.has_redirects() {
-            for (&from, &to) in &bytecode.redirects {
-                inst_entries[from] = inst_entries[to];
-            }
-        }
 
         let dynamic_jump_table = bcx.create_block("dynamic_jump_table");
         let suspend_block = bcx.create_block("suspend");
@@ -336,7 +328,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
             fx.bcx.switch_to_block(fx.dynamic_jump_table);
             let jumpdests = bytecode.iter_insts().filter(|(_, data)| data.opcode == op::JUMPDEST);
             let targets = jumpdests
-                .map(|(inst, data)| (data.jumpdest_pc() as u64, fx.inst_entries[inst]))
+                .map(|(inst, data)| (data.jumpdest_pc() as u64, fx.effective_entry(inst)))
                 .collect::<Vec<_>>();
             let i64_type = fx.bcx.type_int(64);
             let index = fx.bcx.phi(i64_type, &fx.incoming_dynamic_jumps);
@@ -486,6 +478,11 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         self.bytecode.redirects.get(&inst).copied().unwrap_or(inst)
     }
 
+    /// Returns the IR block for an instruction after applying dedup redirects.
+    fn effective_entry(&self, inst: Inst) -> B::BasicBlock {
+        self.inst_entries[self.effective_inst(inst)]
+    }
+
     /// Returns the runtime fallthrough target after applying dedup redirects.
     fn effective_next_inst(&self, inst: Inst) -> Option<Inst> {
         self.lexical_next_inst(inst).map(|next| self.effective_inst(next))
@@ -493,7 +490,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
 
     /// Returns the IR block for the runtime fallthrough target.
     fn effective_next_entry(&self, inst: Inst) -> Option<B::BasicBlock> {
-        self.effective_next_inst(inst).map(|next| self.inst_entries[next])
+        self.effective_next_inst(inst).map(|next| self.effective_entry(next))
     }
 
     #[instrument(level = "debug", skip_all, fields(inst = %self.bytecode.inst(inst).to_op()))]
@@ -1006,7 +1003,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                             .iter()
                             .map(|&t| {
                                 let pc = self.bytecode.inst(t).jumpdest_pc() as u64;
-                                (pc, self.inst_entries[t])
+                                (pc, self.effective_entry(t))
                             })
                             .collect();
                         let invalid_jump = self.add_invalid_jump();
@@ -1023,7 +1020,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                                 || (opcode == op::JUMPI && has_const_jumpi_condition),
                             "jumping to non-JUMPDEST; target_inst={target_inst}",
                         );
-                        self.inst_entries[target_inst]
+                        self.effective_entry(target_inst)
                     } else {
                         // Dynamic jump.
                         debug_assert!(self.bytecode.has_dynamic_jumps());

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -2058,6 +2058,74 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
 
+        dedup_fallthrough_redirect_materializes_stack(@raw {
+            bytecode: &asm("
+                CALLVALUE
+                PUSH 123456789
+                SUB
+                PUSH %join_a
+                JUMPI
+                CALLVALUE
+                PUSH 123456789
+                SUB
+                PUSH %join_b
+                JUMPI
+
+                CALLDATASIZE
+                PUSH %case_b_entry
+                JUMPI
+
+                PUSH0
+                PUSH0
+                PUSH %case_a
+                JUMP
+
+            case_a:
+                JUMPDEST
+                PUSH 0xaa
+                SWAP2
+                POP
+            join_a:
+                JUMPDEST
+                PUSH %done
+                JUMP
+
+            case_b_entry:
+                JUMPDEST
+                PUSH0
+                PUSH0
+                PUSH %case_b
+                JUMP
+
+            case_b:
+                JUMPDEST
+                PUSH 0xbb
+                SWAP2
+                POP
+            join_b:
+                JUMPDEST
+                PUSH %done
+                JUMP
+
+            done:
+                JUMPDEST
+                POP
+                ISZERO
+                PUSH %bad
+                JUMPI
+                STOP
+
+            bad:
+                JUMPDEST
+                PUSH0
+                PUSH0
+                REVERT
+            "),
+            inspect_stack: Some(false),
+            expected_return: InstructionResult::Stop,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+
         // Disabled opcodes must not poison stack sections.
         //
         // When a disabled opcode (e.g. TSTORE before Cancun) follows executable instructions


### PR DESCRIPTION
When block dedup redirects a dead fallthrough target to its canonical block, the translator still used the original dead next instruction to decide whether a section-boundary stack flush was needed. For selector-style blocks that materialize a value with `PUSH/SWAP2/POP` and then fall through into a deduped `JUMPDEST`, this could branch to the canonical block without writing the selected stack value back to memory.

This resolves the next instruction through `bytecode.redirects` before the materialization decision, keeping dedup enabled while preserving the stack state expected by the canonical target. The regression is a minimal version of the failing pattern: two reachable identical join blocks are deduped, the runtime path falls through the duplicate, and the selected nonzero value must survive into the shared zero-check.
