### PR TITLE
chore: bump revm to 43.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3095,9 +3095,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "revm"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
+checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3114,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "paste",
@@ -3127,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+checksum = "67822069c254eb83e95fa5912a0d1324dd176f6ea05e8f110671ad242e27d61b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3144,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3160,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -3176,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -3190,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3209,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
 dependencies = [
  "auto_impl",
  "either",
@@ -3227,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3240,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
+checksum = "d85f7a8906482f8d18f2a2c793bc4daf254b29465af4285268384505ce6ee308"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3264,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3275,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "bitflags",
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "revm-statetest-types"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61ce97f20c478a2b9be24e967d7c6481301d466a47b3c13dd3b030a7a93709d"
+checksum = "7c8b1acb65575b17a3f74a4342bc821ecedd13f22f4286b534ade7cf054acfac"
 dependencies = [
  "alloy-eip7928 0.4.3",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,19 +47,19 @@ revmc-runtime = { version = "0.1.0", path = "crates/revmc-runtime", default-feat
 
 alloy-primitives = { version = "1.6.0", default-features = false }
 ruint = { version = "1.18", default-features = false }
-alloy-evm = { version = "0.38.0", default-features = false }
+alloy-evm = { version = "0.39.0", default-features = false }
 
-revm-bytecode = { version = "42.0.0", default-features = false, features = ["parse"] }
-revm-context = { version = "42.0.0", default-features = false }
-revm-context-interface = { version = "42.0.0", default-features = false }
-revm-database = { version = "42.0.0", default-features = false }
-revm-database-interface = { version = "42.0.0", default-features = false }
-revm-handler = { version = "42.0.0", default-features = false }
-revm-inspector = { version = "42.0.0", default-features = false }
-revm-interpreter = { version = "42.0.0", default-features = false }
-revm-primitives = { version = "42.0.0", default-features = false }
-revm-state = { version = "42.0.0", default-features = false }
-revm-statetest-types = { version = "42.0.0", default-features = false }
+revm-bytecode = { version = "43.0.0", default-features = false, features = ["parse"] }
+revm-context = { version = "43.0.0", default-features = false }
+revm-context-interface = { version = "43.0.0", default-features = false }
+revm-database = { version = "43.0.0", default-features = false }
+revm-database-interface = { version = "43.0.0", default-features = false }
+revm-handler = { version = "43.0.0", default-features = false }
+revm-inspector = { version = "43.0.0", default-features = false }
+revm-interpreter = { version = "43.0.0", default-features = false }
+revm-primitives = { version = "43.0.0", default-features = false }
+revm-state = { version = "43.0.0", default-features = false }
+revm-statetest-types = { version = "43.0.0", default-features = false }
 
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"

--- a/crates/revmc-codegen/src/tests/resume_at_call.rs
+++ b/crates/revmc-codegen/src/tests/resume_at_call.rs
@@ -61,6 +61,7 @@ fn run_call_then_push<B: Backend>(compiler: &mut EvmCompiler<B>) {
         caller_address: DEF_CALLER,
         input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
         call_value: DEF_VALUE,
+        depth: 0,
     };
     let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
     let ext_bytecode = ExtBytecode::new(bytecode_obj);
@@ -144,6 +145,7 @@ fn run_call_then_return<B: Backend>(compiler: &mut EvmCompiler<B>) {
         caller_address: DEF_CALLER,
         input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
         call_value: DEF_VALUE,
+        depth: 0,
     };
     let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
     let ext_bytecode = ExtBytecode::new(bytecode_obj);
@@ -219,6 +221,7 @@ fn run_call_returndatasize<B: Backend>(compiler: &mut EvmCompiler<B>) {
         caller_address: DEF_CALLER,
         input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
         call_value: DEF_VALUE,
+        depth: 0,
     };
     let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
     let ext_bytecode = ExtBytecode::new(bytecode_obj);
@@ -335,6 +338,7 @@ fn run_call_pop_push_sload_stack_len<B: Backend>(compiler: &mut EvmCompiler<B>) 
         caller_address: DEF_CALLER,
         input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
         call_value: DEF_VALUE,
+        depth: 0,
     };
     let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
     let ext_bytecode = ExtBytecode::new(bytecode_obj);

--- a/crates/revmc-codegen/src/tests/runner.rs
+++ b/crates/revmc-codegen/src/tests/runner.rs
@@ -442,6 +442,7 @@ pub fn with_evm_context<F: FnOnce(&mut EvmContext<'_>, &mut EvmStack, &mut usize
         caller_address: DEF_CALLER,
         input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
         call_value: DEF_VALUE,
+        depth: 0,
     };
 
     let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
@@ -512,6 +513,7 @@ fn run_compiled_test_case(test_case: &TestCase<'_>, f: EvmCompilerFn) {
             caller_address: DEF_CALLER,
             input: CallInput::Bytes(Bytes::from_static(DEF_CD)),
             call_value: DEF_VALUE,
+            depth: 0,
         };
         let bytecode_obj = revm_bytecode::Bytecode::new_raw(Bytes::copy_from_slice(bytecode));
         let ext_bytecode = ExtBytecode::new(bytecode_obj);


### PR DESCRIPTION
Bumps revm to 43.0.0 and alloy-evm to 0.39.0 for Glamsterdam devnet-8 support. Updates test interpreter inputs with the new top-level call depth field.

Checks:
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --workspace --all-targets`
- `cargo test --workspace`

Prompted by: @mattsse