### PR TITLE
fix: preserve jump entry blocks

### DIFF
--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -1009,7 +1009,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         let invalid_jump = self.add_invalid_jump();
                         self.bcx.switch(target_value, invalid_jump, &switch_targets, true);
 
-                        self.inst_entries[inst] = self.bcx.current_block().unwrap();
                         goto_return!(no_branch);
                     } else if data.flags.contains(InstFlags::STATIC_JUMP) {
                         // Pop and discard the target; it's always on the stack.
@@ -1048,7 +1047,6 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                         self.materialize_live_stack();
                         self.bcx.br(target);
                     }
-                    self.inst_entries[inst] = self.bcx.current_block().unwrap();
                 }
 
                 goto_return!(no_branch);

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -2058,6 +2058,33 @@ tests! {
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
 
+        dedup_fallthrough_jump_tail_charges_jump_gas(@raw {
+            bytecode: &asm("
+                PUSH %done
+                CALLER
+                PUSH %path2
+                JUMPI
+                JUMP
+
+            path2:
+                JUMPDEST
+                PUSH0
+                PUSH %other
+                JUMPI
+                JUMP
+
+            other:
+                JUMPDEST
+                STOP
+
+            done:
+                JUMPDEST
+                STOP
+            "),
+            expected_return: InstructionResult::Stop,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
+
         dedup_fallthrough_redirect_materializes_stack(@raw {
             bytecode: &asm("
                 CALLVALUE


### PR DESCRIPTION
This fixes a dedup gas-accounting bug where a redirected dead fallthrough `JUMP` tail could enter the canonical jump after its section gas had already been charged. The translator was rewriting `inst_entries[inst]` for jump instructions to the current continuation block after emitting the branch, so later dedup redirects that used the canonical instruction entry could skip the canonical `JUMP`'s 8 gas.

The fix keeps instruction entries stable after initial block creation and leaves dedup redirect resolution at control-flow callsites. A regression test covers two deduped fallthrough jump tails and asserts JIT gas matches the interpreter.

Reproduced on mainnet tx `0xce2ade111d1f9dab83bd33925e10a9e208ca42218b4ec515b6aaf65efba07dc4`, where patched JIT reports `Gas used: 340617` against `https://ethereum.reth.rs/rpc`.
