### PR TITLE
fix: filter changelog commits by crate

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -17,8 +17,9 @@ if [[ "$crate" = */tests/* || "$crate" = */examples/* || "$crate" = *test-utils*
     exit 0
 fi
 
-command=(git cliff --workdir "$root" --config "$root/cliff.toml" "${@}")
-run_unless_dry_run "${command[@]}" --output "$root/CHANGELOG.md"
-if [ -n "$crate" ] && [ "$root" != "$crate" ]; then
-    run_unless_dry_run "${command[@]}" --include-path "$crate_glob" --output "$crate/CHANGELOG.md"
+changelog="$crate/CHANGELOG.md"
+if [ -f "$changelog" ] && grep -q '^## \[[0-9]' "$changelog"; then
+    run_unless_dry_run git cliff --repository "$root" --config "$root/cliff.toml" --include-path "$crate_glob" --unreleased "${@}" --prepend "$changelog"
+else
+    run_unless_dry_run git cliff --repository "$root" --config "$root/cliff.toml" --include-path "$crate_glob" "${@}" --output "$changelog"
 fi


### PR DESCRIPTION
Pass the releasing crate path to git-cliff explicitly so each workspace crate changelog contains only commits for that crate. Keep incremental generation to preserve existing changelog history.