### PR TITLE
fix(runtime): evict stale cold entries

### DIFF
--- a/crates/revmc-runtime/src/runtime/backend.rs
+++ b/crates/revmc-runtime/src/runtime/backend.rs
@@ -101,6 +101,8 @@ struct EntryState {
     phase: EntryPhase,
     /// The bytecode for this key (captured from a miss event).
     bytecode: Bytes,
+    /// When this entry was last observed.
+    last_observed_at: Instant,
     /// Sync notifiers waiting for this entry to finish compiling.
     pending_notifiers: Vec<SyncNotifier>,
 }
@@ -246,12 +248,15 @@ impl BackendState {
             return;
         }
 
+        let now = Instant::now();
         let entry = self.entries.entry(key).or_insert_with(|| EntryState {
             hotness: 0,
             phase: EntryPhase::Cold,
             bytecode: bytecode.clone(),
+            last_observed_at: now,
             pending_notifiers: Vec::new(),
         });
+        entry.last_observed_at = now;
 
         if entry.phase == EntryPhase::Working {
             entry.pending_notifiers.push(sync_notifier);
@@ -632,7 +637,18 @@ impl BackendState {
             }
         }
 
-        // Phase 2: enforce memory budget by evicting LRU JIT entries.
+        // Phase 2: evict stale cold entries that never became hot enough to compile.
+        if let Some(idle) = idle_duration {
+            let resident = &self.inner.resident;
+            self.entries.retain(|key, entry| {
+                let stale = entry.phase == EntryPhase::Cold
+                    && now.duration_since(entry.last_observed_at) > idle
+                    && !resident.contains_key(key);
+                !stale
+            });
+        }
+
+        // Phase 3: enforce memory budget by evicting LRU JIT entries.
         if budget > 0 && jit_total_bytes() > budget {
             // Collect JIT entries sorted by last_hit_at ascending (oldest first).
             // AOT entries are excluded because they don't contribute to `jit_total_bytes()`.

--- a/crates/revmc-runtime/src/runtime/tests.rs
+++ b/crates/revmc-runtime/src/runtime/tests.rs
@@ -1111,6 +1111,40 @@ fn prepare_aot_skips_jit_resident() {
 }
 
 // ===========================================================================
+// Tests: cold-entry eviction.
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "llvm")]
+fn cold_entries_are_evicted() {
+    let tb = TestBackend::with_tuning_1w(RuntimeTuning {
+        jit_hot_threshold: 2,
+        jit_max_pending_jobs: 1,
+        idle_evict_duration: Some(std::time::Duration::from_millis(20)),
+        eviction_sweep_interval: std::time::Duration::from_millis(10),
+        event_drain_interval: std::time::Duration::from_millis(10),
+        ..Default::default()
+    });
+
+    for i in 0..10 {
+        let _ = tb.lookup(TestBackend::req_cancun(&indexed_bytecode(i)));
+    }
+
+    let compile_me = indexed_bytecode(42);
+    for _ in 0..2 {
+        let _ = tb.lookup(TestBackend::req_cancun(&compile_me));
+    }
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert_eq!(tb.stats().resident_entries, 0);
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    for _ in 0..2 {
+        let _ = tb.lookup(TestBackend::req_cancun(&compile_me));
+    }
+    tb.wait_resident_count(1);
+}
+
+// ===========================================================================
 // Tests: compiler recycling.
 // ===========================================================================
 


### PR DESCRIPTION
The runtime keeps per-key `EntryState` for observed misses before they become hot enough to compile. Entries that never reach the hot threshold currently retain their captured bytecode until the cold-entry cap is hit or the backend is cleared, which can look like a slow leak on long-running nodes that see many one-off contracts.

This records the last observation time for each cold entry and reuses the existing idle eviction sweep to drop stale cold entries that are not resident. The resident compiled-code eviction behavior is unchanged.
