### PR TITLE
test: add LOG topic memory regression

### DIFF
--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -2247,6 +2247,26 @@ fn bytecode_ternop(op: u8, a: U256, b: U256, c: U256) -> [u8; 100] {
     code
 }
 
+matrix_tests!(
+    log_topics_do_not_preexpand_memory = |jit| {
+        let bytecode = [
+            op::PUSH2,
+            0x08,
+            0x00, // Topic value, not the LOG memory offset or length.
+            op::PUSH0,
+            op::PUSH0,
+            op::PUSH0,
+            op::PUSH0,
+            op::LOG3,
+            op::PUSH0,
+            op::PUSH0,
+            op::MSTORE,
+        ];
+        let test_case = TestCase::what_interpreter_says(&bytecode, SpecId::CANCUN);
+        run_test_case(&test_case, jit);
+    }
+);
+
 /// Build opaque unop bytecode: MSTORE(a, 0), MLOAD(0), `<op>`.
 fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
     let mut code = Vec::with_capacity(64);


### PR DESCRIPTION
Adds a focused regression test for the `LOG1..LOG4` constant-memory analysis bug.

The minimized bytecode is:

```text
0x6108005f5f5f5fa35f5f52
PUSH2 0x0800
PUSH0
PUSH0
PUSH0
PUSH0
LOG3
PUSH0
PUSH0
MSTORE
```

The large value is a `LOG3` topic, not the memory offset or length. The interpreter therefore performs a zero-length log and then expands memory for the later `MSTORE`. The compiled path currently treats that topic as LOG memory length during static memory-section analysis and skips the later memory resize, leaving memory empty.

## Reproduction

```bash
PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
LLVM_SYS_221_PREFIX="/opt/homebrew/Cellar/llvm/22.1.7_1" \
cargo nextest run --workspace "log_topics_do_not_preexpand_memory"
```

## Output

```text
Summary [   0.028s] 2 tests run: 0 passed, 2 failed, 2294 skipped
FAIL revmc-codegen tests::log_topics_do_not_preexpand_memory::llvm::unopt
FAIL revmc-codegen tests::log_topics_do_not_preexpand_memory::llvm::opt

thread 'tests::log_topics_do_not_preexpand_memory::llvm::unopt' panicked at crates/revmc-codegen/src/tests/runner.rs:646:17:
assertion failed: `(left == right)`: memory mismatch'
  left: `"[]"`
 right: `"[\"0x0000000000000000000000000000000000000000000000000000000000000000\"]"`
```

## Root Cause

`Bytecode::const_memory_accesses` decodes `LOG1..LOG4` memory operands using topic-shifted depths:

```rust
op::LOG3 => [Some((operand(3), operand(4))), None],
```

For EVM stack order, the true memory operands for every `LOGn` are still `operand(0)` for offset and `operand(1)` for length; the topics are above those depths. Reading topic operands as `(offset, len)` makes memory-section analysis believe memory was already expanded by the `LOG`, which can remove or understate a later `Mresize`.
