### PR TITLE
feat: configure single error mode

### DIFF
--- a/crates/revmc-runtime/src/runtime/config.rs
+++ b/crates/revmc-runtime/src/runtime/config.rs
@@ -50,6 +50,19 @@ pub struct RuntimeConfig {
     /// Defaults to `false`.
     pub debug_assertions: bool,
 
+    /// Collapse every JIT failure path to a single
+    /// [`OutOfGas`](revm_interpreter::InstructionResult::OutOfGas) constant.
+    ///
+    /// Failures (stack under/overflow, invalid jump, real OOG, invalid opcode, etc.) are
+    /// semantically interchangeable for callers that only branch on success vs failure, so
+    /// this lets LLVM DCE the per-failure-site materialization and the failure-block phi.
+    /// Successful exits (`STOP`/`RETURN`/`REVERT`) keep their original codes.
+    ///
+    /// Useful for benchmarking the cost of failure-result materialization.
+    ///
+    /// Defaults to `true`.
+    pub single_error: bool,
+
     /// Disable the block deduplication pass.
     ///
     /// When `true`, the dedup pass that merges identical basic blocks is skipped.
@@ -199,6 +212,7 @@ impl Default for RuntimeConfig {
             tuning: RuntimeTuning::default(),
             dump_dir: None,
             debug_assertions: false,
+            single_error: true,
             no_dedup: false,
             no_dse: false,
             gas_params: None,

--- a/crates/revmc-runtime/src/runtime/out_of_process.rs
+++ b/crates/revmc-runtime/src/runtime/out_of_process.rs
@@ -500,6 +500,7 @@ fn limit_cpu_affinity(_cpu_count: usize) -> std::io::Result<()> {
 #[derive(Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
 struct HelperInit {
     debug_assertions: bool,
+    single_error: bool,
     no_dedup: bool,
     no_dse: bool,
     dump_dir: Option<String>,
@@ -864,6 +865,7 @@ fn gas_params_from_pairs(pairs: GasParamPairs) -> eyre::Result<GasParams> {
 fn helper_init(config: &RuntimeConfig) -> HelperInit {
     HelperInit {
         debug_assertions: config.debug_assertions,
+        single_error: config.single_error,
         no_dedup: config.no_dedup,
         no_dse: config.no_dse,
         dump_dir: config.dump_dir.as_ref().map(|path| path.to_string_lossy().into_owned()),
@@ -877,6 +879,7 @@ fn runtime_config_from_init(init: HelperInit) -> eyre::Result<RuntimeConfig> {
     let mut config = RuntimeConfig {
         dump_dir: init.dump_dir.map(PathBuf::from),
         debug_assertions: init.debug_assertions,
+        single_error: init.single_error,
         no_dedup: init.no_dedup,
         no_dse: init.no_dse,
         gas_params: init.gas_params.map(gas_params_from_pairs).transpose()?,

--- a/crates/revmc-runtime/src/runtime/worker.rs
+++ b/crates/revmc-runtime/src/runtime/worker.rs
@@ -533,6 +533,7 @@ pub(super) fn create_compiler(
         config.tuning.jit_opt_level
     });
     compiler.debug_assertions(config.debug_assertions);
+    compiler.single_error(config.single_error);
     compiler.set_dedup(!config.no_dedup);
     compiler.set_dse(!config.no_dse);
     if let Some(gas_params) = &config.gas_params {


### PR DESCRIPTION
Expose `RuntimeConfig::single_error` so runtime users can choose whether compiled failure paths collapse to the compiler default single error code or preserve per-failure materialization.

The default remains `true`, matching the compiler optimization. The option is also forwarded to the out-of-process helper so both JIT modes behave consistently.
