### PR TITLE
chore: bump revm to 42.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,14 +161,13 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
+version = "0.37.1"
+source = "git+https://github.com/alloy-rs/evm?rev=28062bcdec074ff7344cebcd3bea95dbf5f2361b#28062bcdec074ff7344cebcd3bea95dbf5f2361b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -430,43 +429,43 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-r1cs-std",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -532,6 +531,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +572,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -600,31 +626,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-poly"
-version = "0.5.0"
+name = "ark-ff-macros"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-relations",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "educe",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -633,14 +673,18 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-poly",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -670,7 +714,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -678,10 +721,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
+name = "ark-serialize"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -713,6 +769,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -946,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -1625,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1865,7 +1931,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
  "foldhash 0.1.5",
 ]
 
@@ -1875,6 +1940,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2064,7 +2130,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2097,6 +2163,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2138,7 +2213,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2275,7 +2350,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2346,7 +2421,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2545,7 +2620,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2619,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2630,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -2640,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2653,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -3019,9 +3094,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "revm"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+checksum = "0087201ffe574cebaf478f07e93657f680037b36743b0e37c4c94d63483cd2d8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3038,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "paste",
@@ -3051,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3068,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3084,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -3100,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -3114,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+checksum = "4581161baf64b8a0f7613f7a7d05a1fba6f5c78d1a51d125a97b5f09610c9ee4"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3133,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+checksum = "7a5ae9c22c149c7c99b599dbb3b0ca6ba1a2938410b30c0603e74afc03bb59f8"
 dependencies = [
  "auto_impl",
  "either",
@@ -3151,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3164,15 +3239,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+checksum = "1283c9ea7b635ce7514a694ffb60a1662c398f60ddb712cf21f2a50e3d29babd"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
  "c-kzg",
@@ -3183,14 +3258,14 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3199,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
@@ -3213,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ced634104a9857185f02a7a3a5dd4a503590fababafbb295ad213df6dbf302"
+checksum = "b61ce97f20c478a2b9be24e967d7c6481301d466a47b3c13dd3b030a7a93709d"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",
@@ -3302,7 +3377,7 @@ dependencies = [
  "revmc-statetest",
  "serde",
  "serde_json",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracing-tracy",
 ]
 
@@ -3348,7 +3423,7 @@ dependencies = [
  "snapbox",
  "tempfile",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3450,7 +3525,7 @@ dependencies = [
  "similar-asserts",
  "tempfile",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "wait-timeout",
  "wincode",
 ]
@@ -3484,7 +3559,7 @@ dependencies = [
  "thiserror 2.0.18",
  "thread_local",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -3500,11 +3575,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3597,7 +3672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3806,6 +3881,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4022,7 +4108,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4231,7 +4317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4242,15 +4328,6 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 
@@ -4279,7 +4356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracy-client",
 ]
 
@@ -4547,7 +4624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=28062bcdec074ff7344cebcd3bea95dbf5f2361b#28062bcdec074ff7344cebcd3bea95dbf5f2361b"
+source = "git+https://github.com/alloy-rs/evm?rev=42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8#42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1691,7 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2421,7 +2421,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3672,7 +3672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4108,7 +4108,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4624,7 +4624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,17 +49,17 @@ alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
 alloy-evm = { version = "0.37.0", default-features = false }
 
-revm-bytecode = { version = "41.0.0", default-features = false, features = ["parse"] }
-revm-context = { version = "41.0.0", default-features = false }
-revm-context-interface = { version = "41.0.0", default-features = false }
-revm-database = { version = "41.0.0", default-features = false }
-revm-database-interface = { version = "41.0.0", default-features = false }
-revm-handler = { version = "41.0.0", default-features = false }
-revm-inspector = { version = "41.0.0", default-features = false }
-revm-interpreter = { version = "41.0.0", default-features = false }
-revm-primitives = { version = "41.0.0", default-features = false }
-revm-state = { version = "41.0.0", default-features = false }
-revm-statetest-types = { version = "41.0.0", default-features = false }
+revm-bytecode = { version = "42.0.0", default-features = false, features = ["parse"] }
+revm-context = { version = "42.0.0", default-features = false }
+revm-context-interface = { version = "42.0.0", default-features = false }
+revm-database = { version = "42.0.0", default-features = false }
+revm-database-interface = { version = "42.0.0", default-features = false }
+revm-handler = { version = "42.0.0", default-features = false }
+revm-inspector = { version = "42.0.0", default-features = false }
+revm-interpreter = { version = "42.0.0", default-features = false }
+revm-primitives = { version = "42.0.0", default-features = false }
+revm-state = { version = "42.0.0", default-features = false }
+revm-statetest-types = { version = "42.0.0", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
@@ -96,3 +96,8 @@ strip = false
 
 [profile.bench]
 inherits = "profiling"
+
+# TODO: remove once a version of alloy-evm built against revm 42 is released.
+# Needed so the optional `alloy-evm` feature resolves a single revm in the graph.
+[patch.crates-io]
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "28062bcdec074ff7344cebcd3bea95dbf5f2361b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,4 +100,4 @@ inherits = "profiling"
 # TODO: remove once a version of alloy-evm built against revm 42 is released.
 # Needed so the optional `alloy-evm` feature resolves a single revm in the graph.
 [patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "28062bcdec074ff7344cebcd3bea95dbf5f2361b" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8" }

--- a/crates/revmc-codegen/src/bytecode/asm.rs
+++ b/crates/revmc-codegen/src/bytecode/asm.rs
@@ -307,8 +307,8 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
 
     let name = match tok.next() {
         Some(Token { src, kind: TokenKind::Ident }) => src,
-        Some(other) => eyre::bail!("expected macro name after #define, got {other:?}"),
-        None => eyre::bail!("expected macro name after #define"),
+        Some(other) => return Err(eyre::eyre!("expected macro name after #define, got {other:?}")),
+        None => return Err(eyre::eyre!("expected macro name after #define")),
     };
 
     // Function-like macro: NAME(a, b).
@@ -330,7 +330,9 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
                         i += 1;
                     }
                     other => {
-                        eyre::bail!("expected parameter name in #define {name}, got {other:?}")
+                        return Err(eyre::eyre!(
+                            "expected parameter name in #define {name}, got {other:?}"
+                        ));
                     }
                 }
                 match all_tokens.get(i) {
@@ -339,9 +341,11 @@ fn parse_define<'a>(after: &'a str, macros: &mut HashMap<&'a str, MacroDef<'a>>)
                         break;
                     }
                     Some(Token { kind: TokenKind::Comma, .. }) => i += 1,
-                    other => eyre::bail!(
-                        "expected ',' or ')' in #define {name} parameter list, got {other:?}"
-                    ),
+                    other => {
+                        return Err(eyre::eyre!(
+                            "expected ',' or ')' in #define {name} parameter list, got {other:?}"
+                        ));
+                    }
                 }
             }
         } else {
@@ -571,8 +575,8 @@ fn parse_items<'a>(tokens: &[Token<'a>]) -> Result<Vec<Item<'a>>> {
                     }
                 }
             }
