### PR TITLE
fix(statetest): default omitted excess_blob_gas on block headers

### DIFF
--- a/crates/revmc-statetest/src/btest/mod.rs
+++ b/crates/revmc-statetest/src/btest/mod.rs
@@ -629,11 +629,12 @@ fn execute_blockchain_test(
         if let Some(block_header) = block.block_header.as_ref() {
             block_hash = Some(block_header.hash);
             beacon_root = block_header.parent_beacon_block_root;
+            let this_excess = block_header.excess_blob_gas.unwrap_or_default().to::<u64>();
             block_env = block_header.to_block_env(Some(BlobExcessGasAndPrice::new_with_spec(
                 parent_excess_blob_gas,
                 spec_id,
             )));
-            this_excess_blob_gas = block_header.excess_blob_gas.map(|i| i.to::<u64>());
+            this_excess_blob_gas = Some(this_excess);
         } else {
             this_excess_blob_gas = None;
         }


### PR DESCRIPTION
Blockchain tests sometimes omit excess_blob_gas on non-genesis headers. Use zero like genesis handling so parent_excess_blob_gas updates every block instead of retaining the previous fork value.