### PR TITLE
test: add stack underflow ASan regression

### DIFF
--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -2247,6 +2247,16 @@ fn bytecode_ternop(op: u8, a: U256, b: U256, c: U256) -> [u8; 100] {
     code
 }
 
+matrix_tests!(
+    stack_underflow_failure_does_not_write_below_stack = |jit| {
+        let bytecode = hex!(
+            "554242524058654061ff62f8a083ffffffff7fffffffffff01ff055865404040405557010142423e32475135353447474747473d473332949ff247474747473d473332989ff24332923b323a"
+        );
+        let test_case = TestCase::what_interpreter_says(&bytecode, SpecId::PRAGUE);
+        run_test_case(&test_case, jit);
+    }
+);
+
 /// Build opaque unop bytecode: MSTORE(a, 0), MLOAD(0), `<op>`.
 fn bytecode_unop_opaque(opcode: u8, a: U256) -> Vec<u8> {
     let mut code = Vec::with_capacity(64);


### PR DESCRIPTION
Adds the minimized ASan fuzz artifact as a regression test for stack-failure paths.

The test exercises the compiled-vs-interpreter path for this bytecode under Prague:

```text
0x554242524058654061ff62f8a083ffffffff7fffffffffff01ff055865404040405557010142423e32475135353447474747473d473332949ff247474747473d473332989ff24332923b323a
```

This branch is based directly on current `origin/main` (`6917dae`, `fix: sync stack for diverging builtins (#394)`) and contains only this regression test.

## Reproduction

Normal test run:

```bash
PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
LLVM_SYS_221_PREFIX="/opt/homebrew/Cellar/llvm/22.1.7_1" \
cargo nextest run --workspace "stack_underflow_failure_does_not_write_below_stack"
```

ASan run:

```bash
PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
LLVM_SYS_221_PREFIX="/opt/homebrew/Cellar/llvm/22.1.7_1" \
RUSTFLAGS="-Zsanitizer=address" \
ASAN_OPTIONS="detect_leaks=0" \
cargo +nightly test -p revmc-codegen stack_underflow_failure_does_not_write_below_stack --target aarch64-apple-darwin
```

## Output

Normal nextest output on current `main`:

```text
Summary [   0.031s] 2 tests run: 2 passed, 2294 skipped
```

ASan output on current `main`:

```text
running 2 tests
test tests::stack_underflow_failure_does_not_write_below_stack::llvm::unopt ... ok
test tests::stack_underflow_failure_does_not_write_below_stack::llvm::opt ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2184 filtered out; finished in 0.02s
```

## Root Cause

The original sanitizer finding was an invalid memory access on a compiled stack-failure path for this minimized bytecode. The relevant invariant is that compiler-generated failure returns, including stack-underflow exits, must not materialize or write virtual stack slots outside the actual live stack.

Current `main` no longer reproduces the ASan failure after the shared failure/return stack-sync fix in #394, so this PR keeps the minimized artifact as a guard against reintroducing that class of failure-path stack corruption.
