### PR TITLE
ci: add shared LLVM install script

### DIFF
--- a/.github/scripts/install_llvm.sh
+++ b/.github/scripts/install_llvm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+os=${1:?usage: install_llvm.sh <ubuntu|macos> [version]}
+version=${2:-22}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$os" in
+    ubuntu)
+        sudo "$script_dir/install_llvm_ubuntu.sh" "$version"
+        ;;
+    macos)
+        "$script_dir/install_llvm_brew.sh" "$version"
+        ;;
+    *)
+        echo "unsupported OS: $os" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/install_llvm_brew.sh
+++ b/.github/scripts/install_llvm_brew.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+v=${1:-22}
+
+brew install "llvm@${v}"
+prefix="$(brew --prefix "llvm@${v}")"
+echo "LLVM_SYS_${v}1_PREFIX=${prefix}" >> "$GITHUB_ENV"
+echo "${prefix}/bin" >> "$GITHUB_PATH"
+
+echo "LLVM $v installed:"
+"${prefix}/bin/llvm-config" --version

--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -3,11 +3,23 @@ set -eo pipefail
 
 v=${1:-22}
 bins=(clang llvm-config lld ld.lld FileCheck)
-llvm_sh=$(mktemp)
 
-wget https://apt.llvm.org/llvm.sh -O "$llvm_sh"
+# Install prerequisites for llvm.sh.
+# software-properties-common is needed on older distros (bookworm) for add-apt-repository.
+# It is not needed on newer distros (trixie, forky), where llvm.sh uses a different method.
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    lsb-release wget gnupg ca-certificates
+apt-get install -y --no-install-recommends software-properties-common 2>/dev/null || true
+
+# Use the official LLVM install script.
+# It handles distro detection, GPG key import, and apt source configuration.
+llvm_sh=$(mktemp)
+wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
 chmod +x "$llvm_sh"
 "$llvm_sh" "$v" all
+rm -f "$llvm_sh"
+
 for bin in "${bins[@]}"; do
     if ! command -v "$bin-$v" &>/dev/null; then
         echo "Warning: $bin-$v not found" 1>&2

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install LLVM
-        run: sudo .github/scripts/install_llvm_ubuntu.sh ${{ env.LLVM_VERSION }}
+        run: .github/scripts/install_llvm.sh ubuntu
       - name: llvm-config
         run: llvm-config --version --bindir --libdir
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,12 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v4
-      - name: Install LLVM (apt)
+      - name: Install LLVM
         if: ${{ matrix.os == 'ubuntu' }}
-        run: sudo .github/scripts/install_llvm_ubuntu.sh
-      - name: Install LLVM (brew)
+        run: .github/scripts/install_llvm.sh ubuntu
+      - name: Install LLVM
         if: ${{ matrix.os == 'macos' }}
-        run: |
-          v=22
-          brew install "llvm@${v}"
-          prefix="$(brew --prefix llvm@${v})"
-          echo "LLVM_SYS_${v}1_PREFIX=${prefix}" >> $GITHUB_ENV
-          echo "${prefix}/bin" >> $GITHUB_PATH
+        run: .github/scripts/install_llvm.sh macos
       - name: llvm-config
         run: llvm-config --version --bindir --libdir
       - uses: dtolnay/rust-toolchain@master
@@ -81,17 +76,12 @@ jobs:
         run: git submodule update --init --checkout --depth 1 tests/ethereum-tests
       - name: Download test fixtures
         run: ./scripts/setup-test-fixtures.sh
-      - name: Install LLVM (apt)
+      - name: Install LLVM
         if: ${{ matrix.os == 'ubuntu' }}
-        run: sudo .github/scripts/install_llvm_ubuntu.sh
-      - name: Install LLVM (brew)
+        run: .github/scripts/install_llvm.sh ubuntu
+      - name: Install LLVM
         if: ${{ matrix.os == 'macos' }}
-        run: |
-          v=22
-          brew install "llvm@${v}"
-          prefix="$(brew --prefix llvm@${v})"
-          echo "LLVM_SYS_${v}1_PREFIX=${prefix}" >> $GITHUB_ENV
-          echo "${prefix}/bin" >> $GITHUB_PATH
+        run: .github/scripts/install_llvm.sh macos
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
@@ -110,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install LLVM
-        run: sudo .github/scripts/install_llvm_ubuntu.sh
+        run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@cargo-hack
@@ -128,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install LLVM
-        run: sudo .github/scripts/install_llvm_ubuntu.sh
+        run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2
@@ -144,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install LLVM
-        run: sudo .github/scripts/install_llvm_ubuntu.sh
+        run: .github/scripts/install_llvm.sh ubuntu
       - uses: dtolnay/rust-toolchain@nightly
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Adds the shared LLVM installation wrapper from reth and uses it from CI. The Ubuntu installer now installs the prerequisites expected by apt.llvm.org before invoking llvm.sh, while macOS uses the new brew helper instead of inlining the setup in each workflow job.
