### PR TITLE
chore: fix Clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,21 +16,21 @@ repository = "https://github.com/paradigmxyz/revmc"
 exclude = [".github/", "benches/", "fuzz/", "tests/"]
 
 [workspace.lints.clippy]
-dbg-macro = "warn"
-manual-string-new = "warn"
-uninlined-format-args = "warn"
-use-self = "warn"
-redundant-clone = "warn"
+dbg_macro = "warn"
+manual_string_new = "warn"
+uninlined_format_args = "warn"
+use_self = "warn"
+redundant_clone = "warn"
 
 [workspace.lints.rust]
-missing-debug-implementations = "warn"
-missing-docs = "warn"
-rust-2018-idioms = "warn"
-unreachable-pub = "warn"
-unused-must-use = "warn"
-redundant-lifetimes = "warn"
-unnameable-types = "warn"
-unsafe-op-in-unsafe-fn = "allow"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+rust_2018_idioms = { level = "warn", priority = -1 }
+unreachable_pub = "warn"
+unused_must_use = "warn"
+redundant_lifetimes = "warn"
+unnameable_types = "warn"
+unsafe_op_in_unsafe_fn = "allow"
 
 [workspace.lints.rustdoc]
 all = "warn"

--- a/crates/revmc-codegen/src/bytecode/interner.rs
+++ b/crates/revmc-codegen/src/bytecode/interner.rs
@@ -68,10 +68,7 @@ impl<I: Idx, T: std::fmt::Debug, S> std::fmt::Debug for Interner<I, T, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    oxc_index::define_index_type! {
-        struct TestIdx = u32;
-    }
+    use crate::bytecode::Inst as TestIdx;
 
     #[test]
     fn deduplication() {

--- a/crates/revmc-codegen/src/bytecode/mod.rs
+++ b/crates/revmc-codegen/src/bytecode/mod.rs
@@ -772,12 +772,13 @@ impl<'a> Bytecode<'a> {
             });
             entry.total += 1;
             let mut all = true;
-            for depth in 0..inputs as usize {
-                entry.per_input[depth][0] += 1;
+            for (depth, input_stats) in entry.per_input.iter_mut().enumerate().take(inputs as usize)
+            {
+                input_stats[0] += 1;
                 if let Some(val) = self.const_operand(inst, depth) {
-                    entry.per_input[depth][1] += 1;
+                    input_stats[1] += 1;
                     if val <= usize::MAX {
-                        entry.per_input[depth][2] += 1;
+                        input_stats[2] += 1;
                     }
                 } else {
                     all = false;

--- a/crates/revmc-codegen/src/compiler/translate/vstack.rs
+++ b/crates/revmc-codegen/src/compiler/translate/vstack.rs
@@ -55,8 +55,8 @@ impl<T: Copy> VStack<T> {
         self.slots.resize(capacity, None);
 
         // Section inputs are already in memory.
-        for i in 0..inputs {
-            self.slots[i] = Some(VSlot::Materialized);
+        for slot in self.slots.iter_mut().take(inputs) {
+            *slot = Some(VSlot::Materialized);
         }
     }
 

--- a/fuzz/fuzz_targets/vs_interpreter.rs
+++ b/fuzz/fuzz_targets/vs_interpreter.rs
@@ -26,9 +26,6 @@ fn should_skip(bytecode: &[u8], spec_id: SpecId) -> bool {
         let Some(info) = OPCODE_INFO[op.opcode as usize] else { return true };
         // Skip if the immediate is incomplete.
         // TODO: What is the expected behavior here?
-        if info.immediate_size() > 0 && op.immediate.is_none() {
-            return true;
-        }
-        false
+        info.immediate_size() > 0 && op.immediate.is_none()
     })
 }


### PR DESCRIPTION
Current CI tooling reports newly enabled diagnostics in `revmc-codegen` and the fuzz target, while Cargo warns that the workspace's hyphenated lint keys are deprecated. The workspace's `-D warnings` policy turns the code diagnostics into CI failures.

Iterate over the per-input statistics and virtual-stack slots directly, reuse the production instruction index in the interner tests instead of expanding a deprecated test-only macro, simplify the fuzz predicate, and migrate the lint configuration to canonical underscore names with explicit group priority. These changes preserve existing behavior while making the full workspace Clippy job pass again.
