### PR TITLE
fix: use log memory operands for analysis

### DIFF
--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -710,7 +710,7 @@ impl<'a> Bytecode<'a> {
         let operand =
             |depth| self.const_operand(inst, depth).and_then(|value| u64::try_from(value).ok());
         match data.opcode {
-            op::KECCAK256 | op::RETURN | op::REVERT | op::LOG0 => {
+            op::KECCAK256 | op::RETURN | op::REVERT | op::LOG0..=op::LOG4 => {
                 [Some((operand(0), operand(1))), None]
             }
             op::MLOAD | op::MSTORE => [Some((operand(0), Some(32))), None],
@@ -723,10 +723,6 @@ impl<'a> Bytecode<'a> {
                 Some((operand(0).zip(operand(1)).map(|(dst, src)| dst.max(src)), operand(2))),
                 None,
             ],
-            op::LOG1 => [Some((operand(1), operand(2))), None],
-            op::LOG2 => [Some((operand(2), operand(3))), None],
-            op::LOG3 => [Some((operand(3), operand(4))), None],
-            op::LOG4 => [Some((operand(4), operand(5))), None],
             op::CREATE | op::CREATE2 => [Some((operand(1), operand(2))), None],
             op::CALL | op::CALLCODE => {
                 [Some((operand(3), operand(4))), Some((operand(5), operand(6)))]

--- a/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
+++ b/crates/revmc-codegen/src/bytecode/passes/memory_sections.rs
@@ -540,6 +540,15 @@ mod tests {
     }
 
     #[test]
+    fn log_topics_do_not_affect_memory_range() {
+        let bytecode = analyze_asm("PUSH 2048 PUSH0 PUSH0 PUSH0 PUSH0 LOG3 STOP");
+        let log3 = nth_inst(&bytecode, op::LOG3, 0);
+
+        assert_eq!(bytecode.const_memory_access(log3), Some((Some(0), Some(0))));
+        assert_eq!(section(&bytecode, log3), MemorySection::default());
+    }
+
+    #[test]
     fn call_tracks_input_and_output_memory_ranges() {
         let bytecode = analyze_asm(
             "

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -1283,7 +1283,10 @@ tests! {
             }),
         }),
         log3_topic_does_not_resize_memory(@raw {
-            bytecode: &hex!("6108005f5f5f5fa35f5f52"),
+            bytecode: &[
+                op::PUSH2, 0x08, 0x00, op::PUSH0, op::PUSH0, op::PUSH0, op::PUSH0, op::LOG3,
+                op::PUSH0, op::PUSH0, op::MSTORE,
+            ],
             expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
             expected_gas: GAS_WHAT_INTERPRETER_SAYS,
         }),

--- a/crates/revmc-codegen/src/tests/mod.rs
+++ b/crates/revmc-codegen/src/tests/mod.rs
@@ -1282,6 +1282,11 @@ tests! {
                 }]);
             }),
         }),
+        log3_topic_does_not_resize_memory(@raw {
+            bytecode: &hex!("6108005f5f5f5fa35f5f52"),
+            expected_memory: MEMORY_WHAT_INTERPRETER_SAYS,
+            expected_gas: GAS_WHAT_INTERPRETER_SAYS,
+        }),
         create(@raw {
             bytecode: &[op::PUSH1, 0x69, op::PUSH0, op::MSTORE, op::PUSH1, 32, op::PUSH0, op::PUSH1, 0x42, op::CREATE],
             expected_return: InstructionResult::Stop,


### PR DESCRIPTION
Fixes constant memory access analysis for `LOG1..LOG4` by reading the actual memory offset and length operands at stack depths 0 and 1. Topic operands are higher on the stack and should not affect memory expansion analysis.

This supersedes #398 with the fix plus the regression bytecode added as a normal codegen test using explicit opcodes.
