### PR TITLE
fix: avoid materializing failure stack

### DIFF
--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -443,10 +443,11 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 fx.bcx.phi(fx.i8_type, &fx.incoming_failures)
             };
             fx.bcx.set_current_block_cold();
-            let failure_block = fx.bcx.current_block().unwrap();
-            let return_block = fx.return_block.unwrap();
-            fx.incoming_returns.push((failure_value, failure_block));
-            fx.bcx.br(return_block);
+            // Do not sync the stack here: this is a shared synthetic merge block for
+            // failures that may occur before their instruction body has materialized
+            // the current virtual stack. Syncing here can use values that do not
+            // dominate all failure predecessors.
+            fx.build_return_inner(failure_value);
         } else {
             fx.bcx.unreachable();
         }
@@ -1874,6 +1875,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         if self.config.inspect_stack {
             self.materialize_live_stack();
         }
+        self.build_return_inner(ret);
+    }
+
+    fn build_return_inner(&mut self, ret: B::Value) {
         if let Some(block) = self.return_block {
             self.incoming_returns.push((ret, self.bcx.current_block().unwrap()));
             self.bcx.br(block);

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -443,7 +443,10 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
                 fx.bcx.phi(fx.i8_type, &fx.incoming_failures)
             };
             fx.bcx.set_current_block_cold();
-            fx.build_return(failure_value);
+            let failure_block = fx.bcx.current_block().unwrap();
+            let return_block = fx.return_block.unwrap();
+            fx.incoming_returns.push((failure_value, failure_block));
+            fx.bcx.br(return_block);
         } else {
             fx.bcx.unreachable();
         }
@@ -595,7 +598,7 @@ impl<'a, B: Backend> FunctionCx<'a, B> {
         };
 
         // Check stack length for the current section.
-        if self.config.stack_bound_checks {
+        if self.config.stack_bound_checks && data.is_stack_section_head() {
             self.check_stack_bounds(data.stack_section);
         }
 

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -385,6 +385,13 @@ tests! {
             expected_stack: STACK_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),
+        swap16_dup10_selfdestruct_underflow(@raw {
+            bytecode: &[op::SWAP16, op::DUP10, op::SELFDESTRUCT],
+            spec_id: SpecId::OSAKA,
+            expected_return: InstructionResult::StackUnderflow,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
 
         // Invalid immediate: 0x5B (91) is in the invalid range [91, 127] for decode_single.
         dupn_invalid_imm(@raw {


### PR DESCRIPTION
## Summary

Adds a minimized regression test for an LLVM verifier failure found by the `vs_interpreter_osaka` fuzz target.

The bytecode is:

```text
0x9f89ff
SWAP16 DUP10 SELFDESTRUCT
```

Semantically, execution starts with an empty stack, so `SWAP16` should fail with `InstructionResult::StackUnderflow`. Instead, the current LLVM codegen produces invalid IR before execution.

## Reproduction

Environment used locally:

```bash
export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
export LLVM_SYS_221_PREFIX="/opt/homebrew/Cellar/llvm/22.1.7_1"
```

Run the focused regression:

```bash
cargo nextest run --workspace "swap16_dup10_selfdestruct_underflow"
```

## Current Output

```text
────────────
 Nextest run ID 5eaf0a7e-c4bd-44a2-97ac-f66eb5e7b81c with nextest profile: default
    Starting 2 tests across 16 binaries (2287 tests skipped)
        FAIL [   0.022s] (1/2) revmc-codegen tests::stack::swap16_dup10_selfdestruct_underflow::llvm::unopt
  stderr ───

    thread 'tests::stack::swap16_dup10_selfdestruct_underflow::llvm::unopt' panicked at crates/revmc-codegen/src/tests/runner.rs:475:64:
    called `Result::unwrap()` on an `Err` value: Instruction does not dominate all uses!
      %16 = getelementptr inbounds i256, ptr %1, i64 %15
      %39 = getelementptr inbounds i256, ptr %16, i64 -1
    Instruction does not dominate all uses!
      %25 = load i256, ptr %24, align 8
      store i256 %25, ptr %39, align 8

    Location:
        crates/revmc-llvm/src/lib.rs:2251:5

        FAIL [   0.022s] (2/2) revmc-codegen tests::stack::swap16_dup10_selfdestruct_underflow::llvm::opt
  stderr ───

    thread 'tests::stack::swap16_dup10_selfdestruct_underflow::llvm::opt' panicked at crates/revmc-codegen/src/tests/runner.rs:475:64:
    called `Result::unwrap()` on an `Err` value: Instruction does not dominate all uses!
      %16 = getelementptr inbounds i256, ptr %1, i64 %15
      %39 = getelementptr inbounds i256, ptr %16, i64 -1
    Instruction does not dominate all uses!
      %25 = load i256, ptr %24, align 8
      store i256 %25, ptr %39, align 8

    Location:
        crates/revmc-llvm/src/lib.rs:2251:5

────────────
     Summary [   0.024s] 2 tests run: 0 passed, 2 failed, 2287 skipped
```

## Notes

The failing path appears to be `inspect_stack` stack materialization in the shared failure epilogue. The failure block has predecessors from earlier checks, but its materialization uses virtual stack values produced only on later successful-path blocks, causing LLVM's dominance verifier to reject the module.
