### PR TITLE
perf: initialize only native LLVM target

### DIFF
--- a/crates/revmc-llvm/src/lib.rs
+++ b/crates/revmc-llvm/src/lib.rs
@@ -2077,7 +2077,7 @@ fn init_() -> Result<()> {
         info: true,
         machine_code: true,
     };
-    Target::initialize_all(&config);
+    Target::initialize_native(&config).map_err(|e| eyre::eyre!("{e}"))?;
 
     Ok(())
 }

--- a/crates/revmc-runtime/src/runtime/mod.rs
+++ b/crates/revmc-runtime/src/runtime/mod.rs
@@ -387,9 +387,7 @@ impl JitBackend {
             .inner
             .shared
             .pause_depth
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |depth| {
-                Some(depth.saturating_sub(1))
-            })
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |depth| Some(depth.saturating_sub(1)))
             .is_ok_and(|depth| depth == 1)
         {
             self.try_send_control(Command::Resume);


### PR DESCRIPTION
Initialize only the host LLVM target instead of every target built into LLVM. revmc creates target machines for the native triple, so retaining the other target backends is unnecessary. Initialization failures are now propagated as well.

## Binary size

The `revmc` CLI was built against LLVM 22.1.8 component archives with `llvm-prefer-static`; both outputs were confirmed to have no dynamic LLVM dependency.

| Profile | Before | After | Change |
| --- | ---: | ---: | ---: |
| `profiling` | 254,582,504 bytes | 177,592,928 bytes | -76,989,576 bytes (-30.24%) |
| `maxperf` | 143,331,920 bytes | 76,399,256 bytes | -66,932,664 bytes (-46.70%) |
