### PR TITLE
feat: glamsterdam-devnet-7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,17 +3023,17 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-handler 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-inspector 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-interpreter 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3043,9 +3043,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "bitvec",
  "paste",
  "phf",
- "revm-primitives",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3058,11 +3067,26 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-context"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3076,9 +3100,23 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3088,13 +3126,26 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
 dependencies = [
+ "derive_more",
+ "either",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-database"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3106,8 +3157,20 @@ checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3120,14 +3183,31 @@ checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-interpreter 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-precompile 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-handler"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3139,12 +3219,27 @@ checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-database-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-handler 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-interpreter 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
  "serde_json",
 ]
@@ -3155,10 +3250,21 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-context-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-state 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
@@ -3175,12 +3281,33 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd",
+ "sha2",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
  "c-kzg",
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
- "revm-primitives",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -3191,6 +3318,15 @@ name = "revm-primitives"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3206,24 +3342,35 @@ dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
  "nonmax",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm-primitives 41.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "revm-state"
+version = "41.0.0"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+dependencies = [
+ "alloy-eip7928 0.4.3",
+ "bitflags",
+ "nonmax",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
 ]
 
 [[package]]
 name = "revm-statetest-types"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ced634104a9857185f02a7a3a5dd4a503590fababafbb295ad213df6dbf302"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-primitives",
