### PR TITLE
chore: bump alloy-evm to 0.38.0, drop git patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,8 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8#42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3094,9 +3095,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "revm"
-version = "42.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0087201ffe574cebaf478f07e93657f680037b36743b0e37c4c94d63483cd2d8"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3189,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4581161baf64b8a0f7613f7a7d05a1fba6f5c78d1a51d125a97b5f09610c9ee4"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3208,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5ae9c22c149c7c99b599dbb3b0ca6ba1a2938410b30c0603e74afc03bb59f8"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -3239,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1283c9ea7b635ce7514a694ffb60a1662c398f60ddb712cf21f2a50e3d29babd"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ revmc-runtime = { version = "0.1.0", path = "crates/revmc-runtime", default-feat
 
 alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
-alloy-evm = { version = "0.37.0", default-features = false }
+alloy-evm = { version = "0.38.0", default-features = false }
 
 revm-bytecode = { version = "42.0.0", default-features = false, features = ["parse"] }
 revm-context = { version = "42.0.0", default-features = false }
@@ -96,8 +96,3 @@ strip = false
 
 [profile.bench]
 inherits = "profiling"
-
-# TODO: remove once a version of alloy-evm built against revm 42 is released.
-# Needed so the optional `alloy-evm` feature resolves a single revm in the graph.
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "42a2afeaaa0f110e0d596f48d62be3e5a8f8afb8" }


### PR DESCRIPTION
Bumps `alloy-evm` to the just-released 0.38.0, which is built against revm 42. This lets us drop the `[patch.crates-io]` git pin on `alloy-rs/evm` that #406 added as a stopgap, so the optional `alloy-evm` feature now resolves a single revm from crates.io. The lockfile also picks up the revm 42.0.1 patch releases (`revm`, `revm-handler`, `revm-inspector`, `revm-precompile`) that alloy-evm 0.38 requires.

## glam-devnet-7 backport status

Audited `glamsterdam-devnet-7` against `main`; all of its code changes already landed with the revm 42 bump (#406) and match the released revm 42 crates:

- EIP-8037 `GasTracker` mirror in codegen: `state_gas_spent: i64` + new `state_gas_spilled: u64` — field order and sizes match released `revm-context-interface` 42.0.0 (`gas_limit, remaining, reservoir, state_gas_spent, state_gas_spilled, refunded`), enforced by the compile-time size assert.
- Updated `EvmContext` offset asserts (`spec_id`/`resume_at`/`calldatasize`).
- `is_eip8246_delayed_clear_disabled` rename and `Option`al `transaction.secret_key` handling in the statetest runner.

The only remaining diff on that branch is the older `eyre::eyre!`-style error returns, which #406 intentionally replaced with `eyre::bail!`-free forms to fix nightly trailing-semicolon errors — not backported.

Verified with `cargo cl` (clippy, `llvm,alloy-evm` features) and `cargo nextest run --workspace`: 2297 tests passed.
