### PR TITLE
fix(runtime): cap default JIT bytecode length

### DIFF
--- a/crates/revmc-runtime/src/runtime/config.rs
+++ b/crates/revmc-runtime/src/runtime/config.rs
@@ -10,6 +10,7 @@ const JIT_MODE_ENV: &str = "REVMC_JIT_MODE";
 const JIT_HELPER_PATH_ENV: &str = "REVMC_JIT_HELPER_PATH";
 const JIT_HELPER_MEMORY_LIMIT_ENV: &str = "REVMC_JIT_HELPER_MEMORY_LIMIT_BYTES";
 const JIT_HELPER_CPU_COUNT_ENV: &str = "REVMC_JIT_HELPER_CPU_COUNT";
+const DEFAULT_JIT_MAX_BYTECODE_LEN: usize = 24 * 1024;
 
 /// Runtime configuration.
 #[derive(Clone, derive_more::Debug)]
@@ -240,7 +241,7 @@ pub struct RuntimeTuning {
 
     /// Maximum bytecode length eligible for compilation. `0` = no limit.
     ///
-    /// Defaults to `0`.
+    /// Defaults to `24 KiB`.
     pub jit_max_bytecode_len: usize,
 
     /// Maximum number of JIT compilation jobs in flight.
@@ -343,7 +344,7 @@ impl Default for RuntimeTuning {
             event_drain_interval: Duration::from_millis(100),
             shutdown_timeout: Duration::from_secs(5),
             jit_hot_threshold: 8,
-            jit_max_bytecode_len: 0,
+            jit_max_bytecode_len: DEFAULT_JIT_MAX_BYTECODE_LEN,
             jit_max_pending_jobs: 2048,
             jit_worker_count: worker_count,
             jit_timeout: Duration::from_secs(5),

--- a/crates/revmc-runtime/src/runtime/tests.rs
+++ b/crates/revmc-runtime/src/runtime/tests.rs
@@ -445,6 +445,17 @@ fn blocking_mode() {
 }
 
 #[test]
+fn default_jit_max_bytecode_len_matches_eth_limit() {
+    let tuning = RuntimeTuning::default();
+    let max_len_bytecode = vec![0; 24 * 1024];
+    let too_large_bytecode = vec![0; 24 * 1024 + 1];
+
+    assert_eq!(tuning.jit_max_bytecode_len, 24 * 1024);
+    assert!(tuning.should_compile(&max_len_bytecode));
+    assert!(!tuning.should_compile(&too_large_bytecode));
+}
+
+#[test]
 #[cfg(feature = "llvm")]
 fn jit_hotness_promotion() {
     let tb =


### PR DESCRIPTION
Default JIT eligibility now stops at the current Ethereum bytecode limit of 24 KiB. Larger bytecodes remain interpreted by default until the compiler has been tested beyond that size.

The limit is named in runtime tuning and covered by a boundary test for exactly 24 KiB and 24 KiB plus one byte.