-            TokenKind::Unknown => eyre::bail!("unexpected token: {:?}", tokens[i].src),
-            _ => eyre::bail!("unexpected token: {:?}", tokens[i]),
+            TokenKind::Unknown => return Err(eyre::eyre!("unexpected token: {:?}", tokens[i].src)),
+            _ => return Err(eyre::eyre!("unexpected token: {:?}", tokens[i])),
         }
     }
     Ok(items)
@@ -592,7 +596,7 @@ fn expect_number_u8(
                 n.try_into().map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))?;
             u8::try_from(v).map_err(|_| eyre::eyre!("invalid {ctx} immediate: too large"))
         }
-        _ => eyre::bail!("expected numeric immediate for {ctx}, got {tok:?}"),
+        _ => Err(eyre::eyre!("expected numeric immediate for {ctx}, got {tok:?}")),
     }
 }
 
@@ -607,7 +611,7 @@ fn expect_imm<'a>(
     match &tok.kind {
         TokenKind::Number(n) => Ok(Imm::Number(*n)),
         TokenKind::LabelRef => Ok(Imm::Label(tok.src)),
-        _ => eyre::bail!("expected immediate for {ctx}, got {tok:?}"),
+        _ => Err(eyre::eyre!("expected immediate for {ctx}, got {tok:?}")),
     }
 }
 

--- a/crates/revmc-codegen/src/compiler/translate/mod.rs
+++ b/crates/revmc-codegen/src/compiler/translate/mod.rs
@@ -2114,8 +2114,10 @@ mod pf {
         pub(super) remaining: u64,
         /// State gas reservoir (EIP-8037).
         pub(super) reservoir: u64,
-        /// Total state gas spent.
-        pub(super) state_gas_spent: u64,
+        /// Net state gas spent.
+        pub(super) state_gas_spent: i64,
+        /// State gas drawn from regular gas because the reservoir was empty (EIP-8037).
+        pub(super) state_gas_spilled: u64,
         /// Refunded gas.
         pub(super) refunded: i64,
     }

