### PR TITLE
fix(runtime): never block in pause/resume on the bounded command channel

### DIFF
--- a/crates/revmc-runtime/src/runtime/mod.rs
+++ b/crates/revmc-runtime/src/runtime/mod.rs
@@ -101,6 +101,8 @@ pub(crate) struct BackendInner {
     shared: Arc<BackendShared>,
     /// Global enable flag.
     enabled: AtomicBool,
+    /// Whether the backend thread has been spawned and is draining the command channel.
+    started: AtomicBool,
     /// Blocking mode: every lookup synchronously compiles and never falls back.
     blocking: bool,
     /// Tuning knobs (Copy). Cached for hot-path eligibility checks.
@@ -186,6 +188,7 @@ impl JitBackend {
             inner: Arc::new(BackendInner {
                 shared,
                 enabled: AtomicBool::new(false),
+                started: AtomicBool::new(false),
                 blocking: config.blocking,
                 tx,
                 thread: std::sync::Mutex::new(None),
@@ -366,13 +369,18 @@ impl JitBackend {
     /// out-of-process mode, the helper process group is stopped until the pause depth returns to
     /// zero, so dispatched helper requests remain buffered and resume once the helper continues.
     /// In in-process mode, pause only tracks pause depth.
+    ///
+    /// Pause delivery is best-effort and never blocks: callers pause around block validation on
+    /// the engine's critical path. See [`try_send_control`](Self::try_send_control).
     pub fn pause(&self) {
         if self.inner.shared.pause_depth.fetch_add(1, Ordering::Relaxed) == 0 {
-            let _ = self.inner.tx.send(Command::Pause);
+            self.try_send_control(Command::Pause);
         }
     }
 
     /// Resumes out-of-process helper execution once all active pauses have been released.
+    ///
+    /// Resume delivery is best-effort and never blocks, like [`pause`](Self::pause).
     pub fn resume(&self) {
         if self
             .inner
@@ -383,7 +391,28 @@ impl JitBackend {
             })
             .is_ok_and(|depth| depth == 1)
         {
-            let _ = self.inner.tx.send(Command::Resume);
+            self.try_send_control(Command::Resume);
+        }
+    }
+
+    /// Sends a best-effort control command without ever blocking the caller.
+    ///
+    /// The command channel is bounded, so a plain `send` can block. Pause/resume are issued on
+    /// the caller's block-validation critical path and must never block there:
+    ///
+    /// - If the backend thread has not been started (the runtime was constructed but compilation
+    ///   was never enabled), nothing drains the channel. Queued commands would only accumulate
+    ///   until the channel fills and `send` blocks the caller forever, so the send is skipped
+    ///   entirely — there is no helper to pause anyway.
+    /// - If the channel is full, the command is dropped and recorded in
+    ///   [`commands_dropped`](RuntimeStatsSnapshot::commands_dropped). Pause/resume signals are
+    ///   idempotent and re-issued on the next pause cycle, so a dropped command self-heals.
+    fn try_send_control(&self, cmd: Command) {
+        if !self.inner.started.load(Ordering::Acquire) {
+            return;
+        }
+        if self.inner.tx.try_send(cmd).is_err() {
+            self.inner.shared.stats.commands_dropped.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -456,6 +485,7 @@ impl JitBackend {
             .wrap_err("failed to spawn backend thread")?;
 
         *self.inner.thread.lock().unwrap() = Some(BackendThread { handle: thread, done_rx });
+        self.inner.started.store(true, Ordering::Release);
         Ok(())
     }
 

--- a/crates/revmc-runtime/src/runtime/mod.rs
+++ b/crates/revmc-runtime/src/runtime/mod.rs
@@ -371,7 +371,8 @@ impl JitBackend {
     /// In in-process mode, pause only tracks pause depth.
     ///
     /// Pause delivery is best-effort and never blocks: callers pause around block validation on
-    /// the engine's critical path. See [`try_send_control`](Self::try_send_control).
+    /// the engine's critical path. If the backend thread is not running or the command channel
+    /// is full, the command is skipped or dropped instead of blocking.
     pub fn pause(&self) {
         if self.inner.shared.pause_depth.fetch_add(1, Ordering::Relaxed) == 0 {
             self.try_send_control(Command::Pause);
@@ -408,7 +409,7 @@ impl JitBackend {
     ///   [`commands_dropped`](RuntimeStatsSnapshot::commands_dropped). Pause/resume signals are
     ///   idempotent and re-issued on the next pause cycle, so a dropped command self-heals.
     fn try_send_control(&self, cmd: Command) {
-        if !self.inner.started.load(Ordering::Acquire) {
+        if !self.inner.started.load(Ordering::Relaxed) {
             return;
         }
         if self.inner.tx.try_send(cmd).is_err() {
@@ -485,7 +486,7 @@ impl JitBackend {
             .wrap_err("failed to spawn backend thread")?;
 
         *self.inner.thread.lock().unwrap() = Some(BackendThread { handle: thread, done_rx });
-        self.inner.started.store(true, Ordering::Release);
+        self.inner.started.store(true, Ordering::Relaxed);
         Ok(())
     }
 

--- a/crates/revmc-runtime/src/runtime/stats.rs
+++ b/crates/revmc-runtime/src/runtime/stats.rs
@@ -11,6 +11,8 @@ pub(crate) struct RuntimeStats {
     pub(crate) lookup_misses: AtomicU64,
     /// Total lookup events dropped due to event-queue overflow.
     pub(crate) events_dropped: AtomicU64,
+    /// Total control commands dropped because the command channel was full.
+    pub(crate) commands_dropped: AtomicU64,
     /// Total number of entries evicted (idle + budget).
     pub(crate) evictions: AtomicU64,
     /// Total number of compilations dispatched (JIT promotions + AOT requests).
@@ -60,6 +62,11 @@ pub struct RuntimeStatsSnapshot {
     pub lookup_misses: u64,
     /// Total lookup events dropped due to event-queue overflow.
     pub events_dropped: u64,
+    /// Total control commands dropped because the command channel was full.
+    ///
+    /// Pause/resume commands are best-effort and dropped instead of blocking the caller when
+    /// the command channel is full.
+    pub commands_dropped: u64,
     /// Number of entries in the resident compiled map.
     pub resident_entries: u64,
     /// Number of lookup events currently queued for the backend.
@@ -135,6 +142,7 @@ impl RuntimeStats {
             lookup_hits: self.lookup_hits.load(Ordering::Relaxed),
             lookup_misses: self.lookup_misses.load(Ordering::Relaxed),
             events_dropped: self.events_dropped.load(Ordering::Relaxed),
+            commands_dropped: self.commands_dropped.load(Ordering::Relaxed),
             resident_entries: gauges.resident_entries,
             events_queued: gauges.events_queued,
             command_queue_len: gauges.command_queue_len,

--- a/crates/revmc-runtime/src/runtime/tests.rs
+++ b/crates/revmc-runtime/src/runtime/tests.rs
@@ -414,6 +414,53 @@ fn sub_threshold_misses_do_not_dispatch() {
     assert_eq!(stats.compilations_dispatched, 0);
 }
 
+#[test]
+fn pause_resume_never_block_without_backend_thread() {
+    // When the runtime is constructed but compilation is never enabled, the backend thread is
+    // never spawned and nothing drains the bounded command channel. Pause/resume are issued once
+    // per validated block on the engine's critical path, so queueing them would fill the channel
+    // after `channel_capacity` sends and block the caller forever (observed in production as a
+    // consensus-engine deadlock after exactly capacity/2 blocks). They must be skipped, not
+    // queued, while the backend is not started.
+    let tb = TestBackend::new(RuntimeConfig {
+        enabled: false,
+        tuning: RuntimeTuning { channel_capacity: 2, ..Default::default() },
+        ..Default::default()
+    });
+
+    // More pause/resume cycles than the channel can hold: deadlocks without the started check.
+    for _ in 0..16 {
+        tb.pause();
+        assert!(tb.is_paused());
+        tb.resume();
+        assert!(!tb.is_paused());
+    }
+
+    // Nothing was queued or dropped: the sends were skipped entirely.
+    let stats = tb.stats();
+    assert_eq!(stats.command_queue_len, 0);
+    assert_eq!(stats.commands_dropped, 0);
+}
+
+#[test]
+fn pause_resume_depth_tracking_with_backend_thread() {
+    // With the backend running, pause/resume still track depth and deliver commands.
+    let tb = TestBackend::with_tuning_1w(RuntimeTuning::default());
+
+    tb.pause();
+    tb.pause();
+    assert!(tb.is_paused());
+    tb.resume();
+    assert!(tb.is_paused());
+    tb.resume();
+    assert!(!tb.is_paused());
+
+    // Commands are drained by the backend thread rather than accumulating.
+    let stats = tb.wait_stats(|s| s.command_queue_len == 0);
+    assert_eq!(stats.command_queue_len, 0);
+    assert_eq!(stats.commands_dropped, 0);
+}
+
 // ===========================================================================
 // Tests: JIT compilation (require LLVM).
 // ===========================================================================


### PR DESCRIPTION
## Summary

`JitBackend::pause()`/`resume()` used a **blocking `send`** on the bounded command channel (capacity 4096). When the runtime is constructed but compilation is never enabled (binary built with the `jit` feature, `--jit` not passed), the backend thread is never spawned — the receiver sits parked in `lazy_spawn` and **nothing drains the channel**.

reth's `JitPauseGuard` (paradigmxyz/reth#23230) issues exactly one pause + one resume per validated block on the engine-tree thread. After 4096 sends = **2048 validated blocks (~6.8h at 12s slots)** the channel is full and the next `pause()` blocks **forever** on the consensus engine's critical path: the engine stops responding to all Engine API calls while P2P/RPC keep running, with zero log output and no CPU spike.

## Production incident (2026-06-12)

A reth `2.3.0 (fc2cc1e)` mainnet node (`reth-fluffy-fox-0`) wedged at exactly this point:
- node started 07:25:41 UTC, engine deadlocked 13:46:48 UTC while inserting block 25301778
- last log line: `engine::tree` "found canonical state for block in memory, creating provider builder" — the very next statement in `validate_block_with_state` is `JitPauseGuard::new`
- log count of completed validations from startup to hang: **exactly 2048** (= channel_capacity/2)
- lighthouse logged engine API timeouts from 13:46:56 until the node was restarted; no panic, flat memory, no CPU throttling

## Fix

- Track whether the backend thread has been started; **skip** pause/resume sends entirely while it has not (there is no helper to pause, and queued commands would only accumulate).
- Use `try_send` instead of `send` so a full channel can never block the caller. Dropped commands are counted in a new `commands_dropped` stat; pause/resume are idempotent and re-issued every cycle, so a drop self-heals.

## Testing

- New `pause_resume_never_block_without_backend_thread` regression test (capacity 2, 16 pause/resume cycles): hangs before this fix (verified), passes after.
- New `pause_resume_depth_tracking_with_backend_thread` test covers the started path: depth tracking intact, commands drained, none dropped.
- `cargo test -p revmc-runtime --no-default-features --lib`: 24 passed (LLVM-gated tests not run locally; CI covers them).

Note: any reth node running a jit-feature build without JIT enabled deadlocks ~6.8h after every restart until it picks up this fix via a `cargo update -p revmc`.