### PR TITLE
fix: include gas params in AOT key

### DIFF
--- a/crates/revmc-runtime/src/runtime/backend.rs
+++ b/crates/revmc-runtime/src/runtime/backend.rs
@@ -6,6 +6,7 @@ use crate::{
         config::{CompilationEvent, CompilationKind, RuntimeConfig, RuntimeTuning},
         storage::{
             ArtifactKey, ArtifactManifest, ArtifactStore, BackendSelection, RuntimeCacheKey,
+            gas_params_hash,
         },
         worker::{
             AotSuccess, CompileJob, JitCodeBacking, JitObjectSuccess, SyncNotifier, WorkerPool,
@@ -21,6 +22,7 @@ use crossbeam_channel as chan;
 use crossbeam_queue::ArrayQueue;
 use dashmap::DashMap;
 use quanta::Instant;
+use revm_context_interface::cfg::GasParams;
 use std::{
     ffi::CString,
     mem,
@@ -210,6 +212,8 @@ struct BackendState {
     result_rx: chan::Receiver<WorkerResult>,
     /// Artifact store for persisted artifacts.
     store: Option<Arc<dyn ArtifactStore>>,
+    /// Effective gas parameters used for compile-time gas folding.
+    gas_params: Option<GasParams>,
     /// Tuning knobs.
     tuning: RuntimeTuning,
     /// Whether observed misses compile AOT artifacts instead of JIT code.
@@ -398,6 +402,7 @@ impl BackendState {
 
         let artifact_key = ArtifactKey {
             runtime: *key,
+            gas_params_hash: gas_params_hash(key.spec_id, self.gas_params.as_ref()),
             backend: BackendSelection::Llvm,
             opt_level: self.tuning.aot_opt_level,
         };
@@ -610,6 +615,7 @@ impl BackendState {
     fn handle_aot_success(&mut self, key: RuntimeCacheKey, success: AotSuccess) {
         let artifact_key = ArtifactKey {
             runtime: key,
+            gas_params_hash: gas_params_hash(key.spec_id, self.gas_params.as_ref()),
             backend: BackendSelection::Llvm,
             opt_level: self.tuning.aot_opt_level,
         };
@@ -831,6 +837,7 @@ pub(crate) fn run(
         workers,
         jit_object_linker: JitObjectLinker::new(),
         result_rx,
+        gas_params: config.gas_params,
         store: config.store,
         tuning: config.tuning,
         aot: config.aot,

--- a/crates/revmc-runtime/src/runtime/mod.rs
+++ b/crates/revmc-runtime/src/runtime/mod.rs
@@ -13,6 +13,7 @@ use api::LoadedLibrary;
 use backend::{Command, CompileJitRequest, EventQueue, PrepareAotRequest, ResidentMap};
 use crossbeam_channel as chan;
 use crossbeam_queue::ArrayQueue;
+use revm_context_interface::cfg::GasParams;
 use revm_primitives::{B256, hardfork::SpecId, hints_util::cold_path};
 use stats::RuntimeStats;
 use std::{
@@ -39,6 +40,7 @@ mod stats;
 pub use stats::RuntimeStatsSnapshot;
 
 mod storage;
+use storage::gas_params_hash;
 pub use storage::{
     ArtifactKey, ArtifactManifest, ArtifactStore, BackendSelection, RuntimeArtifactStore,
     RuntimeCacheKey, StoredArtifact,
@@ -429,7 +431,7 @@ impl JitBackend {
         );
 
         // Preload AOT artifacts into the already-allocated resident map.
-        match Self::preload_aot(config.store.as_deref()) {
+        match Self::preload_aot(config.store.as_deref(), config.gas_params.as_ref()) {
             Ok(entries) => {
                 for (key, prog) in entries {
                     self.inner.shared.resident.insert(key, prog);
@@ -462,6 +464,7 @@ impl JitBackend {
     /// Preloads AOT artifacts from the store as `Arc<CompiledProgram>`s ready to insert.
     fn preload_aot(
         store: Option<&dyn ArtifactStore>,
+        gas_params: Option<&GasParams>,
     ) -> eyre::Result<Vec<(RuntimeCacheKey, Arc<CompiledProgram>)>> {
         let Some(store) = store else {
             debug!("no artifact store configured, skipping AOT preload");
@@ -481,6 +484,12 @@ impl JitBackend {
         let mut failed = 0u64;
 
         for (artifact_key, stored) in artifacts {
+            let expected_gas_params_hash =
+                gas_params_hash(artifact_key.runtime.spec_id, gas_params);
+            if artifact_key.gas_params_hash != expected_gas_params_hash {
+                continue;
+            }
+
             match Self::load_artifact(&artifact_key, &stored) {
                 Ok(program) => {
                     let key = artifact_key.runtime;

--- a/crates/revmc-runtime/src/runtime/storage.rs
+++ b/crates/revmc-runtime/src/runtime/storage.rs
@@ -1,10 +1,13 @@
 //! Artifact storage trait and data model.
 
 use crate::{OptimizationLevel, eyre};
-use alloy_primitives::B256;
+use alloy_primitives::{B256, keccak256};
 use dashmap::DashMap;
+use revm_context_interface::cfg::{GasParams, gas_params::GasId};
 use revm_primitives::hardfork::SpecId;
 use std::{fs, path::PathBuf};
+
+const GAS_PARAM_COUNT: usize = 256;
 
 /// Runtime cache key: the minimal identity for a compiled program at runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -22,10 +25,28 @@ pub struct RuntimeCacheKey {
 pub struct ArtifactKey {
     /// The runtime cache key (code_hash + spec_id).
     pub runtime: RuntimeCacheKey,
+    /// Digest of the effective compile-time gas parameter table.
+    pub gas_params_hash: B256,
     /// The compiler backend used.
     pub backend: BackendSelection,
     /// The optimization level used.
     pub opt_level: OptimizationLevel,
+}
+
+pub(crate) fn gas_params_hash(spec_id: SpecId, gas_params: Option<&GasParams>) -> B256 {
+    let default_gas_params;
+    let gas_params = if let Some(gas_params) = gas_params {
+        gas_params
+    } else {
+        default_gas_params = GasParams::new_spec(spec_id);
+        &default_gas_params
+    };
+
+    let mut bytes = Vec::with_capacity(GAS_PARAM_COUNT * std::mem::size_of::<u64>());
+    for id in 0..GAS_PARAM_COUNT {
+        bytes.extend_from_slice(&gas_params.get(GasId::new(id as u8)).to_le_bytes());
+    }
+    keccak256(bytes)
 }
 
 /// A stored artifact consisting of a manifest and a path to the compiled dylib.
@@ -116,8 +137,12 @@ impl RuntimeArtifactStore {
 
     fn artifact_path(&self, key: &ArtifactKey) -> PathBuf {
         self.dir.path().join(format!(
-            "{:x}_{:?}_{:?}_{:?}.so",
-            key.runtime.code_hash, key.runtime.spec_id, key.backend, key.opt_level,
+            "{:x}_{:?}_{:x}_{:?}_{:?}.so",
+            key.runtime.code_hash,
+            key.runtime.spec_id,
+            key.gas_params_hash,
+            key.backend,
+            key.opt_level,
         ))
     }
 }
@@ -178,6 +203,7 @@ mod tests {
     fn artifact_key(code_hash: B256) -> ArtifactKey {
         ArtifactKey {
             runtime: RuntimeCacheKey { code_hash, spec_id: SpecId::OSAKA },
+            gas_params_hash: super::gas_params_hash(SpecId::OSAKA, None),
             backend: BackendSelection::Llvm,
             opt_level: OptimizationLevel::Default,
         }

--- a/crates/revmc-runtime/src/runtime/tests.rs
+++ b/crates/revmc-runtime/src/runtime/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use alloy_primitives::{B256, Bytes};
-use revm_primitives::hardfork::SpecId;
+use revm_primitives::{Address, U256, hardfork::SpecId};
 use std::sync::{Arc, Mutex};
 
 // ---------------------------------------------------------------------------
@@ -14,6 +14,9 @@ const BYTECODE_RET42: &[u8] = &[0x60, 0x42, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3];
 
 /// PUSH1 1 PUSH1 1 ADD PUSH0 MSTORE PUSH1 0x20 PUSH0 RETURN — returns 2.
 const BYTECODE_ADD: &[u8] = &[0x60, 0x01, 0x60, 0x01, 0x01, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3];
+
+/// PUSH1 1 PUSH1 2 EXP STOP — constant EXP whose dynamic gas is folded at compile time.
+const BYTECODE_CONST_EXP: &[u8] = &[0x60, 0x01, 0x60, 0x02, 0x0a, 0x00];
 
 /// Returns a simple bytecode that varies by index (for generating distinct code hashes).
 fn indexed_bytecode(i: u8) -> Vec<u8> {
@@ -133,6 +136,52 @@ impl std::ops::Deref for TestBackend {
 }
 
 // `JitBackend` shuts down automatically when the last `Arc<BackendInner>` drops.
+
+#[cfg(feature = "llvm")]
+fn gas_params_with_exp_byte_gas(
+    spec_id: SpecId,
+    exp_byte_gas: u64,
+) -> revm_context_interface::cfg::GasParams {
+    use revm_context_interface::cfg::gas_params::GasId;
+
+    let mut gas_params = revm_context_interface::cfg::GasParams::new_spec(spec_id);
+    gas_params.override_gas([(GasId::exp_byte_gas(), exp_byte_gas)]);
+    gas_params
+}
+
+#[cfg(feature = "llvm")]
+fn run_compiled_gas(
+    program: &CompiledProgram,
+    bytecode: &[u8],
+    spec_id: SpecId,
+    gas_params: &revm_context_interface::cfg::GasParams,
+) -> u64 {
+    use revm_context_interface::host::DummyHost;
+    use revm_interpreter::{
+        CallInput, InputsImpl, Interpreter, SharedMemory, interpreter::ExtBytecode,
+    };
+
+    let input = InputsImpl {
+        target_address: Address::ZERO,
+        bytecode_address: None,
+        caller_address: Address::ZERO,
+        input: CallInput::Bytes(Bytes::new()),
+        call_value: U256::ZERO,
+    };
+    let bytecode = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
+    let ext_bytecode = ExtBytecode::new(bytecode);
+    let mut interpreter =
+        Interpreter::new(SharedMemory::new(), ext_bytecode, input, false, spec_id, 1_000_000);
+    let mut host = DummyHost::new(spec_id);
+
+    unsafe {
+        program.func.call_with_interpreter_with(&mut interpreter, &mut host, |ecx| {
+            ecx.gas_params = gas_params.clone();
+        });
+    }
+
+    interpreter.gas.total_gas_spent()
+}
 
 // ---------------------------------------------------------------------------
 // Artifact stores for testing.
@@ -927,6 +976,63 @@ fn prepare_aot_persist_and_load() {
     let p = tb.wait_compiled(BYTECODE_RET42, SpecId::CANCUN);
     assert_eq!(p.kind, ProgramKind::Aot);
     assert_eq!(store.len(), 1);
+}
+
+#[test]
+#[cfg(feature = "llvm")]
+fn aot_artifact_recompiled_when_gas_params_change_for_const_exp() {
+    let spec_id = SpecId::CANCUN;
+    let high_exp_gas_params = gas_params_with_exp_byte_gas(spec_id, 500);
+    let default_gas_params = revm_context_interface::cfg::GasParams::new_spec(spec_id);
+    let store = Arc::new(RuntimeArtifactStore::new().unwrap());
+    let code_hash = alloy_primitives::keccak256(BYTECODE_CONST_EXP);
+
+    {
+        let tb = TestBackend::new(RuntimeConfig {
+            enabled: true,
+            store: Some(store.clone()),
+            gas_params: Some(high_exp_gas_params.clone()),
+            tuning: RuntimeTuning { jit_worker_count: 1, ..Default::default() },
+            ..Default::default()
+        });
+
+        tb.prepare_aot(AotRequest {
+            code_hash,
+            code: Bytes::copy_from_slice(BYTECODE_CONST_EXP),
+            spec_id,
+        });
+        let p = tb.wait_compiled(BYTECODE_CONST_EXP, spec_id);
+        assert_eq!(p.kind, ProgramKind::Aot);
+        assert_eq!(
+            run_compiled_gas(&p, BYTECODE_CONST_EXP, spec_id, &high_exp_gas_params),
+            3 + 3 + 10 + 500,
+            "test setup should compile with the custom EXP byte gas",
+        );
+    }
+
+    {
+        let tb = TestBackend::new(RuntimeConfig {
+            enabled: true,
+            store: Some(store),
+            gas_params: Some(default_gas_params.clone()),
+            tuning: RuntimeTuning { jit_worker_count: 1, ..Default::default() },
+            ..Default::default()
+        });
+
+        tb.prepare_aot(AotRequest {
+            code_hash,
+            code: Bytes::copy_from_slice(BYTECODE_CONST_EXP),
+            spec_id,
+        });
+        let p = tb.wait_compiled(BYTECODE_CONST_EXP, spec_id);
+        assert_eq!(p.kind, ProgramKind::Aot);
+
+        assert_eq!(
+            run_compiled_gas(&p, BYTECODE_CONST_EXP, spec_id, &default_gas_params),
+            3 + 3 + 10 + default_gas_params.exp_cost(U256::from(1)),
+            "AOT artifacts compiled under different GasParams must not be reused",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a failing regression test for stale persisted AOT artifact reuse across different runtime gas schedules.

## Issue

Persisted compiled AOT artifacts are keyed by `RuntimeCacheKey` plus backend and optimization level, but not by compilation-affecting runtime settings such as `RuntimeConfig::gas_params`.

That lets a shared `ArtifactStore` accept an artifact compiled under one gas schedule in a later runtime configured with a different gas schedule. For bytecode where gas is folded into the compiled section, this can silently charge gas from the old runtime configuration.

The repro uses constant `EXP` bytecode:

```text
PUSH1 1 PUSH1 2 EXP STOP
```

`EXP` dynamic gas is folded at compile time for this shape. The test first compiles AOT with `exp_byte_gas = 500`, then reuses the same artifact store in a second backend with default Cancun gas params. The second backend currently loads the persisted AOT artifact instead of rejecting/recompiling it, so execution charges the stale custom schedule.

Impacted paths:

- `crates/revmc-runtime/src/runtime/storage.rs`
- `crates/revmc-runtime/src/runtime/backend.rs`
- `crates/revmc-runtime/src/runtime/mod.rs`
- `crates/revmc-runtime/src/runtime/worker.rs`
- `crates/revmc-codegen/src/bytecode/passes/sections.rs`

## Reproduction

Run:

```bash
cargo nextest run --workspace aot_artifact_recompiled_when_gas_params_change_for_const_exp
```

Observed on `main`:

```text
thread 'runtime::tests::aot_artifact_recompiled_when_gas_params_change_for_const_exp' panicked at crates/revmc-runtime/src/runtime/tests.rs:
assertion `left == right` failed: AOT artifacts compiled under different GasParams must not be reused
  left: 516
 right: 66
```

The expected `66` is the default gas for `PUSH1 1 PUSH1 2 EXP STOP` under the active second runtime schedule. The observed `516` is the same bytecode using the first runtime's custom `exp_byte_gas = 500`, showing that the stale AOT artifact was reused.

## Notes

This PR intentionally adds only a regression test. A fix should make persisted artifact compatibility include the effective gas schedule, or otherwise validate/reject artifacts whose compile-time settings do not match the active runtime configuration before inserting them into the resident map.
