### PR TITLE
feat(cli): honor --gas-limit for path/custom bytecode fixtures

### DIFF
--- a/crates/revmc-cli/src/benches.rs
+++ b/crates/revmc-cli/src/benches.rs
@@ -36,7 +36,7 @@ pub fn fixture_from_bytecode(
     "env": {{
       "currentBaseFee": "0x0",
       "currentCoinbase": "0x0000000000000000000000000000000000000000",
-      "currentGasLimit": "0x{gas_limit:x}",
+      "currentGasLimit": "{gas_limit}",
       "currentNumber": "0x1",
       "currentTimestamp": "0x1"
     }},

--- a/crates/revmc-cli/src/benches.rs
+++ b/crates/revmc-cli/src/benches.rs
@@ -20,8 +20,14 @@ impl Bench {
     }
 }
 
-pub fn fixture_from_bytecode(name: &'static str, bytecode: Vec<u8>, spec_id: SpecId) -> Bench {
+pub fn fixture_from_bytecode(
+    name: &'static str,
+    bytecode: Vec<u8>,
+    spec_id: SpecId,
+    gas_limit: u64,
+) -> Bench {
     let bytecode = revmc::primitives::hex::encode(bytecode);
+    let gas_limit = format!("0x{gas_limit:x}");
     Bench {
         name,
         fixture_json: Some(Cow::Owned(format!(
@@ -30,7 +36,7 @@ pub fn fixture_from_bytecode(name: &'static str, bytecode: Vec<u8>, spec_id: Spe
     "env": {{
       "currentBaseFee": "0x0",
       "currentCoinbase": "0x0000000000000000000000000000000000000000",
-      "currentGasLimit": "0x7fffffffffffffff",
+      "currentGasLimit": "0x{gas_limit:x}",
       "currentNumber": "0x1",
       "currentTimestamp": "0x1"
     }},
@@ -51,7 +57,7 @@ pub fn fixture_from_bytecode(name: &'static str, bytecode: Vec<u8>, spec_id: Spe
     "transaction": [
       {{
         "data": "0x",
-        "gasLimit": "0x7fffffffffffffff",
+        "gasLimit": "{gas_limit}",
         "gasPrice": "0x0",
         "nonce": "0x0",
         "sender": "0x1111111111111111111111111111111111111111",

--- a/crates/revmc-cli/src/cmd/run.rs
+++ b/crates/revmc-cli/src/cmd/run.rs
@@ -136,7 +136,12 @@ impl RunArgs {
                     .to_string();
                 (stem, path.to_path_buf())
             };
-            fixture_from_bytecode(name.leak(), read_code_path(&bytecode_path)?, spec_id)
+            fixture_from_bytecode(
+                name.leak(),
+                read_code_path(&bytecode_path)?,
+                spec_id,
+                self.gas_limit,
+            )
         } else {
             let bytecode = read_code_string(bench_name.trim().as_bytes(), None).map_err(|e| {
                 eyre!(
@@ -144,7 +149,7 @@ impl RunArgs {
                      or valid EVM hex/asm: {e}"
                 )
             })?;
-            fixture_from_bytecode("custom", bytecode, spec_id)
+            fixture_from_bytecode("custom", bytecode, spec_id, self.gas_limit)
         };
 
         let name = bench_entry.name;


### PR DESCRIPTION
## Summary
- Pass `--gas-limit` into `fixture_from_bytecode` for path and custom (hex/asm) inputs.
- Set both `currentGasLimit` and transaction `gasLimit` from that value instead of hardcoding `0x7fffffffffffffff`.
- Named catalog benches are unchanged (they keep their JSON fixture gas limits).

## Test plan
- [ ] `cargo r -- run 0x6001600201 --gas-limit 100000` runs successfully
- [ ] Same without `--gas-limit` uses the default (`1000000000`)
- [ ] Named bench (`cargo r -- run usdc_proxy`) still works as before