### PR TITLE
fix(runtime): separate cold-entry and resident eviction

### DIFF
--- a/crates/revmc-runtime/src/runtime/backend.rs
+++ b/crates/revmc-runtime/src/runtime/backend.rs
@@ -242,6 +242,14 @@ impl BackendState {
     fn tick(&mut self) {
         self.drain_events();
         self.run_eviction_sweep();
+        self.update_entry_stats();
+    }
+
+    fn update_entry_stats(&self) {
+        self.inner.stats.tracked_entries.store(self.entries.len() as u64, Ordering::Relaxed);
+        let cold_entries =
+            self.entries.values().filter(|entry| entry.phase == EntryPhase::Cold).count();
+        self.inner.stats.cold_entries.store(cold_entries as u64, Ordering::Relaxed);
     }
 
     /// Drains all currently-queued lookup events.
@@ -312,6 +320,7 @@ impl BackendState {
         if matches!(mode, AdmitMode::Observed) {
             let max_entries = self.tuning.jit_max_pending_jobs * 10;
             if !self.entries.contains_key(&key) && self.entries.len() >= max_entries {
+                self.inner.stats.observed_entry_rejections.fetch_add(1, Ordering::Relaxed);
                 return;
             }
         }
@@ -726,6 +735,7 @@ impl BackendState {
         self.last_sweep = now;
 
         let idle_duration = self.tuning.idle_evict_duration;
+        let cold_idle_duration = self.tuning.cold_entry_idle_duration;
         let budget = self.tuning.resident_code_cache_bytes;
 
         // Phase 1: evict idle entries.
@@ -750,14 +760,19 @@ impl BackendState {
         }
 
         // Phase 2: evict stale cold entries that never became hot enough to compile.
-        if let Some(idle) = idle_duration {
+        if let Some(idle) = cold_idle_duration {
             let resident = &self.inner.resident;
+            let before = self.entries.len();
             self.entries.retain(|key, entry| {
                 let stale = entry.phase == EntryPhase::Cold
                     && now.duration_since(entry.last_observed_at) > idle
                     && !resident.contains_key(key);
                 !stale
             });
+            self.inner
+                .stats
+                .cold_entry_evictions
+                .fetch_add((before - self.entries.len()) as u64, Ordering::Relaxed);
         }
 
         // Phase 3: enforce memory budget by evicting LRU JIT entries.
@@ -797,7 +812,8 @@ impl BackendState {
         if maxrss > 0 && jit_total_bytes() > maxrss {
             return true;
         }
-        self.tuning.idle_evict_duration.is_some()
+        (self.tuning.idle_evict_duration.is_some()
+            || self.tuning.cold_entry_idle_duration.is_some())
             && self.last_sweep.elapsed() >= self.tuning.eviction_sweep_interval
     }
 }

--- a/crates/revmc-runtime/src/runtime/config.rs
+++ b/crates/revmc-runtime/src/runtime/config.rs
@@ -321,7 +321,15 @@ pub struct RuntimeTuning {
     /// Defaults to `None`.
     pub idle_evict_duration: Option<Duration>,
 
-    /// How often the backend runs eviction sweeps, if `idle_evict_duration` is set.
+    /// Duration after which a cold observed entry that has not reached the compilation threshold
+    /// is forgotten. This is independent from [`Self::idle_evict_duration`], so applications can
+    /// bound miss-tracking state without evicting resident compiled programs.
+    /// `None` disables cold-entry eviction.
+    ///
+    /// Defaults to `10min`.
+    pub cold_entry_idle_duration: Option<Duration>,
+
+    /// How often the backend runs eviction sweeps, if resident or cold-entry idle eviction is set.
     ///
     /// Defaults to `60s`.
     pub eviction_sweep_interval: Duration,
@@ -369,6 +377,7 @@ impl Default for RuntimeTuning {
             aot_opt_level: crate::OptimizationLevel::default(),
             resident_code_cache_bytes: 1024 * 1024 * 1024,
             idle_evict_duration: Some(Duration::from_secs(600)),
+            cold_entry_idle_duration: Some(Duration::from_secs(600)),
             eviction_sweep_interval: Duration::from_secs(60),
             compiler_recycle_threshold: 1000,
         }

--- a/crates/revmc-runtime/src/runtime/stats.rs
+++ b/crates/revmc-runtime/src/runtime/stats.rs
@@ -11,6 +11,14 @@ pub(crate) struct RuntimeStats {
     pub(crate) lookup_misses: AtomicU64,
     /// Total lookup events dropped due to event-queue overflow.
     pub(crate) events_dropped: AtomicU64,
+    /// Total observed entries rejected because the cold-entry tracking table was full.
+    pub(crate) observed_entry_rejections: AtomicU64,
+    /// Number of observed entries currently tracked for hotness or compilation.
+    pub(crate) tracked_entries: AtomicU64,
+    /// Number of tracked entries that have not reached the compilation threshold.
+    pub(crate) cold_entries: AtomicU64,
+    /// Total stale cold entries forgotten by idle eviction.
+    pub(crate) cold_entry_evictions: AtomicU64,
     /// Total control commands dropped because the command channel was full.
     pub(crate) commands_dropped: AtomicU64,
     /// Total number of entries evicted (idle + budget).
@@ -62,6 +70,14 @@ pub struct RuntimeStatsSnapshot {
     pub lookup_misses: u64,
     /// Total lookup events dropped due to event-queue overflow.
     pub events_dropped: u64,
+    /// Total observed entries rejected because the cold-entry tracking table was full.
+    pub observed_entry_rejections: u64,
+    /// Number of observed entries currently tracked for hotness or compilation.
+    pub tracked_entries: u64,
+    /// Number of tracked entries that have not reached the compilation threshold.
+    pub cold_entries: u64,
+    /// Total stale cold entries forgotten by idle eviction.
+    pub cold_entry_evictions: u64,
     /// Total control commands dropped because the command channel was full.
     ///
     /// Pause/resume commands are best-effort and dropped instead of blocking the caller when
@@ -142,6 +158,10 @@ impl RuntimeStats {
             lookup_hits: self.lookup_hits.load(Ordering::Relaxed),
             lookup_misses: self.lookup_misses.load(Ordering::Relaxed),
             events_dropped: self.events_dropped.load(Ordering::Relaxed),
+            observed_entry_rejections: self.observed_entry_rejections.load(Ordering::Relaxed),
+            tracked_entries: self.tracked_entries.load(Ordering::Relaxed),
+            cold_entries: self.cold_entries.load(Ordering::Relaxed),
+            cold_entry_evictions: self.cold_entry_evictions.load(Ordering::Relaxed),
             commands_dropped: self.commands_dropped.load(Ordering::Relaxed),
             resident_entries: gauges.resident_entries,
             events_queued: gauges.events_queued,

--- a/crates/revmc-runtime/src/runtime/tests.rs
+++ b/crates/revmc-runtime/src/runtime/tests.rs
@@ -1204,7 +1204,8 @@ fn cold_entries_are_evicted() {
     let tb = TestBackend::with_tuning_1w(RuntimeTuning {
         jit_hot_threshold: 2,
         jit_max_pending_jobs: 1,
-        idle_evict_duration: Some(std::time::Duration::from_millis(20)),
+        idle_evict_duration: None,
+        cold_entry_idle_duration: Some(std::time::Duration::from_millis(20)),
         eviction_sweep_interval: std::time::Duration::from_millis(10),
         event_drain_interval: std::time::Duration::from_millis(10),
         ..Default::default()
@@ -1222,7 +1223,56 @@ fn cold_entries_are_evicted() {
     assert_eq!(tb.stats().resident_entries, 0);
 
     std::thread::sleep(std::time::Duration::from_millis(100));
+    let stats = tb.stats();
+    assert_eq!(stats.cold_entries, 0);
+    assert!(stats.cold_entry_evictions >= 10);
     tb.wait_compiled(&compile_me, SpecId::CANCUN);
+}
+
+#[test]
+#[cfg(feature = "llvm")]
+fn cold_entry_eviction_preserves_resident_programs() {
+    let tb = TestBackend::with_tuning_1w(RuntimeTuning {
+        jit_hot_threshold: 2,
+        jit_max_pending_jobs: 2,
+        idle_evict_duration: None,
+        cold_entry_idle_duration: Some(std::time::Duration::from_millis(50)),
+        eviction_sweep_interval: std::time::Duration::from_millis(10),
+        event_drain_interval: std::time::Duration::from_millis(10),
+        ..Default::default()
+    });
+
+    tb.trigger_jit_cancun(BYTECODE_RET42);
+    let resident_hash = alloy_primitives::keccak256(BYTECODE_RET42);
+    let _ = tb.lookup(TestBackend::req_cancun(&indexed_bytecode(42)));
+
+    tb.wait_stats(|stats| stats.cold_entries == 1);
+    let stats = tb.wait_stats(|stats| stats.cold_entry_evictions >= 1);
+    assert_eq!(stats.cold_entries, 0);
+    assert_eq!(stats.resident_entries, 1);
+    assert!(tb.get_compiled(resident_hash, SpecId::CANCUN).is_some());
+}
+
+#[test]
+fn observed_entry_capacity_is_reported() {
+    let tb = TestBackend::with_tuning(RuntimeTuning {
+        jit_hot_threshold: usize::MAX,
+        jit_max_pending_jobs: 1,
+        jit_worker_count: 0,
+        idle_evict_duration: None,
+        cold_entry_idle_duration: None,
+        event_drain_interval: std::time::Duration::from_millis(1),
+        ..Default::default()
+    });
+
+    for i in 0..11 {
+        let _ = tb.lookup(TestBackend::req_cancun(&indexed_bytecode(i)));
+    }
+
+    let stats = tb.wait_stats(|stats| stats.lookup_misses == 11);
+    assert_eq!(stats.tracked_entries, 10);
+    assert_eq!(stats.cold_entries, 10);
+    assert_eq!(stats.observed_entry_rejections, 1);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- separate stale cold-observation expiry from resident compiled-program eviction
- expose tracked/cold entry gauges and capacity-rejection/cold-eviction counters
- cover capacity observability and preserving resident programs while cold entries expire

## Root cause

Applications that intentionally disabled resident idle eviction also disabled stale cold-entry cleanup. Once the bounded observation table filled, new code hashes were silently rejected and could never accumulate enough observations to compile.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p revmc-runtime observed_entry_capacity_is_reported --no-default-features`
- `cargo test -p revmc-runtime cold_entry_eviction_preserves_resident_programs`
- `cargo cl -p revmc-runtime` (validated on the revm 41-compatible parent; the patch also passes focused tests on current main/revm 42)