--- a/crates/revmc-context/src/lib.rs
+++ b/crates/revmc-context/src/lib.rs
@@ -136,9 +136,9 @@ const _: () = {
     // Key fields accessed by JIT code
     assert!(offset_of!(EvmContext<'_>, memory) == 0);
     assert!(offset_of!(EvmContext<'_>, gas) == 16);
-    assert!(offset_of!(EvmContext<'_>, spec_id) == 113);
-    assert!(offset_of!(EvmContext<'_>, resume_at) == 120);
-    assert!(offset_of!(EvmContext<'_>, calldatasize) == 160);
+    assert!(offset_of!(EvmContext<'_>, spec_id) == 121);
+    assert!(offset_of!(EvmContext<'_>, resume_at) == 128);
+    assert!(offset_of!(EvmContext<'_>, calldatasize) == 168);
 };
 
 impl fmt::Debug for EvmContext<'_> {

--- a/crates/revmc-runtime/src/runtime/out_of_process.rs
+++ b/crates/revmc-runtime/src/runtime/out_of_process.rs
@@ -724,7 +724,7 @@ fn read_helper_init<R: Read + ?Sized>(stdin: &mut BufReader<R>) -> eyre::Result<
     match read_message(stdin)? {
         HelperRequest::Init(init) => runtime_config_from_init(init),
         HelperRequest::Compile(_) | HelperRequest::Pause { .. } | HelperRequest::Resume => {
-            eyre::bail!("JIT helper received request before init")
+            Err(eyre::eyre!("JIT helper received request before init"))
         }
     }
 }
@@ -740,7 +740,9 @@ fn read_helper_request<R: Read + ?Sized>(stdin: &mut BufReader<R>) -> eyre::Resu
         HelperRequest::Compile(req) => req,
         HelperRequest::Pause { id } => return Ok(HelperWork::Pause { id }),
         HelperRequest::Resume => return Ok(HelperWork::Resume),
-        HelperRequest::Init(_) => eyre::bail!("JIT helper received duplicate init"),
+        HelperRequest::Init(_) => {
+            return Err(eyre::eyre!("JIT helper received duplicate init"));
+        }
     };
     let spec_id = SpecId::try_from_u8(req.spec_id).ok_or_else(|| eyre::eyre!("invalid spec id"))?;
     let opt_level = opt_level_from_u8(req.opt_level)?;
@@ -827,7 +829,7 @@ fn opt_level_from_u8(level: u8) -> eyre::Result<OptimizationLevel> {
         1 => OptimizationLevel::Less,
         2 => OptimizationLevel::Default,
         3 => OptimizationLevel::Aggressive,
-        _ => eyre::bail!("invalid optimization level"),
+        _ => return Err(eyre::eyre!("invalid optimization level")),
     })
 }
 

--- a/crates/revmc-statetest/src/compiled.rs
+++ b/crates/revmc-statetest/src/compiled.rs
@@ -56,7 +56,7 @@ fn execute_single_test_runtime(
     journal.set_spec_id(*evm.ctx.cfg.spec());
     journal.set_eip7708_config(
         evm.ctx.cfg.is_eip7708_disabled(),
-        evm.ctx.cfg.is_eip7708_delayed_burn_disabled(),
+        evm.ctx.cfg.is_eip8246_delayed_clear_disabled(),
     );
 
     let timer = Instant::now();
@@ -167,7 +167,9 @@ fn execute_test_suite_runtime(
                         return Err(TestError {
                             name,
                             path: path_str,
-                            kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
+                            kind: TestErrorKind::UnknownPrivateKey(
+                                unit.transaction.secret_key.unwrap_or_default(),
+                            ),
                         });
                     }
                 };

--- a/crates/revmc-statetest/src/runner.rs
+++ b/crates/revmc-statetest/src/runner.rs
@@ -314,7 +314,9 @@ pub fn execute_test_suite(
                         return Err(TestError {
                             name,
                             path,
-                            kind: TestErrorKind::UnknownPrivateKey(unit.transaction.secret_key),
+                            kind: TestErrorKind::UnknownPrivateKey(
+                                unit.transaction.secret_key.unwrap_or_default(),
+                            ),
                         });
                     }
                 };


### PR DESCRIPTION
Bumps the `revm-*` crates to `42.0.0` (revm [v114](https://github.com/bluealloy/revm/releases/tag/v114)).

Source changes for the bump (already verified on the `glamsterdam-devnet-7` branch, which tracked the same revm changes):

- `revmc-context`: update the `EvmContext` layout static asserts (`spec_id` 113 -> 121, `resume_at` 120 -> 128, `calldatasize` 160 -> 168).
- `revmc-codegen`: mirror the new `GasTracker` layout — `state_gas_spent` is now `i64` (net, can go negative) and a new `state_gas_spilled: u64` field was added (EIP-8037 reservoir spill).
- `revmc-statetest`: `is_eip7708_delayed_burn_disabled` -> `is_eip8246_delayed_clear_disabled`, and `TransactionParts::secret_key` is now `Option<B256>`.

Temporary: a `[patch.crates-io]` entry points `alloy-evm` at https://github.com/alloy-rs/evm/pull/396 (`42a2afea`), since the released `alloy-evm 0.37.1` still depends on revm 41 and the optional `alloy-evm` feature would otherwise pull two revm versions into the graph. Drop the patch once an alloy-evm release with revm 42 is out.

### Unrelated CI fix

Recent nightlies turned `semicolon_in_expressions_from_macros` into a deny-by-default lint, and `eyre::bail!` expands with a trailing semicolon, so every `bail!` in expression position now fails to compile. This broke the nightly test, clippy and docs jobs (`main` is affected too — its last CI run predates the nightly change). Rewrote the 11 affected call sites in `revmc-codegen/src/bytecode/asm.rs` and `revmc-runtime/src/runtime/out_of_process.rs` as `return Err(eyre::eyre!(...))`, which sidesteps the upcoming hard error rather than allowing the lint.

Verified locally on nightly `1.99.0 (2026-07-22)`: clippy with `-Dwarnings`, the docs build with the CI's `RUSTDOCFLAGS`, 2297/2297 tests, and `cargo check --workspace --features revmc/alloy-evm`.