- "revm-state",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3233,12 +3380,12 @@ dependencies = [
 name = "revmc"
 version = "0.1.0"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3266,10 +3413,10 @@ name = "revmc-builtins"
 version = "0.1.0"
 dependencies = [
  "paste",
- "revm-bytecode",
- "revm-context-interface",
- "revm-interpreter",
- "revm-primitives",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -3286,15 +3433,15 @@ dependencies = [
  "hex",
  "libloading",
  "open",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revm-statetest-types",
  "revmc",
  "revmc-build",
@@ -3327,15 +3474,15 @@ dependencies = [
  "indexmap 2.14.0",
  "oxc_index",
  "paste",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3355,13 +3502,13 @@ dependencies = [
 name = "revmc-context"
 version = "0.1.0"
 dependencies = [
- "revm-context",
- "revm-context-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "ruint",
 ]
 
@@ -3380,13 +3527,13 @@ name = "revmc-examples-runner"
 version = "0.1.0"
 dependencies = [
  "cc",
- "revm-bytecode",
- "revm-context",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revmc",
  "revmc-build",
  "revmc-builtins",
@@ -3431,16 +3578,16 @@ dependencies = [
  "paste",
  "quanta",
  "rayon",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -3467,16 +3614,16 @@ dependencies = [
  "indicatif",
  "k256",
  "libloading",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
  "revm-statetest-types",
  "revmc",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,12 +3049,12 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "paste",
  "phf",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3077,16 +3077,16 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3108,15 +3108,15 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3137,15 +3137,15 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3165,12 +3165,12 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3196,18 +3196,18 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3230,16 +3230,16 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
  "serde_json",
 ]
@@ -3259,12 +3259,12 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3306,8 +3306,8 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3349,28 +3349,28 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
  "nonmax",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
 ]
 
 [[package]]
 name = "revm-statetest-types"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3380,12 +3380,12 @@ dependencies = [
 name = "revmc"
 version = "0.1.0"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3413,10 +3413,10 @@ name = "revmc-builtins"
 version = "0.1.0"
 dependencies = [
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -3433,15 +3433,15 @@ dependencies = [
  "hex",
  "libloading",
  "open",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revm-statetest-types",
  "revmc",
  "revmc-build",
@@ -3474,15 +3474,15 @@ dependencies = [
  "indexmap 2.14.0",
  "oxc_index",
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3502,13 +3502,13 @@ dependencies = [
 name = "revmc-context"
 version = "0.1.0"
 dependencies = [
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "ruint",
 ]
 
@@ -3527,13 +3527,13 @@ name = "revmc-examples-runner"
 version = "0.1.0"
 dependencies = [
  "cc",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revmc",
  "revmc-build",
  "revmc-builtins",
@@ -3578,16 +3578,16 @@ dependencies = [
  "paste",
  "quanta",
  "rayon",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -3614,16 +3614,16 @@ dependencies = [
  "indicatif",
  "k256",
  "libloading",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
  "revm-statetest-types",
  "revmc",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,12 +3049,12 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "bitvec",
  "paste",
  "phf",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3077,16 +3077,16 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3108,15 +3108,15 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3137,15 +3137,15 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3165,12 +3165,12 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3196,18 +3196,18 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3230,16 +3230,16 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
  "serde_json",
 ]
@@ -3259,12 +3259,12 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3306,8 +3306,8 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3349,28 +3349,28 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
  "nonmax",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
 ]
 
 [[package]]
 name = "revm-statetest-types"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3380,12 +3380,12 @@ dependencies = [
 name = "revmc"
 version = "0.1.0"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3413,10 +3413,10 @@ name = "revmc-builtins"
 version = "0.1.0"
 dependencies = [
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -3433,15 +3433,15 @@ dependencies = [
  "hex",
  "libloading",
  "open",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revm-statetest-types",
  "revmc",
  "revmc-build",
@@ -3474,15 +3474,15 @@ dependencies = [
  "indexmap 2.14.0",
  "oxc_index",
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3502,13 +3502,13 @@ dependencies = [
 name = "revmc-context"
 version = "0.1.0"
 dependencies = [
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "ruint",
 ]
 
@@ -3527,13 +3527,13 @@ name = "revmc-examples-runner"
 version = "0.1.0"
 dependencies = [
  "cc",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revmc",
  "revmc-build",
  "revmc-builtins",
@@ -3578,16 +3578,16 @@ dependencies = [
  "paste",
  "quanta",
  "rayon",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -3614,16 +3614,16 @@ dependencies = [
  "indicatif",
  "k256",
  "libloading",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
  "revm-statetest-types",
  "revmc",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2064,7 +2064,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3049,12 +3049,12 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "paste",
  "phf",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3077,16 +3077,16 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3108,15 +3108,15 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3137,15 +3137,15 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3165,12 +3165,12 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3196,18 +3196,18 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-precompile 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3230,16 +3230,16 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
  "serde_json",
 ]
@@ -3259,12 +3259,12 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3306,8 +3306,8 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3349,28 +3349,28 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
  "nonmax",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
 ]
 
 [[package]]
 name = "revm-statetest-types"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3380,12 +3380,12 @@ dependencies = [
 name = "revmc"
 version = "0.1.0"
 dependencies = [
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3413,10 +3413,10 @@ name = "revmc-builtins"
 version = "0.1.0"
 dependencies = [
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -3433,15 +3433,15 @@ dependencies = [
  "hex",
  "libloading",
  "open",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revm-statetest-types",
  "revmc",
  "revmc-build",
@@ -3474,15 +3474,15 @@ dependencies = [
  "indexmap 2.14.0",
  "oxc_index",
  "paste",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -3502,13 +3502,13 @@ dependencies = [
 name = "revmc-context"
 version = "0.1.0"
 dependencies = [
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "ruint",
 ]
 
@@ -3527,13 +3527,13 @@ name = "revmc-examples-runner"
 version = "0.1.0"
 dependencies = [
  "cc",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revmc",
  "revmc-build",
  "revmc-builtins",
@@ -3578,16 +3578,16 @@ dependencies = [
  "paste",
  "quanta",
  "rayon",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -3614,16 +3614,16 @@ dependencies = [
  "indicatif",
  "k256",
  "libloading",
- "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
- "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9)",
+ "revm-bytecode 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-context-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-database-interface 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-handler 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-inspector 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-interpreter 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-primitives 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
+ "revm-state 41.0.0 (git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f)",
  "revm-statetest-types",
  "revmc",
  "serde_json",
@@ -3744,7 +3744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4169,7 +4169,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4694,7 +4694,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,17 +49,17 @@ alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false, features = ["parse"] }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
-revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false, features = ["parse"] }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,17 +49,17 @@ alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 
-revm-bytecode = { version = "41.0.0", default-features = false, features = ["parse"] }
-revm-context = { version = "41.0.0", default-features = false }
-revm-context-interface = { version = "41.0.0", default-features = false }
-revm-database = { version = "41.0.0", default-features = false }
-revm-database-interface = { version = "41.0.0", default-features = false }
-revm-handler = { version = "41.0.0", default-features = false }
-revm-inspector = { version = "41.0.0", default-features = false }
-revm-interpreter = { version = "41.0.0", default-features = false }
-revm-primitives = { version = "41.0.0", default-features = false }
-revm-state = { version = "41.0.0", default-features = false }
-revm-statetest-types = { version = "41.0.0", default-features = false }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false, features = ["parse"] }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,17 +49,17 @@ alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false, features = ["parse"] }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
-revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558", default-features = false }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false, features = ["parse"] }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
+revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,17 +49,17 @@ alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false, features = ["parse"] }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
-revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9", default-features = false }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false, features = ["parse"] }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
+revm-statetest-types = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -2114,8 +2114,10 @@ mod pf {
         pub(super) remaining: u64,
         /// State gas reservoir (EIP-8037).
         pub(super) reservoir: u64,
-        /// Total state gas spent.
-        pub(super) state_gas_spent: u64,
+        /// Net state gas spent.
+        pub(super) state_gas_spent: i64,
+        /// State gas drawn from regular gas because the reservoir was empty (EIP-8037).
+        pub(super) state_gas_spilled: u64,
         /// Refunded gas.
         pub(super) refunded: i64,
     }

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -136,9 +136,9 @@ const _: () = {
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
-    assert!(offset_of!(EvmContext<'_>, spec_id) == 113);
-    assert!(offset_of!(EvmContext<'_>, resume_at) == 120);
-    assert!(offset_of!(EvmContext<'_>, calldatasize) == 160);
+    assert!(offset_of!(EvmContext<'_>, spec_id) == 121);
+    assert!(offset_of!(EvmContext<'_>, resume_at) == 128);
+    assert!(offset_of!(EvmContext<'_>, calldatasize) == 168);
 };
 
 impl fmt::Debug for EvmContext<'_> {

--- a/crates/revmc-statetest/src/compiled.rs
+++ b/crates/revmc-statetest/src/compiled.rs
@@ -167,7 +167,9 @@ fn execute_test_suite_runtime(
                         return Err(TestError {
                             name,
                             path: path_str,
-                            kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
+                            kind: TestErrorKind::UnknownPrivateKey(
+                                unit.transaction.secret_key.unwrap_or_default(),
+                            ),
                         });
                     }
                 };

--- a/crates/revmc-statetest/src/compiled.rs
+++ b/crates/revmc-statetest/src/compiled.rs
@@ -56,7 +56,7 @@ fn execute_single_test_runtime(
     journal.set_spec_id(*evm.ctx.cfg.spec());
     journal.set_eip7708_config(
         evm.ctx.cfg.is_eip7708_disabled(),
-        evm.ctx.cfg.is_eip7708_delayed_burn_disabled(),
+        evm.ctx.cfg.is_eip8246_delayed_clear_disabled(),
     );
 
     let timer = Instant::now();

--- a/crates/revmc-statetest/src/runner.rs
+++ b/crates/revmc-statetest/src/runner.rs
@@ -314,7 +314,9 @@ pub fn execute_test_suite(
                         return Err(TestError {
                             name,
                             path,
-                            kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
+                            kind: TestErrorKind::UnknownPrivateKey(
+                                unit.transaction.secret_key.unwrap_or_default(),
+                            ),
                         });
                     }
                 };


### PR DESCRIPTION
Glamsterdam devnet-7 integration, on top of the glam-devnet-6 branch.

- Bumps revm git pins to `glam-devnet-7` tip (bluealloy/revm#3795, rev `0c688c68`)
- Adapts the statetest runner to `secret_key` becoming `Option<B256>`

Devnet branch — not for merge into main.