### PR TITLE
chore: bump alloy-evm and oxc-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58673bde58f17022886547b618346aeae9b147ed398f9c847105fa91c49f97eb"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2530,9 +2530,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
 dependencies = [
  "nonmax",
 ]
@@ -4837,18 +4837,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ revmc-runtime = { version = "0.1.0", path = "crates/revmc-runtime", default-feat
 
 alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
-alloy-evm = { version = "0.35.0", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 
 revm-bytecode = { version = "11.0.0", default-features = false, features = ["parse"] }
 revm-context = { version = "18.0.2", default-features = false }

--- a/crates/revmc-codegen/Cargo.toml
+++ b/crates/revmc-codegen/Cargo.toml
@@ -50,7 +50,7 @@ paste = { workspace = true, optional = true }
 similar-asserts = { version = "2.0", optional = true }
 tracing-subscriber = { workspace = true, features = ["fmt"], optional = true }
 smallvec = "1.15.1"
-oxc_index = { version = "4.1.0", features = ["nonmax"] }
+oxc_index = { version = "5.0.0", features = ["nonmax"] }
 indexmap = "2.13.0"
 
 [build-dependencies]


### PR DESCRIPTION
Bumps alloy-evm to 0.36.0 and oxc_index to 5.0.0, with the corresponding Cargo.lock updates. No source changes are needed for these dependency updates.