### PR TITLE
Add regression for SELFDESTRUCT stack preservation

### DIFF
--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -1424,6 +1424,13 @@ tests! {
                 assert_eq!(host.selfdestructs, [(DEF_ADDR, Address::with_last_byte(0x69))]);
             }),
         }),
+        selfdestruct_preserves_remaining_stack(@raw {
+            bytecode: &[op::NUMBER, op::NUMBER, op::SELFDESTRUCT],
+            spec_id: SpecId::BERLIN,
+            expected_return: InstructionResult::SelfDestruct,
+            expected_stack: STACK_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
         // Static-context SELFDESTRUCT: gas < 5000 → OOG before static-call check.
         selfdestruct_static_oog(@raw {
             bytecode: &[op::PUSH1, 0x01, op::SELFDESTRUCT],


### PR DESCRIPTION
## Summary

Adds a focused regression test for a compiled-vs-interpreter stack mismatch around `SELFDESTRUCT`.

The minimized bytecode is:

```text
0x4343ff
NUMBER NUMBER SELFDESTRUCT
```

On Berlin, the interpreter preserves the first `NUMBER` stack item after `SELFDESTRUCT` consumes the beneficiary. The compiled path returns an empty stack instead.

This branch is based directly on `origin/main` (`e86ab24`) and contains only this regression test.

## Reproduction

```bash
PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
LLVM_SYS_221_PREFIX="/opt/homebrew/Cellar/llvm/22.1.7_1" \
cargo nextest run --workspace "selfdestruct_preserves_remaining_stack"
```

## Output

```text
Summary [   0.026s] 2 tests run: 0 passed, 2 failed, 2287 skipped
FAIL revmc-codegen tests::host::selfdestruct_preserves_remaining_stack::llvm::opt
FAIL revmc-codegen tests::host::selfdestruct_preserves_remaining_stack::llvm::unopt

thread 'tests::host::selfdestruct_preserves_remaining_stack::llvm::opt' panicked at crates/revmc-codegen/src/tests/runner.rs:642:17:
assertion failed: `(left == right)`: stack mismatch'
  left: `"[]"`
 right: `"[500]"`
```

## Root Cause Notes

This is distinct from the LLVM dominance verifier crash found in the broader fuzz run. The dominance crash fails during JIT compilation on shared failure-block stack materialization. This test compiles and executes, then fails the runtime stack comparison.

The likely cause is in the `SELFDESTRUCT` translator: it calls the builtin and emits `unreachable` directly, so it does not go through `build_return`, where `inspect_stack` normally materializes remaining live virtual stack slots before returning.
